### PR TITLE
Improve relevant alts mapping

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -38,8 +38,8 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
     public List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end, List<Alteration> alterations) {
         Set<Alteration> result = new HashSet<>();
 
-        if(gene != null && consequence != null) {
-            for(String cons: consequence.getTerm().split("\\s*,\\s*")) {
+        if (gene != null && consequence != null) {
+            for (String cons : consequence.getTerm().split("\\s*,\\s*")) {
                 VariantConsequence tmpConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm(cons);
                 if (alterations != null && alterations.size() > 0) {
                     for (Alteration alteration : alterations) {
@@ -49,7 +49,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                     }
                 } else {
                     List<Alteration> queryResult = getDao().findMutationsByConsequenceAndPosition(gene, tmpConsequence, start, end);
-                    if(queryResult != null) {
+                    if (queryResult != null) {
                         result.addAll(queryResult);
                     }
                 }
@@ -61,6 +61,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
     /**
      * Find all relevant alterations. The order is important. The list should be generated based on priority.
+     *
      * @param alteration
      * @param fullAlterations
      * @return
@@ -73,7 +74,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             alterations.add(matchedAlt);
         }
         if (alteration.getConsequence() != null) {
-            if(alteration.getConsequence().getTerm().equals("synonymous_variant")) {
+            if (alteration.getConsequence().getTerm().equals("synonymous_variant")) {
                 return new ArrayList<>();
             }
             // we need to develop better way to match mutation
@@ -162,6 +163,12 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             Alteration alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), "fusions");
             if (alt != null) {
                 alterations.add(alt);
+            } else {
+                // If no fusions curated, check the Truncating Mutations.
+                alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), "Truncating Mutations");
+                if (alt != null) {
+                    alterations.add(alt);
+                }
             }
         }
 
@@ -181,7 +188,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             }
         }
 
-        for(String effect : effects) {
+        for (String effect : effects) {
             Alteration alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), effect + " mutations");
             if (alt != null) {
                 alterations.add(alt);
@@ -189,8 +196,8 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         // Looking for oncogenic mutations
-        for(Alteration alt : alterations) {
-            if(AlterationUtils.isOncogenicAlteration(alt)) {
+        for (Alteration alt : alterations) {
+            if (AlterationUtils.isOncogenicAlteration(alt)) {
                 Alteration oncogenicMutations = findAlteration(alt.getGene(), alt.getAlterationType(), "oncogenic mutations");
                 if (oncogenicMutations != null) {
                     alterations.add(oncogenicMutations);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -101,76 +101,99 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), anyConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations));
 
         //If alteration contains 'fusion'
-        if (alteration.getAlteration() != null && alteration.getAlteration().toLowerCase().contains("fusion")) {
-            boolean matchFusionForBothPatnerGenes = false;
-            if (matchFusionForBothPatnerGenes) {
-                GeneBo geneBo = ApplicationContextSingleton.getGeneBo();
-                String fusion = alteration.getAlteration(); // e.g. TRB-NKX2-1 fusion
-                int ix = fusion.toLowerCase().indexOf("fusion");
-                if (ix >= 0) {
-                    Gene gene = alteration.getGene();
-                    if (gene.getEntrezGeneId() > 0) {
-                        // find fusions annotated in the other gene
-                        String symbol = gene.getHugoSymbol();
-                        String genes = fusion.substring(0, ix);
-                        int ixg = genes.indexOf(symbol);
-                        if (ixg < 0) {
-                            System.err.println(fusion + " was under " + symbol);
+        if (alteration.getAlteration() != null) {
+            Alteration truncatingMutation = findAlteration(alteration.getGene(), alteration.getAlterationType(), "Truncating Mutations");
+            if (alteration.getAlteration().toLowerCase().contains("fusion")) {
+                boolean matchFusionForBothPatnerGenes = false;
+                if (matchFusionForBothPatnerGenes) {
+                    GeneBo geneBo = ApplicationContextSingleton.getGeneBo();
+                    String fusion = alteration.getAlteration(); // e.g. TRB-NKX2-1 fusion
+                    int ix = fusion.toLowerCase().indexOf("fusion");
+                    if (ix >= 0) {
+                        Gene gene = alteration.getGene();
+                        if (gene.getEntrezGeneId() > 0) {
+                            // find fusions annotated in the other gene
+                            String symbol = gene.getHugoSymbol();
+                            String genes = fusion.substring(0, ix);
+                            int ixg = genes.indexOf(symbol);
+                            if (ixg < 0) {
+                                System.err.println(fusion + " was under " + symbol);
+                            } else {
+                                String theOtherGene = genes.replace(symbol, "")
+                                    .replaceAll("-", " ").trim() // trim -
+                                    .replaceAll(" ", "-");
+
+                                Gene tog = geneBo.findGeneByHugoSymbol(theOtherGene);
+                                if (tog != null) {
+                                    String reverse;
+                                    if (ixg == 0) {
+                                        reverse = tog.getHugoSymbol() + "-" + symbol + " fusion";
+                                    } else {
+                                        reverse = symbol + "-" + tog.getHugoSymbol() + " fusion";
+                                    }
+
+                                    Alteration toa = findAlteration(tog, alteration.getAlterationType(), reverse);
+                                    if (toa != null) {
+                                        alterations.add(toa);
+                                    }
+
+                                    toa = findAlteration(tog, alteration.getAlterationType(), "fusions");
+                                    if (toa != null) {
+                                        alterations.add(toa);
+                                    }
+                                }
+                            }
                         } else {
-                            String theOtherGene = genes.replace(symbol, "")
-                                .replaceAll("-", " ").trim() // trim -
-                                .replaceAll(" ", "-");
-
-                            Gene tog = geneBo.findGeneByHugoSymbol(theOtherGene);
-                            if (tog != null) {
-                                String reverse;
-                                if (ixg == 0) {
-                                    reverse = tog.getHugoSymbol() + "-" + symbol + " fusion";
-                                } else {
-                                    reverse = symbol + "-" + tog.getHugoSymbol() + " fusion";
-                                }
-
-                                Alteration toa = findAlteration(tog, alteration.getAlterationType(), reverse);
+                            if (gene.getGeneAliases().size() == 2) {
+                                String[] aliases = gene.getGeneAliases().toArray(new String[0]);
+                                Gene gene0 = geneBo.findGeneByHugoSymbol(aliases[0]);
+                                Gene gene1 = geneBo.findGeneByHugoSymbol(aliases[1]);
+                                Alteration toa = findAlteration(gene1, alteration.getAlterationType(), aliases[0] + "-" + aliases[1] + " fusion");
                                 if (toa != null) {
                                     alterations.add(toa);
                                 }
-
-                                toa = findAlteration(tog, alteration.getAlterationType(), "fusions");
+                                toa = findAlteration(gene0, alteration.getAlterationType(), aliases[1] + "-" + aliases[0] + " fusion");
                                 if (toa != null) {
                                     alterations.add(toa);
                                 }
-                            }
-                        }
-                    } else {
-                        if (gene.getGeneAliases().size() == 2) {
-                            String[] aliases = gene.getGeneAliases().toArray(new String[0]);
-                            Gene gene0 = geneBo.findGeneByHugoSymbol(aliases[0]);
-                            Gene gene1 = geneBo.findGeneByHugoSymbol(aliases[1]);
-                            Alteration toa = findAlteration(gene1, alteration.getAlterationType(), aliases[0] + "-" + aliases[1] + " fusion");
-                            if (toa != null) {
-                                alterations.add(toa);
-                            }
-                            toa = findAlteration(gene0, alteration.getAlterationType(), aliases[1] + "-" + aliases[0] + " fusion");
-                            if (toa != null) {
-                                alterations.add(toa);
                             }
                         }
                     }
                 }
+
+                //the alteration 'fusions' should be injected into alteration list
+                Alteration alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), "fusions");
+                if (alt != null) {
+                    alterations.add(alt);
+                } else {
+                    // If no fusions curated, check the Truncating Mutations.
+                    if (truncatingMutation != null) {
+                        alterations.add(alt);
+                    }
+                }
             }
 
-            //the alteration 'fusions' should be injected into alteration list
-            Alteration alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), "fusions");
-            if (alt != null) {
-                alterations.add(alt);
-            } else {
+            // Map Truncating Mutations to Translocation and Inversion
+            // These two are all structural variants, need a better way to model them.
+            if (alteration.getAlteration().toLowerCase().equals("translocation")
+                || alteration.getAlteration().toLowerCase().equals("inversion")) {
                 // If no fusions curated, check the Truncating Mutations.
-                alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), "Truncating Mutations");
+                if (truncatingMutation != null) {
+                    alterations.add(truncatingMutation);
+                }
+            }
+
+            // If no Deletion curated, attach Truncating Mutations
+            if (alteration.getAlteration().toLowerCase().equals("deletion")) {
+                Alteration alt = findAlteration(alteration.getGene(), alteration.getAlterationType(), "Deletion");
                 if (alt != null) {
+                    alterations.add(alt);
+                } else if (truncatingMutation != null) {
                     alterations.add(alt);
                 }
             }
         }
+
 
         // Looking for inferred mutations.
         EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -135,6 +135,9 @@ public final class AlterationUtils {
                             case "trunc":
                                 consequence = "feature_truncation";
                                 break;
+                            case "dup":
+                                consequence = "inframe_insertion";
+                                break;
                             case "mut":
                                 consequence = "any";
                         }
@@ -148,7 +151,7 @@ public final class AlterationUtils {
 
                             consequence = "frameshift_variant";
                         } else {
-                            p = Pattern.compile("([A-Z]+)?([0-9]+)((ins)|(del))");
+                            p = Pattern.compile("([A-Z]+)?([0-9]+)((ins)|(del)|(dup))");
                             m = p.matcher(proteinChange);
                             if (m.matches()) {
                                 ref = m.group(1);
@@ -157,6 +160,9 @@ public final class AlterationUtils {
                                 String v = m.group(3);
                                 switch (v) {
                                     case "ins":
+                                        consequence = "inframe_insertion";
+                                        break;
+                                    case "dup":
                                         consequence = "inframe_insertion";
                                         break;
                                     case "del":

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -341,6 +341,10 @@ public final class AlterationUtils {
         return alterations;
     }
 
+    public static Alteration getTruncatingMutations(Gene gene) {
+        return findAlteration(gene, "Truncating Mutations");
+    }
+
     public static Set<Alteration> findVUSFromEvidences(Set<Evidence> evidences) {
         Set<Alteration> alterations = new HashSet<>();
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -939,6 +939,14 @@ public class EvidenceUtils {
                 Set<Evidence> resistanceEvidences = EvidenceUtils.getResistanceEvidences(allEvidences);
                 filteredEvidences.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(resistanceEvidences));
 
+
+                // Also include all non-treatment evidences
+                for (Evidence evidence : allEvidences) {
+                    if (!sensitiveEvidences.contains(evidence) && !resistanceEvidences.contains(evidence)) {
+                        filteredEvidences.add(evidence);
+                    }
+                }
+
                 query.setEvidences(filteredEvidences);
             }
         }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -73,6 +73,24 @@ public class IndicatorUtils {
                         gene = tmpGenes.get(0);
                     }
                 }
+            } else {
+                String geneStr = geneStrsSet.iterator().next();
+                if(geneStr != null) {
+                    Gene tmpGene = GeneUtils.getGeneByHugoSymbol(geneStr);
+                    if (tmpGene != null) {
+                        gene = tmpGene;
+                        Alteration alt = AlterationUtils.getAlteration(gene.getHugoSymbol(), query.getAlteration(),
+                            null, null, null, null);
+                        AlterationUtils.annotateAlteration(alt, alt.getAlteration());
+                        relevantAlterations = AlterationUtils.getRelevantAlterations(alt);
+
+                        // Map Truncating Mutations to single gene fusion event
+                        Alteration truncatingMutations = AlterationUtils.getTruncatingMutations(gene);
+                        if (truncatingMutations != null && !relevantAlterations.contains(truncatingMutations)) {
+                            relevantAlterations.add(truncatingMutations);
+                        }
+                    }
+                }
             }
         } else {
             gene = query.getEntrezGeneId() == null ? GeneUtils.getGeneByHugoSymbol(query.getHugoSymbol()) :


### PR DESCRIPTION
For Fusion, if no `Fusions` has been curated, map `Truncating Mutations`;
For Deletion, if no `Deletion` has been curated, map `Truncating Mutations`;
For Translocation, map `Truncating Mutations`;
For Inversion, map `Truncating Mutations`;
Hanle single gene fusion event(two genes are the same gene);
Map `dup` to `inframe_insertion`;
This pull request will close #401 #416 