### PR TITLE
set uuid when empty uuid is detected

### DIFF
--- a/web/yo/app/scripts/app.js
+++ b/web/yo/app/scripts/app.js
@@ -406,7 +406,11 @@ OncoKB.initialize = function() {
                         this[__key + '_uuid'] = model.createString('');
                         this[__key + '_review'] = model.createMap();
                         if(!OncoKB.backingUp) {
-                            this[__key + '_uuid'].setText(UUIDjs.create(4).toString());
+                            var tempString = '';
+                            while(!tempString) {
+                                tempString = UUIDjs.create(4).toString();
+                            }
+                            this[__key + '_uuid'].setText(tempString);
                         }
                     }
                     switch (OncoKB.curateInfo[id][__key].type) {

--- a/web/yo/app/scripts/services/stringutils.js
+++ b/web/yo/app/scripts/services/stringutils.js
@@ -8,7 +8,7 @@
  * Factory in the oncokbApp.
  */
 angular.module('oncokbApp')
-    .factory('stringUtils', function(_, OncoKB, S) {
+    .factory('stringUtils', function(_, OncoKB, S, UUIDjs) {
         /* eslint camelcase: ["error", {properties: "never"}]*/
         function findMutationEffect(query) {
             var mapping = {
@@ -903,7 +903,9 @@ angular.module('oncokbApp')
                     if (!(excludeObsolete && e.oncogenic_eStatus && e.oncogenic_eStatus.has('obsolete') && e.oncogenic_eStatus.get('obsolete') === 'true')) {
                         _mutation = combineData(_mutation, e, ['description', 'short'], excludeObsolete, excludeComments, onlyReviewedContent);
                         _mutation.effect = combineData(_mutation.effect, e.effect, ['value', 'addOn'], false, excludeComments, onlyReviewedContent);
-                        _mutation.effect_uuid = e.effect_uuid ? e.effect_uuid.getText() : '';
+                        if(e.effect_uuid) {
+                            _mutation.effect_uuid = validUUID(e.effect_uuid);
+                        }
                         _mutation.effect_review = getReview(e.effect_review);
                         // if(_mutation.effect && _mutation.effect.value) {
                         //     var effect = _mutation.effect.value;
@@ -965,7 +967,9 @@ angular.module('oncokbApp')
 
                             if (!(excludeObsolete && e1.nccn_eStatus && e1.nccn_eStatus.has('obsolete') && e1.nccn_eStatus.get('obsolete') === 'true')) {
                                 __tumor.nccn = combineData(__tumor.nccn, e1.nccn, ['therapy', 'disease', 'version', 'pages', 'category', 'description', 'short'], excludeObsolete, excludeComments, onlyReviewedContent);
-                                __tumor.nccn_uuid = e1.nccn_uuid ? e1.nccn_uuid.getText() : '';
+                                if(e1.nccn_uuid) {
+                                    __tumor.nccn_uuid = validUUID(e1.nccn_uuid);
+                                }
                                 __tumor.nccn_review = getReview(e1.nccn_review);
                             }
 
@@ -977,7 +981,9 @@ angular.module('oncokbApp')
                                 if (!excludeComments && e1.trials_comments) {
                                     __tumor.trials_comments = getComments(e1.trials_comments);
                                 }
-                                __tumor.trials_uuid = e1.trials_uuid ? e1.trials_uuid.getText() : '';
+                                if(e1.trials_uuid) {
+                                    __tumor.trials_uuid = validUUID(e1.trials_uuid);
+                                }
                                 __tumor.trials_review = getReview(e1.trials_review);
                             }
 
@@ -1038,7 +1044,7 @@ angular.module('oncokbApp')
                             object[e][keyMapping] = model[e].get(keyMapping);
                         });
                         if (model[e + '_uuid']) {
-                            object[e + '_uuid'] = model[e + '_uuid'].getText();
+                            object[e + '_uuid'] = validUUID(model[e + '_uuid']);
                         }
                     } else {
                         if (onlyReviewedContent && model[e + '_review'] && model[e + '_review'].get('lastReviewed')) {
@@ -1063,7 +1069,7 @@ angular.module('oncokbApp')
                             object[e + '_timeStamp'] = getTimeStamp(model[e + '_timeStamp']);
                         }
                         if (model[e + '_uuid']) {
-                            object[e + '_uuid'] = model[e + '_uuid'].getText();
+                            object[e + '_uuid'] = validUUID(model[e + '_uuid']);
                         }
                         if (model[e + '_review']) {
                             object[e + '_review'] = getReview(model[e + '_review']);
@@ -1161,6 +1167,17 @@ angular.module('oncokbApp')
                 }
             }
             return result.join('\t');
+        }
+
+        function validUUID(obj) {
+            if(!obj.getText()) {
+                var tempString = '';
+                while(!tempString) {
+                    tempString = UUIDjs.create(4).toString();
+                }
+                obj.setText(tempString);
+                return tempString;
+            } else return obj.getText();
         }
 
         // Public API here


### PR DESCRIPTION
I don't see how UUIDjs.create(4) would create empty string, but looks like it is happening somehow. 
In this PR, we reset uuid when invalid uuid is detected.