### PR TITLE
under review check

### DIFF
--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -3607,7 +3607,7 @@ angular.module('oncokbApp')
                 $timeout(function() {
                     if (underOthersReview()) {
                         $scope.$emit('interruptedDueToOtherReview');
-                    } else {
+                    } else if(underReview()) {
                         // if no other is reviewing the current document,
                         // need to reset the document to initial state.
                         $scope.exitReview();


### PR DESCRIPTION
Issue: Gene document got written when curator only opened it, which reflects on the Last Modified column in genes page.

Fix: Check if this gene document is under review or not before exit review systematically. 