### PR TITLE
Turn off query cache

### DIFF
--- a/core/src/main/resources/hibernate/hibernate.cfg.xml
+++ b/core/src/main/resources/hibernate/hibernate.cfg.xml
@@ -19,7 +19,7 @@
     <property name="hibernate.cache.provider_class">org.hibernate.cache.EhCacheProvider</property>
     <property name="net.sf.ehcache.configurationResourceName">/hibernate/ehcache.conf.xml</property>
     <property name="hibernate.cache.use_second_level_cache">false</property>
-    <property name="hibernate.cache.use_query_cache">true</property>
+    <property name="hibernate.cache.use_query_cache">false</property>
     <mapping resource="hibernate/Drug.hbm.xml"/>
     <mapping resource="hibernate/Alteration.hbm.xml"/>
     <mapping resource="hibernate/Article.hbm.xml"/>


### PR DESCRIPTION
According to this article, query cache should be used with
second_level_cache. Since we implement our own cache, these should be
turned off. Current implementation will run into issue on items
updated(deletion) on other instance, but only refresh our cache
implementation won’t work because the query is still cached in session
http://www.javalobby.org/java/forums/t48846.html `query cache should
always be used in conjunction with the second-level cache.`