### PR TITLE
display items precisely for review mode

### DIFF
--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -1590,9 +1590,6 @@ angular.module('oncokbApp')
             };
             $scope.getData = function() {
                 var test1 = this.gene;
-                var test = $scope.geneStatus;
-                console.log(test);
-
             };
             $scope.showEntry = function(eStatus) {
                 if (eStatus) {
@@ -1645,7 +1642,7 @@ angular.module('oncokbApp')
             }
 
             $rootScope.reviewMode = false;
-            $scope.displayCheck = function(uuid, reviewObj, mutationReview, tumorReview, treatmentReview) {
+            $scope.displayCheck = function(uuid, reviewObj, mutationReview, tumorReview, treatmentReview, precise) {
                 // regular mode check
                 if (!$rootScope.reviewMode) {
                     if (mutationReview && mutationReview.get('removed') || tumorReview && tumorReview.get('removed') || treatmentReview && treatmentReview.get('removed')) {
@@ -1655,10 +1652,17 @@ angular.module('oncokbApp')
                 }
                 // review mode check
                 if (mutationReview && mutationReview.get('removed') || tumorReview && tumorReview.get('removed') || treatmentReview && treatmentReview.get('removed')) {
-                    return true;
-                } else if (uuid !== null && checkReview(uuid)) {
+                    // removedItem is set to true to indicate it is inside a deleted section
+                    if(reviewObj && !reviewObj.get('removedItem')) {
+                        reviewObj.set('removedItem', true);
+                    }
                     return true;
                 }
+                // precisely check for this element
+                if(_.isBoolean(precise) && precise) {
+                    return uuid !== null && checkReview(uuid);
+                }
+                // check elements in a section
                 return reviewObj.get('review') || reviewObj.get('action') || reviewObj.get('rollback');
             };
             $scope.signatureCheck = function(reviewObj, mutationReview, tumorReview, treatmentReview) {
@@ -1688,9 +1692,9 @@ angular.module('oncokbApp')
                     return false;
                 }
                 if (type === 'accept') {
-                    return $rootScope.reviewMode && reviewObj.get('action') !== 'rejected' && !reviewObj.get('rollback');
+                    return $rootScope.reviewMode && reviewObj.get('action') !== 'rejected' && !reviewObj.get('rollback') && !reviewObj.get('removedItem');
                 } else if (type === 'reject') {
-                    return $rootScope.reviewMode && reviewObj.get('action') !== 'accepted' && !reviewObj.get('rollback');
+                    return $rootScope.reviewMode && reviewObj.get('action') !== 'accepted' && !reviewObj.get('rollback') && !reviewObj.get('removedItem');
                 }
             };
             function resetReview(reviewObj) {
@@ -2338,6 +2342,7 @@ angular.module('oncokbApp')
                 setReview(uuid, false);
                 delete myUpdatedEvidences[uuid];
                 reviewObj.delete('lastReviewed');
+                reviewObj.delete('removedItem');
                 reviewObj.delete('updatedBy');
                 reviewObj.delete('updateTime');
             }
@@ -2422,6 +2427,7 @@ angular.module('oncokbApp')
                     obj.set('OCG', lastReviewedContent.OCG);
                 }
                 reviewObj.delete('lastReviewed');
+                reviewObj.delete('removedItem');
                 reviewObj.delete('updatedBy');
                 reviewObj.delete('updateTime');
             }

--- a/web/yo/app/views/driveRealtimeString.html
+++ b/web/yo/app/views/driveRealtimeString.html
@@ -1,45 +1,33 @@
 <div class="drive-realtime-string">
     <div ng-if="t === 'p'">
-        <h4 ng-if="reviewMode && !rs.get('action')">New Content:</h4>
+        <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">New Content:</h4>
         <p class="doubleH" ng-if="!reviewMode || !rs.get('action')"
            ng-class="{editableBox:fe, unEditableBox:!fe}"
            contenteditable="{{!reviewMode ? fe : true}}"
            placeholder="{{ph}}"
            ng-model="content.stringO">
         </p>
