### PR TITLE
add google spreadsheet file Ids

### DIFF
--- a/core/src/main/resources/properties/config-EXAMPLE.properties
+++ b/core/src/main/resources/properties/config-EXAMPLE.properties
@@ -28,3 +28,7 @@ importer.drugs=
 #data version, date format mm/dd/yyyy
 data.version=
 data.version_date=
+
+#validation result report google spreadsheet related file Ids
+google.report_parent_folder=
+google.report_data_template=


### PR DESCRIPTION
The validation results are stored in the google spreadsheet now. Thus we need to add the related folder or file Ids in this property file.
