### PR TITLE
Bug fixes: treatment separator; NULL check on truncating info of consequence

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -91,7 +91,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                 }
             }
 
-            if (alteration.getConsequence().getIsGenerallyTruncating()) {
+            if (alteration.getConsequence().getIsGenerallyTruncating() != null && alteration.getConsequence().getIsGenerallyTruncating()) {
                 VariantConsequence truncatingVariantConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm("feature_truncation");
                 alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), truncatingVariantConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations));
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -91,7 +91,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                 }
             }
 
-            if (alteration.getConsequence().getIsGenerallyTruncating() != null && alteration.getConsequence().getIsGenerallyTruncating()) {
+            if (alteration.getConsequence().getIsGenerallyTruncating()) {
                 VariantConsequence truncatingVariantConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm("feature_truncation");
                 alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), truncatingVariantConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations));
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/VariantConsequence.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/VariantConsequence.java
@@ -43,7 +43,10 @@ public class VariantConsequence implements java.io.Serializable {
     }
 
     public Boolean getIsGenerallyTruncating() {
-        return isGenerallyTruncating;
+        if(this.isGenerallyTruncating == null) {
+            return false;
+        }
+        return this.isGenerallyTruncating;
     }
 
     public void setIsGenerallyTruncating(Boolean isGenerallyTruncating) {
@@ -71,6 +74,6 @@ public class VariantConsequence implements java.io.Serializable {
         }
         return true;
     }
-    
-    
+
+
 }

--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -917,9 +917,9 @@ angular.module('oncokbApp')
                         data.description = treatment.description.getText();
                         data.propagation = levelMapping[treatment.name_eStatus.get('propagation')];
                         data.treatments = [];
-                        var treatments = treatment.name.getText().split('+');
+                        var treatments = treatment.name.getText().split(',');
                         for (i = 0; i < treatments.length; i++) {
-                            var drugs = treatments[i].split(',');
+                            var drugs = treatments[i].split('+');
                             var drugList = [];
                             for (var j = 0; j < drugs.length; j++) {
                                 drugList.push({


### PR DESCRIPTION
Should check whether consequence has truncating info;
`,` should be used to separate treatment;
`+` should be used to separate drug in one treatment;