-        <h4 ng-if="reviewMode && !rs.get('action')">Old Content:</h4>
-        <p ng-if="reviewMode">{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}
+        <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">Old Content:</h4>
+        <p ng-if="reviewMode && !rs.get('removedItem')">{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}
         </p>
         <pub-iframe
             ng-model="content.stringO"
-            ng-if="io">
+            ng-if="!reviewMode && io">
         </pub-iframe>
     </div>
-    <div ng-if="t === 'input'">
-        <input type='text' ng-class="{editableBox:fe, unEditableBox:!fe}" contenteditable="{{fe}}" placeholder="{{ph}}"
-               ng-model="content.stringO"/>
-    </div>
     <div ng-if="t === 'short'">
-        <h4 ng-if="reviewMode && !rs.get('action')">New Content:</h4>
+        <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">New Content:</h4>
         <p ng-class="{editableBox:fe, unEditableBox:!fe}" ng-if="!reviewMode || !rs.get('action')"
            contenteditable="{{!reviewMode ? fe : true}}"
            placeholder="{{ph}}"
            ng-model="content.stringO">
         </p>
-        <h4 ng-if="reviewMode && !rs.get('action')">Old Content:</h4>
-        <p ng-if="reviewMode">{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}
-    </div>
-    <div ng-if="t === 'select'">
-        <h4 ng-if="reviewMode && !rs.get('action')">New Content:</h4>
-        <select ng-model="content.stringO" ng-if="!reviewMode || !rs.get('action')"
-                ng-options="opt.value as opt.label for opt in o">
-        </select>
-        <h4 ng-if="reviewMode && !rs.get('action')">Old Content:</h4>
-        <p ng-if="reviewMode">{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}
+        <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">Old Content:</h4>
+        <p ng-if="reviewMode && !rs.get('removedItem')">{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}
     </div>
     <div ng-if="t === 'treatment-select'" class="treatment-select">
         <div>
-            <h4 ng-if="reviewMode && !rs.get('action')">New Content:</h4>
+            <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">New Content:</h4>
             <div ng-if="!reviewMode || !rs.get('action')">
                 <select ng-model="content.stringO"
                         ng-options="opt.value as opt.label for opt in o">
@@ -51,8 +39,8 @@
                     </select>
                 </div>
             </div>
-            <h4 ng-if="reviewMode && !rs.get('action')">Old Content:</h4>
-            <div ng-if="reviewMode">
+            <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">Old Content:</h4>
+            <div ng-if="reviewMode && !rs.get('removedItem')">
                 <p>{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}</p>
                 <div class="propagation" ng-if="content.propagationOpts.length > 0">
                     <span>Level of Evidence in other tumor types: </span>
@@ -63,15 +51,18 @@
 
     </div>
     <div ng-if="t === 'select-chosen'" class="chosen-full-width">
+        <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">New Content:</h4>
         <select chosen ng-attr-id="{{chosenid}}" allow-single-deselect="true" ng-model="content.stringO"
                 ng-options="opt for opt in o">
             <option value="NA"></option>
         </select>
+        <h4 ng-if="reviewMode && !rs.get('action') && !rs.get('removedItem')">Old Content:</h4>
+        <p ng-if="reviewMode && !rs.get('removedItem')">{{!rs.get('action') ? rs.get('lastReviewed') : content.stringO}}
     </div>
     <div ng-if="t === 'checkbox'">
         <div>
             <br/>
-            <h4 ng-if="reviewMode && !objecttype && !rs.get('action')">New Content:</h4>
+            <h4 ng-if="reviewMode && !objecttype && !rs.get('action') && !rs.get('removedItem')">New Content:</h4>
             <div>
                     <span ng-repeat="checkbox in checkboxes" ng-if="!reviewMode || !rs.get('action')">
                       <input
