### PR TITLE
recache gene related data when read not after updating

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -300,8 +300,7 @@ public final class AlterationUtils {
     public static Set<Alteration> getAllAlterations(Gene gene) {
         if (CacheUtils.isEnabled()) {
             if (!CacheUtils.containAlterations(gene.getEntrezGeneId())) {
-                CacheUtils.setAlterations(gene.getEntrezGeneId(),
-                    new HashSet<>(alterationBo.findAlterationsByGene(Collections.singleton(gene))));
+                CacheUtils.setAlterations(gene);
             }
             return CacheUtils.getAlterations(gene.getEntrezGeneId());
         } else {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
@@ -26,16 +26,13 @@ public class CacheUtils {
     private static Map<Integer, Map<String, Map<String, String>>> variantTumorTypeSummary = new HashMap<>();
     private static Map<Integer, Map<String, List<Integer>>> relevantAlterations = new HashMap<>();
     private static Map<Integer, Gene> genesByEntrezId = new HashMap<>();
+    private static Map<String, Integer> hugoSymbolToEntrez = new HashMap<>();
     // The key would be entrezGeneId, variant name and evidence ID. -1 will be used to store gene irrelevant evidences.
     private static Map<Integer, Map<String, Set<Integer>>> relevantEvidences = new HashMap<>();
-    private static Map<Integer, Set<Alteration>> VUS = new HashMap<>();
 
     private static Map<String, List<OncoTreeType>> mappedTumorTypes = new HashMap<>();
-    private static Map<String, Integer> hugoSymbolToEntrez = new HashMap<>();
     private static Map<String, List<OncoTreeType>> allOncoTreeTypes = new HashMap<>(); //Tag by different categories. main or subtype
     private static Map<String, Object> numbers = new HashMap<>();
-    
-    private static Map<String, List<Evidence>> uuidToEvidence = new HashMap<>();
 
     private static String status = "enabled"; //Current cacheUtils status. Applicable value: disabled enabled
 
@@ -44,6 +41,7 @@ public class CacheUtils {
     private static Set<Drug> drugs = new HashSet<>();
     private static Map<Integer, Set<Evidence>> evidences = new HashMap<>(); //Gene based evidences
     private static Map<Integer, Set<Alteration>> alterations = new HashMap<>(); //Gene based alterations
+    private static Map<Integer, Set<Alteration>> VUS = new HashMap<>(); //Gene based VUSs
 
     private static Observer variantSummaryObserver = new Observer() {
         @Override
@@ -97,9 +95,7 @@ public class CacheUtils {
             Map<String, String> operation = (Map<String, String>) arg;
             if (operation.get("cmd") == "update") {
                 Integer entrezGeneId = Integer.parseInt(operation.get("val"));
-                Gene gene = GeneUtils.getGeneByEntrezId(entrezGeneId);
                 VUS.remove(entrezGeneId);
-                VUS.put(entrezGeneId, AlterationUtils.findVUSFromEvidences(EvidenceUtils.getEvidenceByGenes(Collections.singleton(gene)).get(gene)));
             } else if (operation.get("cmd") == "reset") {
                 VUS.clear();
             }
@@ -119,31 +115,11 @@ public class CacheUtils {
         }
     };
 
-    private static Observer geneObserver = new Observer() {
-        @Override
-        public void update(Observable o, Object arg) {
-            Map<String, String> operation = (Map<String, String>) arg;
-            if (operation.get("cmd") == "update") {
-                Integer entrezGeneId = Integer.parseInt(operation.get("val"));
-                genesByEntrezId.remove(entrezGeneId);
-                Iterator it = hugoSymbolToEntrez.entrySet().iterator();
-                while (it.hasNext()) {
-                    Map.Entry pair = (Map.Entry) it.next();
-                    if ((pair.getValue()).equals(entrezGeneId)) {
-                        it.remove();
-                    }
-                }
-            } else if (operation.get("cmd") == "reset") {
-                genesByEntrezId.clear();
-                hugoSymbolToEntrez.clear();
-            }
-        }
-    };
-
+    // Always update genes since everything is relying on this.
     private static Observer genesObserver = new Observer() {
         @Override
         public void update(Observable o, Object arg) {
-            genes = new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll());
+            cacheAllGenes();
         }
     };
 
@@ -175,21 +151,10 @@ public class CacheUtils {
             Map<String, String> operation = (Map<String, String>) arg;
             if (operation.get("cmd") == "update") {
                 Integer entrezGeneId = Integer.parseInt(operation.get("val"));
-                Gene gene = GeneUtils.getGeneByEntrezId(entrezGeneId);
                 evidences.remove(entrezGeneId);
-                evidences.put(entrezGeneId, new HashSet<>(
-                    ApplicationContextSingleton.getEvidenceBo().findEvidencesByGene(Collections.singleton(gene))));
-
             } else if (operation.get("cmd") == "reset") {
                 evidences.clear();
-                Map<Gene, Set<Evidence>> mappedEvidence =
-                    EvidenceUtils.separateEvidencesByGene(genes, new HashSet<>(
-                        ApplicationContextSingleton.getEvidenceBo().findAll()));
-                Iterator it = mappedEvidence.entrySet().iterator();
-                while (it.hasNext()) {
-                    Map.Entry<Gene, Set<Evidence>> pair = (Map.Entry) it.next();
-                    evidences.put(pair.getKey().getEntrezGeneId(), pair.getValue());
-                }
+                cacheAllEvidencesByGenes();
             }
         }
     };
@@ -209,7 +174,6 @@ public class CacheUtils {
             GeneObservable.getInstance().addObserver(variantTumorTypeSummaryObserver);
             GeneObservable.getInstance().addObserver(relevantAlterationsObserver);
             GeneObservable.getInstance().addObserver(alterationsObserver);
-            GeneObservable.getInstance().addObserver(geneObserver);
             GeneObservable.getInstance().addObserver(relevantEvidencesObserver);
             GeneObservable.getInstance().addObserver(allCancerTypesObserver);
             GeneObservable.getInstance().addObserver(genesObserver);
@@ -218,18 +182,14 @@ public class CacheUtils {
             GeneObservable.getInstance().addObserver(numbersObserver);
             GeneObservable.getInstance().addObserver(drugsObserver);
 
-            if(status.equals("enabled")) {
+            if (status.equals("enabled")) {
                 System.out.println("Observer: " + MainUtils.getTimestampDiff(current));
-                current = MainUtils.getCurrentTimestamp();
 
-                genes = new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll());
-                System.out.println("Cache all genes: " + MainUtils.getTimestampDiff(current));
-                current = MainUtils.getCurrentTimestamp();
+                cacheAllGenes();
 
                 setAllAlterations();
-                System.out.println("Cache all alterations: " + MainUtils.getTimestampDiff(current));
-                current = MainUtils.getCurrentTimestamp();
 
+                current = MainUtils.getCurrentTimestamp();
                 drugs = new HashSet<>(ApplicationContextSingleton.getDrugBo().findAll());
                 System.out.println("Cache all drugs: " + MainUtils.getTimestampDiff(current));
                 current = MainUtils.getCurrentTimestamp();
@@ -255,7 +215,7 @@ public class CacheUtils {
                     setVUS(entry.getKey(), entry.getValue());
                 }
                 System.out.println("Cache all VUSs: " + MainUtils.getTimestampDiff(current));
-            }else{
+            } else {
                 System.out.println("CacheUtil is disabled.");
             }
             current = MainUtils.getCurrentTimestamp();
@@ -293,22 +253,26 @@ public class CacheUtils {
         }
     }
 
+    private static void cacheAllGenes() {
+        Long current = MainUtils.getCurrentTimestamp();
+
+        genes = new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll());
+        genesByEntrezId = new HashedMap();
+        hugoSymbolToEntrez = new HashedMap();
+        for(Gene gene : genes) {
+            genesByEntrezId.put(gene.getEntrezGeneId(), gene);
+            hugoSymbolToEntrez.put(gene.getHugoSymbol(), gene.getEntrezGeneId());
+        }
+
+        System.out.println("Cache all genes: " + MainUtils.getTimestampDiff(current));
+    }
+
     public static Gene getGeneByHugoSymbol(String hugoSymbol) {
         Integer entrezGeneId = hugoSymbolToEntrez.get(hugoSymbol);
         if (entrezGeneId == null)
             return null;
 
         return genesByEntrezId.get(entrezGeneId);
-    }
-    
-    public static void setEvidenceByUUID(List<Evidence> evidences) {
-        if (!evidences.isEmpty()) {
-            uuidToEvidence.put(evidences.get(0).getUuid(), evidences);
-        }
-    }
-
-    public static List<Evidence> getEvidenceByUUID(String uuid) {
-        return uuidToEvidence.get(uuid);
     }
 
     public static Boolean containGeneByHugoSymbol(String hugoSymbol) {
@@ -323,13 +287,6 @@ public class CacheUtils {
         }
     }
 
-    public static void setGeneByHugoSymbol(Gene gene) {
-        if (gene != null) {
-            hugoSymbolToEntrez.put(gene.getHugoSymbol(), gene.getEntrezGeneId());
-            genesByEntrezId.put(gene.getEntrezGeneId(), gene);
-        }
-    }
-
     public static Set<Evidence> getRelevantEvidences(Integer entrezGeneId, String variant) {
         if (relevantEvidences.containsKey(entrezGeneId) && relevantEvidences.get(entrezGeneId).containsKey(variant)) {
             Set<Integer> mappedEntrez = relevantEvidences.get(entrezGeneId).get(variant);
@@ -341,7 +298,7 @@ public class CacheUtils {
                     geneEvidences.addAll(map.getValue());
                 }
             } else {
-                geneEvidences = evidences.get(entrezGeneId);
+                geneEvidences = getEvidences(genesByEntrezId.get(entrezGeneId));
             }
             for (Evidence evidence : geneEvidences) {
                 if (mappedEntrez.contains(evidence.getId())) {
@@ -359,7 +316,7 @@ public class CacheUtils {
             relevantEvidences.get(entrezGeneId).containsKey(variant)) ? true : false;
     }
 
-    public static void setVUS(Integer entrezGeneId, Set<Evidence> evidences) {
+    private static void setVUS(Integer entrezGeneId, Set<Evidence> evidences) {
         if (!VUS.containsKey(entrezGeneId)) {
             VUS.put(entrezGeneId, new HashSet<Alteration>());
         }
@@ -426,7 +383,7 @@ public class CacheUtils {
     public static Boolean containVariantTumorTypeSummary(Integer entrezGeneId, String variant, String tumorType) {
         return (variantTumorTypeSummary.containsKey(entrezGeneId)
             && variantTumorTypeSummary.get(entrezGeneId).containsKey(variant)
-        && variantTumorTypeSummary.get(entrezGeneId).get(variant).containsKey(tumorType)) ? true : false;
+            && variantTumorTypeSummary.get(entrezGeneId).get(variant).containsKey(tumorType)) ? true : false;
     }
 
     public static void setVariantTumorTypeSummary(Integer entrezGeneId, String variant, String tumorType, String summary) {
@@ -443,10 +400,10 @@ public class CacheUtils {
         if (relevantAlterations.containsKey(entrezGeneId) && relevantAlterations.get(entrezGeneId).containsKey(variant)) {
             List<Integer> mappedAltsIds = relevantAlterations.get(entrezGeneId).get(variant);
             List<Alteration> mappedAlts = new ArrayList<>();
-            Set<Alteration> geneAlts = alterations.get(entrezGeneId);
+            Set<Alteration> geneAlts = getAlterations(entrezGeneId);
 
             // Need to keep the order of mappedAltsIds
-            for(Integer mappedAlt : mappedAltsIds) {
+            for (Integer mappedAlt : mappedAltsIds) {
                 for (Alteration alteration : geneAlts) {
                     if (mappedAlt.equals(alteration.getId())) {
                         mappedAlts.add(alteration);
@@ -477,19 +434,23 @@ public class CacheUtils {
     }
 
     public static Set<Alteration> getAlterations(Integer entrezGeneId) {
+        synAlterations();
         Set<Alteration> result = alterations.get(entrezGeneId);
-        if(result == null){
+        if (result == null) {
             result = new HashSet<>();
         }
         return result;
     }
 
     public static Boolean containAlterations(Integer entrezGeneId) {
+        synAlterations();
         return alterations.containsKey(entrezGeneId) ? true : false;
     }
 
-    public static void setAlterations(Integer entrezGeneId, Set<Alteration> alts) {
-        alterations.put(entrezGeneId, alts);
+    public static void setAlterations(Gene gene) {
+        if (gene != null && genes.contains(gene)) {
+            alterations.put(gene.getEntrezGeneId(), new HashSet<>(ApplicationContextSingleton.getAlterationBo().findAlterationsByGene(Collections.singleton(gene))));
+        }
     }
 
     public static List<OncoTreeType> getMappedTumorTypes(String queryTumorType, String source) {
@@ -527,16 +488,18 @@ public class CacheUtils {
         return genes;
     }
 
-    public static void setAllAlterations() {
+    private static void setAllAlterations() {
+        Long current = MainUtils.getCurrentTimestamp();
         List<Alteration> allAlterations = ApplicationContextSingleton.getAlterationBo().findAll();
 
-        for(Alteration alteration : allAlterations) {
+        for (Alteration alteration : allAlterations) {
             Gene gene = alteration.getGene();
-            if(!alterations.containsKey(gene.getEntrezGeneId())) {
+            if (!alterations.containsKey(gene.getEntrezGeneId())) {
                 alterations.put(gene.getEntrezGeneId(), new HashSet<Alteration>());
             }
             alterations.get(gene.getEntrezGeneId()).add(alteration);
         }
+        System.out.println("Cache all alterations: " + MainUtils.getTimestampDiff(current));
     }
 
     public static Set<Drug> getAllDrugs() {
@@ -547,9 +510,11 @@ public class CacheUtils {
     }
 
     public static Set<Evidence> getEvidences(Gene gene) {
-        if (evidences == null || evidences.size() == 0) {
-            cacheAllEvidencesByGenes();
+        if (gene == null) {
+            return new HashSet<>();
         }
+
+        synEvidences();
 
         if (evidences.containsKey(gene.getEntrezGeneId())) {
             Set<Evidence> result = evidences.get(gene.getEntrezGeneId());
@@ -560,15 +525,13 @@ public class CacheUtils {
     }
 
     public static Set<Evidence> getEvidencesByIds(Set<Integer> ids) {
-        if (evidences == null || evidences.size() == 0) {
-            cacheAllEvidencesByGenes();
-        }
+        synEvidences();
 
         Set<Evidence> mappedEvis = new HashSet<>();
-        if(ids != null) {
-            for(Map.Entry<Integer, Set<Evidence>> map : evidences.entrySet()) {
-                for(Evidence evidence : map.getValue()) {
-                    if(ids.contains(evidence.getId())) {
+        if (ids != null) {
+            for (Map.Entry<Integer, Set<Evidence>> map : evidences.entrySet()) {
+                for (Evidence evidence : map.getValue()) {
+                    if (ids.contains(evidence.getId())) {
                         mappedEvis.add(evidence);
                     }
                 }
@@ -577,12 +540,40 @@ public class CacheUtils {
         return mappedEvis;
     }
 
-    public static Boolean containEvidences(Gene gene) {
-        return (evidences.containsKey(gene)) ? true : false;
+    private static void setEvidences(Gene gene) {
+        evidences.put(gene.getEntrezGeneId(), new HashSet<>(ApplicationContextSingleton.getEvidenceBo().findEvidencesByGene(Collections.singleton(gene))));
     }
 
-    public static void setEvidences(Gene gene, Set<Evidence> newEvidences) {
-        evidences.put(gene.getEntrezGeneId(), newEvidences);
+    private static void synEvidences() {
+        Long current = MainUtils.getCurrentTimestamp();
+        if (evidences == null || evidences.size() == 0) {
+            cacheAllEvidencesByGenes();
+        }
+
+        if (evidences.keySet().size() != genes.size()) {
+            for (Gene gene : genes) {
+                if (!evidences.containsKey(gene.getEntrezGeneId())) {
+                    setEvidences(gene);
+                }
+            }
+        }
+        System.out.println("Synchronize all evidences: " + MainUtils.getTimestampDiff(current));
+    }
+
+    private static void synAlterations() {
+        Long current = MainUtils.getCurrentTimestamp();
+        if (alterations == null || alterations.size() == 0) {
+            setAllAlterations();
+        }
+
+        if (alterations.keySet().size() != genes.size()) {
+            for (Gene gene : genes) {
+                if (!alterations.containsKey(gene.getEntrezGeneId())) {
+                    setAlterations(gene);
+                }
+            }
+        }
+        System.out.println("Synchronize all alterations: " + MainUtils.getTimestampDiff(current));
     }
 
     public static void updateGene(Integer entrezGeneId) {
@@ -622,6 +613,8 @@ public class CacheUtils {
     }
 
     private static void cacheAllEvidencesByGenes() {
+        Long current = MainUtils.getCurrentTimestamp();
+
         Map<Gene, Set<Evidence>> mappedEvidence =
             EvidenceUtils.separateEvidencesByGene(genes, new HashSet<>(
                 ApplicationContextSingleton.getEvidenceBo().findAll()));
@@ -630,5 +623,6 @@ public class CacheUtils {
             Map.Entry<Gene, Set<Evidence>> pair = (Map.Entry) it.next();
             evidences.put(pair.getKey().getEntrezGeneId(), pair.getValue());
         }
+        System.out.println("Cache all evidences by gene: " + MainUtils.getTimestampDiff(current));
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -309,21 +309,6 @@ public class EvidenceUtils {
         return evidences;
     }
 
-    public static List<Evidence> getEvidenceByUUID(String uuid) {
-        if (uuid != null) {
-            EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
-            if (CacheUtils.isEnabled()) {
-                if (CacheUtils.getEvidenceByUUID(uuid) == null) {
-                    CacheUtils.setEvidenceByUUID(evidenceBo.findEvidenceByUUIDs(Collections.singletonList(uuid)));
-                }
-                return CacheUtils.getEvidenceByUUID(uuid);
-            } else {
-                return evidenceBo.findEvidenceByUUIDs(Collections.singletonList(uuid));
-            }
-        }
-        return null;
-    }
-
     public static Map<Gene, Set<Evidence>> getEvidenceByGenesAndEvidenceTypes(Set<Gene> genes, Set<EvidenceType> evidenceTypes) {
         Map<Gene, Set<Evidence>> result = new HashMap<>();
         if (CacheUtils.isEnabled()) {
@@ -945,7 +930,7 @@ public class EvidenceUtils {
         }
         return evidenceQueries;
     }
-    
+
     public static void annotateEvidence(Evidence evidence) throws ParserConfigurationException {
         ClinicalTrialBo clinicalTrialBo = ApplicationContextSingleton.getClinicalTrialBo();
         ArticleBo articleBo = ApplicationContextSingleton.getArticleBo();
@@ -956,7 +941,7 @@ public class EvidenceUtils {
         Set<Article> articles = evidence.getArticles();
         Set<Treatment> treatments = evidence.getTreatments();
         Set<NccnGuideline> nccnGuidelines = evidence.getNccnGuidelines();
-             
+
         if(trials != null && !trials.isEmpty()){
             Set<ClinicalTrial> annotatedTrials = new HashSet<>();
             Set<String> nctIds = new HashSet<String>();
@@ -1001,7 +986,7 @@ public class EvidenceUtils {
             }
             evidence.setArticles(annotatedArticles);
         }
-        
+
         Drug tempDrug;
         NccnGuideline tempNccnGuideline;
         if(treatments != null && !treatments.isEmpty()){
@@ -1025,6 +1010,6 @@ public class EvidenceUtils {
                     nccnGuidelineBo.saveOrUpdate(nccnGuideline);
                 }
             }
-        }       
+        }
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GeneUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GeneUtils.java
@@ -23,9 +23,6 @@ public class GeneUtils {
         if (hugoSymbol != null) {
             GeneBo geneBo = ApplicationContextSingleton.getGeneBo();
             if (CacheUtils.isEnabled()) {
-                if (CacheUtils.getGeneByHugoSymbol(hugoSymbol) == null) {
-                    CacheUtils.setGeneByHugoSymbol(geneBo.findGeneByHugoSymbol(hugoSymbol));
-                }
                 return CacheUtils.getGeneByHugoSymbol(hugoSymbol);
             } else {
                 return geneBo.findGeneByHugoSymbol(hugoSymbol);

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
@@ -373,11 +373,10 @@ public class DriveAnnotationParser {
             : null;
     }
 
-    private static Oncogenicity getOncogenicity(JSONObject mutationObj) {
+    public static Oncogenicity getOncogenicityByString(String oncogenicStr) {
         Oncogenicity oncogenic = null;
-        if (mutationObj.has("oncogenic") && !mutationObj.getString("oncogenic").isEmpty()) {
-            String oncogenicStr = mutationObj.getString("oncogenic").toLowerCase();
-
+        if (oncogenicStr != null) {
+            oncogenicStr = oncogenicStr.toLowerCase();
             switch (oncogenicStr) {
                 case "yes":
                     oncogenic = Oncogenicity.YES;
@@ -394,6 +393,14 @@ public class DriveAnnotationParser {
                 default:
                     break;
             }
+        }
+        return oncogenic;
+    }
+
+    private static Oncogenicity getOncogenicity(JSONObject mutationObj) {
+        Oncogenicity oncogenic = null;
+        if (mutationObj.has("oncogenic") && !mutationObj.getString("oncogenic").isEmpty()) {
+            oncogenic = getOncogenicityByString(mutationObj.getString("oncogenic"));
         }
         return oncogenic;
     }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
@@ -6,8 +6,9 @@ package org.mskcc.cbio.oncokb.controller;
 
 import io.swagger.annotations.ApiParam;
 import org.json.JSONArray;
-import org.mortbay.util.ajax.JSON;
-import org.mskcc.cbio.oncokb.bo.*;
+import org.mskcc.cbio.oncokb.bo.AlterationBo;
+import org.mskcc.cbio.oncokb.bo.EvidenceBo;
+import org.mskcc.cbio.oncokb.bo.GeneBo;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.util.*;
 import org.springframework.http.HttpMethod;
@@ -16,8 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.*;
 import javax.xml.parsers.ParserConfigurationException;
+import java.util.*;
 
 /**
  * @author jgao
@@ -221,6 +222,15 @@ public class EvidenceController {
         Set<ClinicalTrial> clinicalTrials = queryEvidence.getClinicalTrials();
 
         List<Evidence> evidences = evidenceBo.findEvidenceByUUIDs(Collections.singletonList(uuid));
+
+        // Use controlled vocabulary to update oncogenic knowneffect
+        if(evidenceType != null && evidenceType.equals(EvidenceType.ONCOGENIC)) {
+            Oncogenicity oncogenicity = DriveAnnotationParser.getOncogenicityByString(knownEffect);
+            if (oncogenicity != null) {
+                knownEffect = oncogenicity.getOncogenic();
+            }
+        }
+
         if (evidences.isEmpty()) {
             Evidence evidence = new Evidence();
             GeneBo geneBo = ApplicationContextSingleton.getGeneBo();

--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -2696,7 +2696,7 @@ angular.module('oncokbApp')
                             collectUUIDs('treatment', treatment, uuids);
                         });
                     });
-                    uuids.push(obj.trialsUuid.getText());
+                    uuids.push(obj.trials_uuid.getText());
                 }
                 if (type === 'treatment') {
                     uuids.push(obj.name_uuid.getText());


### PR DESCRIPTION
If any changes happen on cache layer, we only remove all gene related
cache, only when other utils start to pull data from cache, and if the
gene in the genes list but not in other cached data, recache gene
specific cache.