### PR TITLE
bug Fix on getString

### DIFF
--- a/web/yo/app/scripts/services/stringutils.js
+++ b/web/yo/app/scripts/services/stringutils.js
@@ -1091,7 +1091,7 @@ angular.module('oncokbApp')
                 if (model.get(e)) {
                     if (model.get(e).type === 'Map') {
                         reviewObj[e] = getReview(model[e]);
-                    } else {
+                    } else if(_.isString(model.get(e))) {
                         reviewObj[e] = getString(model.get(e));
                     }
                 }
@@ -1101,6 +1101,7 @@ angular.module('oncokbApp')
 
         function getString(string) {
             if(!string || !_.isString(string)) {
+                console.log('Value passed in is not a string, please double check');
                 return '';
             }
             var tmp = window.document.createElement('DIV');


### PR DESCRIPTION
The reason for the break out in getString function is that we use getString() in the getReview function. But inside the review mapping, not all values are string type. For example, currentReviewer is a collaborative string, review/rollback/loading are boolean. 
Since 'currentReviewer', 'review', 'action', 'rollback', 'loading' are only designed for the review process, which don't need to be backed up, we excluded them here.