@@ -87,10 +78,10 @@
             </div>
         </div>
 
-        <div ng-class="{'left-float': rs.get('mutation_effect')}">
-            <h4 ng-if="reviewMode && !objecttype && !rs.get('action')">Old Content:</h4>
+        <div ng-class="{'left-float': rs.get('mutation_effect')}" ng-if="reviewMode && !rs.get('removedItem')">
+            <h4 ng-if="!objecttype && !rs.get('action')">Old Content:</h4>
             <div>
-                <span ng-if="reviewMode && !objecttype" ng-repeat="checkbox in checkboxes" class="reviewedBG">
+                <span ng-if="!objecttype" ng-repeat="checkbox in checkboxes" class="reviewedBG">
                   <input
                       id="{{checkboxid}}-{{$index}}-review"
                       type="radio"
@@ -102,24 +93,5 @@
             </div>
 
         </div>
-    </div>
-    <div ng-if="t === 's-checkbox'">
-        <span ng-repeat="checkbox in checkboxes">
-            <input
-                id="{{checkboxid}}-{{$index}}"
-                type="radio"
-                ng-model="content.stringO"
-                ng-value="checkbox"
-                ng-change="sCheckboxChange()"
-                ng-click="uncheck($event)"
-                ng-disabled="!fe"
-            >
-            <label for="{{checkboxid}}-{{$index}}">{{checkbox}}</label>
-            <input type='text' ng-class="{editableBox:fe, unEditableBox:!fe}" contenteditable="{{fe}}"
-                   ng-if="content.stringO === checkbox && checkbox !== 'Other'" ng-model="content.addon"
-                   placeholder="{{ph}}"/>
-            <input type='text' ng-class="{editableBox:fe, unEditableBox:!fe}" contenteditable="{{fe}}"
-                   ng-if="content.stringO === checkbox && checkbox === 'Other'" ng-model="content.addon"/>
-        </span>
     </div>
 </div>

--- a/web/yo/app/views/gene.html
+++ b/web/yo/app/views/gene.html
@@ -169,18 +169,18 @@
                     <i class="fa fa-times fa-margin" ng-class="iconClass('reject', mutation.oncogenic_review)" ng-if="iconExist('reject', mutation.oncogenic_review, mutation.name_review)"  ng-click="reject($event, 'Clinical effect', mutation, null, null, null, mutation.oncogenic_review)"></i>
                 </span>
               </uib-accordion-heading>
-                <p>
+                <p ng-if="displayCheck(mutation.oncogenic_uuid, mutation.oncogenic_review, mutation.name_review, null, null, true)">
                     <strong style="float: left">{{::mutation.oncogenic.display}}:</strong>
                     <drive-realtime-string rs="mutation.oncogenic_review" uuid="mutation.oncogenic_uuid" es="mutation.shortSummary_eStatus" fe="fileEditable" t="'checkbox'" object="mutation.oncogenic" checkboxes="checkboxes['oncogenic']" checkboxid="mutation.name.text + '-shortSummary-box-'"></drive-realtime-string>
                 </p>
                 <!-- Migrate from mutation summary -->
                 <div>
-                    <span ng-if="userRole === 8">
+                    <span ng-if="userRole === 8 && displayCheck(mutation.shortSummary_uuid, mutation.shortSummary_review, mutation.name_review, null, null, true)">
                     <strong>Summary statement:</strong>
                     <br/>
                     <drive-realtime-string rs="mutation.shortSummary_review" uuid="mutation.shortSummary_uuid" fe="fileEditable" t="'p'" object="mutation.shortSummary" io="geneStatus[$index].shortSummary.isOpen"></drive-realtime-string>
                   </span>
-                    <span>
+                    <span ng-if="displayCheck(mutation.summary_uuid, mutation.summary_review, mutation.name_review, null, null, true)">
                     <strong>Description of Evidence:</strong>
                     <br/>
                     <drive-realtime-string rs="mutation.summary_review" uuid="mutation.summary_uuid" fe="fileEditable" t="'p'" object="mutation.summary" io="geneStatus[$index].shortSummary.isOpen"></drive-realtime-string>
