### PR TITLE
save abstracts to database

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/ArticleBo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/ArticleBo.java
@@ -15,4 +15,5 @@ public interface ArticleBo extends GenericBo<Article> {
      * @return 
      */
     Article findArticleByPmid(String pmid);
+    Article findArticleByAbstract(String abstractContent);
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/ArticleBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/ArticleBoImpl.java
@@ -16,4 +16,8 @@ public class ArticleBoImpl extends GenericBoImpl<Article, ArticleDao> implements
     public Article findArticleByPmid(String pmid) {
         return getDao().findArticleByPmid(pmid);
     }
+    @Override
+    public Article findArticleByAbstract(String abstractContent) {
+        return getDao().findArticleByAbstract(abstractContent);
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/dao/ArticleDao.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/dao/ArticleDao.java
@@ -15,4 +15,5 @@ public interface ArticleDao extends GenericDao<Article, Integer> {
      * @return gene object or null
      */
     Article findArticleByPmid(String pmid);
+    Article findArticleByAbstract(String abstractContent);
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/dao/impl/ArticleDaoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/dao/impl/ArticleDaoImpl.java
@@ -22,4 +22,9 @@ public class ArticleDaoImpl
         List<Article> list = findByNamedQuery("findArticleByPmid", pmid);
         return list.isEmpty() ? null : list.get(0);
     }
+    
+    public Article findArticleByAbstract(String abstractContent) {
+        List<Article> list = findByNamedQuery("findArticleByAbstract", abstractContent);
+        return list.isEmpty() ? null : list.get(0);
+    }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Article.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Article.java
@@ -19,7 +19,25 @@ public class Article implements java.io.Serializable {
     private String pages;
     private String authors;
     private String elocationId;
+    private String abstractContent;
+    private String link;
 
+    public String getAbstractContent() {
+        return abstractContent;
+    }
+
+    public void setAbstractContent(String abstractContent) {
+        this.abstractContent = abstractContent;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+    
     public Article() {
     }
 
@@ -27,7 +45,7 @@ public class Article implements java.io.Serializable {
         this.pmid = pmid;
     }
 
-    public Article(String pmid, String title, String journal, String pubDate, String volume, String issue, String pages, String authors, String elocationId) {
+    public Article(String pmid, String title, String journal, String pubDate, String volume, String issue, String pages, String authors, String elocationId, String abstractContent, String link) {
         this.pmid = pmid;
         this.title = title;
         this.journal = journal;
@@ -37,6 +55,8 @@ public class Article implements java.io.Serializable {
         this.pages = pages;
         this.authors = authors;
         this.elocationId = elocationId;
+        this.abstractContent = abstractContent;
+        this.link = link;
     }
 
     public Integer getArticleId() {

--- a/core/src/main/resources/hibernate/Article.hbm.xml
+++ b/core/src/main/resources/hibernate/Article.hbm.xml
@@ -9,7 +9,7 @@
       <generator class="identity"/>
     </id>
     <property name="pmid" type="string">
-      <column name="pmid" not-null="true"/>
+      <column name="pmid"/>
     </property>
     <property name="title" type="string">
       <column length="1000" name="title"/>
@@ -35,8 +35,17 @@
     <property name="elocationId" type="string">
       <column name="elocationId"/>
     </property>
+    <property name="abstractContent" type="string">
+      <column name="abstract_content"/>
+    </property>
+    <property name="link" type="string">
+      <column name="link"/>
+    </property>
   </class>
   <query name="findArticleByPmid">
         from Article a where a.pmid=?
+  </query>
+  <query name="findArticleByAbstract">
+        from Article a where a.abstractContent=?
   </query>
 </hibernate-mapping>


### PR DESCRIPTION
1) modified article model 
- a) add two columns: abstract_content and link
- b) allow pmid to be null

2) extract abstract content and link from input and save article record and evidence article mapping.

**Note: the way we extract abstract content is having the assumption that, semicolon is only used as end flag for each abstract and it won't appear in the abstract content.** 