@@ -194,30 +194,30 @@
                       <i class="fa  " ng-class="{'fa-chevron-down': geneStatus[$index].oncogenic.isOpen, 'fa-chevron-right': !geneStatus[$index].oncogenic.isOpen}" ng-click="changeIsOpen(geneStatus[$index].oncogenic.isOpen)"></i>
                       <span> Summary of biological effect</span><span ng-click="stopCollopse($event)" class="curationNoEntry" ng-if="checkEmpty(mutation, 'mutationEffect')">No Entry</span><comments-dict mutation="{{mutation.name.text}}" file-editable="fileEditable" gene-name="{{::gene.name.text}}" comments="mutation.oncogenic_comments" object="mutation" key="oncogenic" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)" add-comment="addComment(arg1,arg2,arg3)"></comments-dict>
                       <span class="pull-right" ng-show="fileEditable">
-                   <e-status ng-if="userRole === 8"  ng-click="commentClick($event)" ng-keypress="stopCollopse($event)" object="mutation.oncogenic_eStatus" id="mutation.name.text  + '-oncogenic'"></e-status>
-                </span>
-                <span style="margin-right:10px;float:right" ng-show="reviewMode">
-                    <p ng-show="signatureCheck(mutation.effect_review, mutation.name_review)" style="float:left;font-size:15px;">Updated by {{mutation.effect_review.get('updatedBy')}} at {{mutation.effect_review.get('updateTime')}}</p>
-                    <i class="fa fa-check fa-margin" ng-class="iconClass('accept', mutation.effect_review)" ng-if="iconExist('accept', mutation.effect_review, mutation.name_review)"  ng-click="accept($event, 'MUTATION_EFFECT', mutation, null, null, null, mutation.effect_review)"></i>
-                    <i class="fa fa-times fa-margin" ng-class="iconClass('reject', mutation.effect_review)" ng-if="iconExist('reject', mutation.effect_review, mutation.name_review)"  ng-click="reject($event, 'MUTATION_EFFECT', mutation, null, null, null, mutation.effect_review)"></i>
-                </span>
+                        <e-status ng-if="userRole === 8"  ng-click="commentClick($event)" ng-keypress="stopCollopse($event)" object="mutation.oncogenic_eStatus" id="mutation.name.text  + '-oncogenic'"></e-status>
+                        </span>
+                        <span style="margin-right:10px;float:right" ng-show="reviewMode">
+                            <p ng-show="signatureCheck(mutation.effect_review, mutation.name_review)" style="float:left;font-size:15px;">Updated by {{mutation.effect_review.get('updatedBy')}} at {{mutation.effect_review.get('updateTime')}}</p>
+                            <i class="fa fa-check fa-margin" ng-class="iconClass('accept', mutation.effect_review)" ng-if="iconExist('accept', mutation.effect_review, mutation.name_review)"  ng-click="accept($event, 'MUTATION_EFFECT', mutation, null, null, null, mutation.effect_review)"></i>
+                            <i class="fa fa-times fa-margin" ng-class="iconClass('reject', mutation.effect_review)" ng-if="iconExist('reject', mutation.effect_review, mutation.name_review)"  ng-click="reject($event, 'MUTATION_EFFECT', mutation, null, null, null, mutation.effect_review)"></i>
+                        </span>
                   </uib-accordion-heading>
-                  <div class="mutationEffect">
+                  <div class="mutationEffect" ng-if="displayCheck(mutation.effect_uuid, mutation.effect_review, mutation.name_review, null, null, true)">
                       <strong class="header">Mutation effect:</strong>
                       <div class="content">
                           <drive-realtime-string rs="mutation.effect_review" uuid="mutation.effect_uuid" es="mutation.oncogenic_eStatus" fe="fileEditable" t="'checkbox'" object="mutation.effect.value" checkboxes="checkboxes['mutationEffect']" checkboxid="mutation.name.text + '-mutation-effect-box-'" addon="mutation.effect.addOn" ph="' Optional text'"></drive-realtime-string>
                       </div>
                   </div>
-                  <span>
-                <strong>Description of Evidence:</strong>
-                <br/>
-                <drive-realtime-string rs="mutation.description_review" uuid="mutation.description_uuid" es="mutation.oncogenic_eStatus" fe="fileEditable" t="'p'" object="mutation.description" io="geneStatus[$index].oncogenic.isOpen"></drive-realtime-string>
-              </span>
-                  <span>
-                <strong>Additional Information (Optional):</strong>
-                <br/>
-                <drive-realtime-string rs="mutation.short_review" uuid="mutation.short_uuid" es="mutation.oncogenic_eStatus" fe="fileEditable" t="'p'" object="mutation.short" io="geneStatus[$index].oncogenic.isOpen"></drive-realtime-string>
-              </span>
+                  <span ng-if="displayCheck(mutation.description_uuid, mutation.description_review, mutation.name_review, null, null, true)">
+                    <strong>Description of Evidence:</strong>
+                    <br/>
+                    <drive-realtime-string rs="mutation.description_review" uuid="mutation.description_uuid" es="mutation.oncogenic_eStatus" fe="fileEditable" t="'p'" object="mutation.description" io="geneStatus[$index].oncogenic.isOpen"></drive-realtime-string>
+                  </span>
+                  <span ng-if="displayCheck(mutation.short_uuid, mutation.short_review, mutation.name_review, null, null, true)">
+                    <strong>Additional Information (Optional):</strong>
+                    <br/>
+                    <drive-realtime-string rs="mutation.short_review" uuid="mutation.short_uuid" es="mutation.oncogenic_eStatus" fe="fileEditable" t="'p'" object="mutation.short" io="geneStatus[$index].oncogenic.isOpen"></drive-realtime-string>
+                  </span>
               </uib-accordion-group>
 
             <!-- tumor types -->
@@ -251,7 +251,7 @@
                 <uib-accordion close-others="false" ng-if="geneStatus[$parent.$parent.$parent.$parent.$index][$index].isOpen">
                   <!--<span><p ng-class="{editableBox:fileEditable, unEditableBox:!fileEditable}" contenteditable="{{fileEditable}}" placeholder="Optional short tumor type summary" ng-model="tumor.shortSummary.text"></p></span>-->
                   <!--<pub-iframe ng-model="tumor.shortSummary.text"></pub-iframe>-->
-                <div ng-if="displayCheck(tumor.summary_uuid, tumor.summary_review, mutation.name_review, tumor.name_review)">
+                <div ng-if="displayCheck(tumor.summary_uuid, tumor.summary_review, mutation.name_review, tumor.name_review, null, true)">
                     <h5><b>Tumor Type Summary (Optional): </b>
                     <span style="margin-right:10px;float:right" ng-show="reviewMode">
                         <p ng-show="signatureCheck(tumor.summary_review, mutation.name_review, tumor.name_review)" style="float:left;font-size:15px;">Updated by {{tumor.summary_review.get('updatedBy')}} at {{tumor.summary_review.get('updateTime')}}</p>
@@ -277,8 +277,8 @@
                             <i class="fa fa-times fa-margin" ng-class="iconClass('reject', tumor.prevalence_review)" ng-if="iconExist('reject', tumor.prevalence_review, tumor.name_review)"  ng-click="reject($event, 'PREVALENCE', mutation, tumor, null, null, tumor.prevalence_review)"></i>
                         </span>
                     </uib-accordion-heading>
-                    <drive-realtime-string rs="tumor.prevalence_review" uuid="tumor.prevalence_uuid" es="tumor.prevalence_eStatus" fe="fileEditable" t="'p'" object="tumor.prevalence" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].prevalence.isOpen" ph="'Description of Evidence'"></drive-realtime-string>
-                    <drive-realtime-string rs="tumor.shortPrevalence_review" uuid="tumor.shortPrevalence_uuid" es="tumor.prevalence_eStatus" fe="fileEditable" t="'p'" object="tumor.shortPrevalence" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].prevalence.isOpen" ph="'Additional Information (Optional)'"></drive-realtime-string>
+                    <drive-realtime-string ng-if="displayCheck(tumor.prevalence_uuid, tumor.prevalence_review, mutation.name_review, tumor.name_review, null, true)" rs="tumor.prevalence_review" uuid="tumor.prevalence_uuid" es="tumor.prevalence_eStatus" fe="fileEditable" t="'p'" object="tumor.prevalence" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].prevalence.isOpen" ph="'Description of Evidence'"></drive-realtime-string>
+                    <drive-realtime-string ng-if="displayCheck(tumor.shortPrevalence_uuid, tumor.shortPrevalence_review, mutation.name_review, tumor.name_review, null, true)" rs="tumor.shortPrevalence_review" uuid="tumor.shortPrevalence_uuid" es="tumor.prevalence_eStatus" fe="fileEditable" t="'p'" object="tumor.shortPrevalence" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].prevalence.isOpen" ph="'Additional Information (Optional)'"></drive-realtime-string>
                   </uib-accordion-group>
 
                   <!-- Prognostic implications -->
@@ -296,8 +296,8 @@
                             <i class="fa fa-times fa-margin" ng-class="iconClass('reject', tumor.progImp_review)" ng-if="iconExist('reject', tumor.progImp_review, tumor.name_review)"  ng-click="reject($event, 'PROGNOSTIC_IMPLICATION', mutation, tumor, null, null, tumor.progImp_review)"></i>
                         </span>
                     </uib-accordion-heading>
-                    <drive-realtime-string rs="tumor.progImp_review" uuid="tumor.progImp_uuid" es="tumor.progImp_eStatus" fe="fileEditable" t="'p'" object="tumor.progImp" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].progImp.isOpen" ph="'Description of Evidence'"></drive-realtime-string>
-                    <drive-realtime-string rs="tumor.shortProgImp_review" uuid="tumor.shortProgImp_uuid" es="tumor.progImp_eStatus" fe="fileEditable" t="'p'" object="tumor.shortProgImp" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].progImp.isOpen" ph="'Additional Information (Optional)'"></drive-realtime-string>
+                    <drive-realtime-string ng-if="displayCheck(tumor.progImp_uuid, tumor.progImp_review, mutation.name_review, tumor.name_review, null, true)" rs="tumor.progImp_review" uuid="tumor.progImp_uuid" es="tumor.progImp_eStatus" fe="fileEditable" t="'p'" object="tumor.progImp" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].progImp.isOpen" ph="'Description of Evidence'"></drive-realtime-string>
+                    <drive-realtime-string ng-if="displayCheck(tumor.shortProgImp_uuid, tumor.shortProgImp_review, mutation.name_review, tumor.name_review, null, true)" rs="tumor.shortProgImp_review" uuid="tumor.shortProgImp_uuid" es="tumor.progImp_eStatus" fe="fileEditable" t="'p'" object="tumor.shortProgImp" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].progImp.isOpen" ph="'Additional Information (Optional)'"></drive-realtime-string>
                   </uib-accordion-group>
 
                   <!-- NCCN guidelines -->
@@ -315,13 +315,15 @@
                             <i class="fa fa-times fa-margin" ng-class="iconClass('reject', tumor.nccn_review)" ng-if="iconExist('reject', tumor.nccn_review, tumor.name_review)"  ng-click="reject($event, 'NCCN_GUIDELINES', mutation, tumor, null, null, tumor.nccn_review)"></i>
                         </span>
                     </uib-accordion-heading>
-                    <strong>{{::tumor.nccn.therapy.display}}:</strong>
-                    <drive-realtime-string rs="tumor.nccn.therapy_review" uuid="tumor.nccn.therapy_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'short'" object="tumor.nccn.therapy"></drive-realtime-string>
-                    <p>
+                    <p ng-if="displayCheck(tumor.nccn.therapy_uuid, tumor.nccn.therapy_review, mutation.name_review, tumor.name_review, null, true)">
+                        <strong>{{::tumor.nccn.therapy.display}}:</strong>
+                        <drive-realtime-string rs="tumor.nccn.therapy_review" uuid="tumor.nccn.therapy_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'short'" object="tumor.nccn.therapy"></drive-realtime-string>
+                    </p>
+                    <p ng-if="displayCheck(tumor.nccn.disease_uuid, tumor.nccn.disease_review, mutation.name_review, tumor.name_review, null, true)">
                       <strong>{{::tumor.nccn.disease.display}}:</strong>
                       <drive-realtime-string rs="tumor.nccn.disease_review" uuid="tumor.nccn.disease_uuid" es="tumor.nccn_eStatus" t="'select-chosen'" object="tumor.nccn.disease" o="nccnDiseaseTypes" chosenid="'CurationNCCNDropDown'"></drive-realtime-string>
                     </p>
-                    <p>
+                    <p ng-if="displayCheck(tumor.nccn.version_uuid, tumor.nccn.version_review, mutation.name_review, tumor.name_review, null, true)">
                       <strong>{{::tumor.nccn.version.display}}:</strong>
                       <drive-realtime-string rs="tumor.nccn.version_review" uuid="tumor.nccn.version_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'short'" object="tumor.nccn.version"></drive-realtime-string>
                     </p>
@@ -333,15 +335,15 @@
                       <!--<strong>{{::tumor.nccn.category.display}}:</strong>-->
                       <!--<drive-realtime-string es="tumor.nccn_eStatus" fe="fileEditable" t="'select'" object="tumor.nccn.category" o="nccnCategories"></drive-realtime-string>-->
                     <!--</p>-->
-                    <span>
-                    <strong>Description of Evidence:</strong>
-                    <br/>
-                    <drive-realtime-string rs="tumor.nccn.description_review" uuid="tumor.nccn.description_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'p'" object="tumor.nccn.description" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].nccn.isOpen"></drive-realtime-string>
+                    <span ng-if="displayCheck(tumor.nccn.description_uuid, tumor.nccn.description_review, mutation.name_review, tumor.name_review, null, true)">
+                        <strong>Description of Evidence:</strong>
+                        <br/>
+                        <drive-realtime-string rs="tumor.nccn.description_review" uuid="tumor.nccn.description_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'p'" object="tumor.nccn.description" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].nccn.isOpen"></drive-realtime-string>
                     </span>
-                    <span>
-                    <strong>Additional Information (Optional):</strong>
-                    <br/>
-                    <drive-realtime-string rs="tumor.nccn.short_review" uuid="tumor.nccn.short_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'p'" object="tumor.nccn.short" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].nccn.isOpen"></drive-realtime-string>
+                    <span ng-if="displayCheck(tumor.nccn.short_uuid, tumor.nccn.short_review, mutation.name_review, tumor.name_review, null, true)">
+                        <strong>Additional Information (Optional):</strong>
+                        <br/>
+                        <drive-realtime-string rs="tumor.nccn.short_review" uuid="tumor.nccn.short_uuid" es="tumor.nccn_eStatus" fe="fileEditable" t="'p'" object="tumor.nccn.short" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$index][$index].nccn.isOpen"></drive-realtime-string>
                     </span>
                   </uib-accordion-group>
 
@@ -359,7 +361,7 @@
                       </uib-accordion-heading>
                       <!--<span><p ng-class="{editableBox:fileEditable, unEditableBox:!fileEditable}" contenteditable="{{fileEditable}}" placeholder="Optional short general summary" ng-model="ti.short.text"></p></span>-->
                       <!--<pub-iframe ng-model="ti.short.text" ng-if="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$index][$index].isOpen"></pub-iframe>-->
-                        <div ng-if="displayCheck(ti.description_uuid, ti.description_review, mutation.name_review, tumor.name_review)">
+                        <div ng-if="displayCheck(ti.description_uuid, ti.description_review, mutation.name_review, tumor.name_review, null, true)">
                             <h5><b>General Summary (Optional): </b>
                                 <span style="margin-right:10px;float:right" ng-show="reviewMode">
                                     <p ng-show="signatureCheck(ti.description_review, mutation.name_review, tumor.name_review)" style="float:left;font-size:15px;">Updated by {{ti.description_review.get('updatedBy')}} at {{ti.description_review.get('updateTime')}}</p>
@@ -400,7 +402,7 @@
                                 <i class="fa fa-times fa-margin" ng-class="iconClass('reject', mutation.name_review)" ng-click="cancelDelete($event, 'treatment', treatment, $parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index, $parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index, $parent.$parent.$parent.$parent.$parent.$parent.$index, $index)"></i>
                             </span>
                             </uib-accordion-heading>
-                            <p>
+                            <p ng-if="displayCheck(treatment.level_uuid, treatment.level_review, mutation.name_review, tumor.name_review, treatment.name_review, true)">
                               <strong>{{::treatment.level.display}}:</strong><br/>
                               <span ng-if="checkTI(ti, 1, 1)">
                                 <drive-realtime-string rs="treatment.level_review" uuid="treatment.level_uuid" es="treatment.name_eStatus" fe="fileEditable" object="treatment.level" t="'treatment-select'" o="levels.SS"></drive-realtime-string>
@@ -417,7 +419,7 @@
                                 <i class="fa fa-question-circle" style="color: grey;" uib-tooltip-html="levelExps.IR"></i>
                               </span>
                             </p>
-                            <div class="approvedIndication" ng-if="checkTI(ti, 1, 1)">
+                            <div class="approvedIndication" ng-if="checkTI(ti, 1, 1) && displayCheck(treatment.indication_uuid, treatment.indication_review, mutation.name_review, tumor.name_review, treatment.name_review, true)">
                               <div class="header">
                                 <strong>{{::treatment.indication.display}}:</strong>
                               </div>
@@ -425,12 +427,12 @@
                                 <drive-realtime-string rs="treatment.indication_review" uuid="treatment.indication_uuid" es="treatment.name_eStatus" fe="fileEditable" t="'short'" object="treatment.indication" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$index][$index].isOpen"></drive-realtime-string>
                               </div>
                             </div>
-                            <span>
+                            <span ng-if="displayCheck(treatment.description_uuid, treatment.description_review, mutation.name_review, tumor.name_review, treatment.name_review, true)">
                               <strong>Description of Evidence:</strong>
                               <br/>
                               <drive-realtime-string rs="treatment.description_review" uuid="treatment.description_uuid" es="treatment.name_eStatus" fe="fileEditable" t="'p'" object="treatment.description" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$index][$index].isOpen"></drive-realtime-string>
                             </span>
-                            <span>
+                            <span ng-if="displayCheck(treatment.short_uuid, treatment.short_review, mutation.name_review, tumor.name_review, treatment.name_review, true)">
                               <strong>Additional Information (Optional):</strong>
                               <br/>
                               <drive-realtime-string rs="treatment.short_review" uuid="treatment.short_uuid" es="treatment.name_eStatus" fe="fileEditable" t="'p'" object="treatment.short" io="geneStatus[$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$parent.$parent.$parent.$parent.$index][$parent.$parent.$parent.$index][$index].isOpen"></drive-realtime-string>


### PR DESCRIPTION
For example, if oncogenicity is changed, then the whole clinical summary section will be displayed in the review mode, which will cause unnecessary reading work for reviewer.
Therefor, in this PR, we add the check to only display the items where change actually happened.