### PR TITLE
validate mutation name upon changing Issue #558

### DIFF
--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -136,12 +136,16 @@ angular.module('oncokbApp')
                 if (vusList.indexOf(newMutationName) !== -1) {
                     isVUS = true;
                 }
-                $scope.gene.mutations.asArray().forEach(function(e) {
+                _.some($scope.gene.mutations.asArray(), function(e) {
                     if (e.name.getText().toLowerCase() === newMutationName) {
                         exists = true;
                         if(e.name_review.get('removed')) {
                             removed = true;
                             tempMutation = e;
+                        } else {
+                            // set 'removed' to false to make sure we only put removed mutation back when there is only duplicated mutation
+                            removed = false;
+                            return true;
                         }
                     }
                 });
@@ -1659,12 +1663,15 @@ angular.module('oncokbApp')
                 var removed = false;
                 var tempTumor;
                 var newTumorTypesName = getNewCancerTypesName($scope.meta.newCancerTypes).toLowerCase();
-                mutation.tumors.asArray().forEach(function(e) {
+                _.some(mutation.tumors.asArray(), function(e) {
                     if ($scope.getCancerTypesName(e.cancerTypes).toLowerCase() === newTumorTypesName) {
                         exists = true;
                         if(e.name_review.get('removed')) {
                             removed = true;
                             tempTumor = e;
+                        } else {
+                            removed = false;
+                            return true;
                         }
                     }
                 });
@@ -1765,12 +1772,15 @@ angular.module('oncokbApp')
                 var removed = false;
                 var tempTreatment;
                 newTreatmentName = newTreatmentName.toString().trim().toLowerCase();
-                ti.treatments.asArray().forEach(function(e) {
+                _.some(ti.treatments.asArray(), function(e) {
                     if (e.name.getText().toLowerCase() === newTreatmentName) {
                         exists = true;
                         if(e.name_review.get('removed')) {
                             removed = true;
                             tempTreatment = e;
+                        } else {
+                            removed = false;
+                            return true;
                         }
                     }
                 });

--- a/web/yo/app/scripts/directives/driverealtimestring.js
+++ b/web/yo/app/scripts/directives/driverealtimestring.js
@@ -26,13 +26,19 @@ angular.module('oncokbApp')
                 chosenid: '=', // Chosen selection ID
                 checkboxes: '=', // checkbox list for input is checkbox
                 checkboxid: '=',
-                ph: '=' // Place holder
+                ph: '=', // Place holder
+                mutation: '=',
+                therapyCategory: '=',
+                treatment: '=',
+                validateMutationInGene: '&validateMutation',
+                validateTreatmentInGene: '&validateTreatment'
             },
             replace: true,
             link: function postLink(scope) {
                 scope.reviewMode = $rootScope.reviewMode;
                 scope.addOnTimeoutPromise = '';
                 scope.stringTimeoutPromise = '';
+
                 if (scope.objecttype === 'object' && scope.objectkey) {
                     if (scope.object.has(scope.objectkey)) {
                         scope.content.stringO = scope.object.get(scope.objectkey);
@@ -75,6 +81,12 @@ angular.module('oncokbApp')
                     $timeout.cancel(scope.stringTimeoutPromise);  // does nothing, if timeout already done
                     scope.stringTimeoutPromise = $timeout(function() {   // Set timeout
                         if (n !== o) {
+                            if (scope.t === 'MUTATION_NAME') {
+                                scope.error = scope.validateMutation(n);
+                            }
+                            if (scope.t === 'TREATMENT_NAME') {
+                                scope.error = scope.validateTreatment(n, false, false, scope.therapyCategory);
+                            }
                             if (scope.es && scope.es.get('obsolete') === 'true') {
                                 if (scope.objecttype === 'object' && scope.objectkey) {
                                     scope.object.set(scope.objectkey, n);
@@ -164,6 +176,7 @@ angular.module('oncokbApp')
                 }
             },
             controller: function($scope) {
+                $scope.error = '';
                 $scope.content = {};
                 $scope.content.propagationOpts = [];
                 $scope.propagationOpts = {
@@ -253,6 +266,32 @@ angular.module('oncokbApp')
                     }
                     return classResult;
                 };
+                $scope.validateMutation = function(newMutationName, alert, firstEnter, mutation) {
+                    return $scope.validateMutationInGene({
+                        newMutationName: newMutationName,
+                        alert: alert,
+                        firstEnter: firstEnter,
+                        mutation: mutation
+                    });
+                };
+                $scope.validateTreatment = function(newTreatmentName, alert, firstEnter, therapyCategory, treatment) {
+                    return $scope.validateTreatmentInGene({
+                        newTreatmentName: newTreatmentName,
+                        alert: alert,
+                        firstEnter: firstEnter,
+                        therapyCategory: therapyCategory,
+                        treatment: treatment
+                    });
+                };
+                function duplicatedNameCheck() {
+                    if ($scope.t === 'MUTATION_NAME') {
+                        $scope.error = $scope.validateMutation($scope.object.text, false, true, $scope.mutation);
+                    }
+                    if ($scope.t === 'TREATMENT_NAME') {
+                        $scope.error = $scope.validateTreatment($scope.object.text, false, true, $scope.therapyCategory, $scope.treatment);
+                    }
+                }
+                duplicatedNameCheck();
             }
         };
     })

--- a/web/yo/app/scripts/directives/driverealtimestring.js
+++ b/web/yo/app/scripts/directives/driverealtimestring.js
@@ -28,6 +28,7 @@ angular.module('oncokbApp')
                 checkboxid: '=',
                 ph: '=', // Place holder
                 mutation: '=',
+                tumor: '=',
                 therapyCategory: '=',
                 treatment: '=',
                 validateMutationInGene: '&validateMutation',
@@ -82,10 +83,10 @@ angular.module('oncokbApp')
                     scope.stringTimeoutPromise = $timeout(function() {   // Set timeout
                         if (n !== o) {
                             if (scope.t === 'MUTATION_NAME') {
-                                scope.error = scope.validateMutation(n);
+                                scope.error = scope.validateMutation(n, false);
                             }
                             if (scope.t === 'TREATMENT_NAME') {
-                                scope.error = scope.validateTreatment(n, false, false, scope.therapyCategory);
+                                scope.error = scope.validateTreatment(n, false, false, scope.mutation, scope.tumor, scope.therapyCategory);
                             }
                             if (scope.es && scope.es.get('obsolete') === 'true') {
                                 if (scope.objecttype === 'object' && scope.objectkey) {
@@ -266,29 +267,29 @@ angular.module('oncokbApp')
                     }
                     return classResult;
                 };
-                $scope.validateMutation = function(newMutationName, alert, firstEnter, mutation) {
+                $scope.validateMutation = function(newMutationName, firstEnter, alert) {
                     return $scope.validateMutationInGene({
                         newMutationName: newMutationName,
-                        alert: alert,
                         firstEnter: firstEnter,
-                        mutation: mutation
+                        alert: alert
                     });
                 };
-                $scope.validateTreatment = function(newTreatmentName, alert, firstEnter, therapyCategory, treatment) {
+                $scope.validateTreatment = function(newTreatmentName, firstEnter, alert, mutation, tumor, therapyCategory) {
                     return $scope.validateTreatmentInGene({
                         newTreatmentName: newTreatmentName,
-                        alert: alert,
                         firstEnter: firstEnter,
-                        therapyCategory: therapyCategory,
-                        treatment: treatment
+                        alert: alert,
+                        mutation: mutation,
+                        tumor: tumor,
+                        therapyCategory: therapyCategory
                     });
                 };
                 function duplicatedNameCheck() {
                     if ($scope.t === 'MUTATION_NAME') {
-                        $scope.error = $scope.validateMutation($scope.object.text, false, true, $scope.mutation);
+                        $scope.error = $scope.validateMutation($scope.object.text, true, false);
                     }
                     if ($scope.t === 'TREATMENT_NAME') {
-                        $scope.error = $scope.validateTreatment($scope.object.text, false, true, $scope.therapyCategory, $scope.treatment);
+                        $scope.error = $scope.validateTreatment($scope.object.text, true, false, $scope.mutation, $scope.tumor, $scope.therapyCategory);
                     }
                 }
                 duplicatedNameCheck();

--- a/web/yo/app/views/driveRealtimeString.html
+++ b/web/yo/app/views/driveRealtimeString.html
@@ -17,12 +17,13 @@
             ng-if="io && t === 'p'">
         </pub-iframe>
     </div>
-    <div ng-if="t === 'name'">
-        <h4 ng-if="reviewMode && reviewObj.get('lastReviewed') && !reviewObj.get('removedItem') && !reviewObj.get('addedItem') && !reviewObj.get('added')">New Content:</h4>
+    <div ng-if="t === 'MUTATION_NAME' || t === 'TREATMENT_NAME'">
+        <h4 ng-if="reviewMode && reviewObj.get('lastReviewed') && !reviewObj.get('removedItem')">New Content:</h4>
         <span contenteditable="{{reviewMode ? (reviewObj.get('lastReviewed') ? true : false) : fe}}"
               ng-class="editableBox"
            ng-model="content.stringO">
         </span>
+        <span style="color:red" ng-if="!reviewMode">{{error}}</span>
         <br/>
         <div ng-if="reviewMode && reviewObj.get('lastReviewed') && !reviewObj.get('removedItem') && !reviewObj.get('addedItem') && !reviewObj.get('added')">
             <h4>Old Content:</h4>

--- a/web/yo/app/views/driveRealtimeString.html
+++ b/web/yo/app/views/driveRealtimeString.html
@@ -18,12 +18,12 @@
         </pub-iframe>
     </div>
     <div ng-if="t === 'MUTATION_NAME' || t === 'TREATMENT_NAME'">
-        <h4 ng-if="reviewMode && reviewObj.get('lastReviewed') && !reviewObj.get('removedItem')">New Content:</h4>
+        <h4 ng-if="reviewMode && reviewObj.get('lastReviewed') && !reviewObj.get('removedItem') && !reviewObj.get('addedItem') && !reviewObj.get('added')">New Content:</h4>
         <span contenteditable="{{reviewMode ? (reviewObj.get('lastReviewed') ? true : false) : fe}}"
               ng-class="editableBox"
            ng-model="content.stringO">
         </span>
-        <span style="color:red" ng-if="!reviewMode">{{error}}</span>
+        <span style="color:red" ng-if="!reviewMode">{{getDuplicationMessage()}}</span>
         <br/>
         <div ng-if="reviewMode && reviewObj.get('lastReviewed') && !reviewObj.get('removedItem') && !reviewObj.get('addedItem') && !reviewObj.get('added')">
             <h4>Old Content:</h4>

--- a/web/yo/app/views/gene.html
+++ b/web/yo/app/views/gene.html
@@ -141,8 +141,8 @@
               <!--<span ng-click="stopCollopse($event)" ng-class="{editableBox:mutationNameEditable(mutation.name.text), unEditableBox:!mutationNameEditable(mutation.name.text)}" contenteditable="{{mutationNameEditable(mutation.name.text)}}" ng-model="mutation.name.text"/></span>-->
              <div ng-if="reviewMode && mutation.name_review.get('lastReviewed')"><br/></div>
               <div style="display:inline-block">
-                 <drive-realtime-string review-obj="mutation.name_review" uuid="mutation.name_uuid"  es="mutation.name_eStatus" fe="fileEditable" t="'MUTATION_NAME'" object="mutation.name" mutation="mutation" validate-mutation="validateMutation(newMutationName, alert, firstEnter, mutation)" ng-click="stopCollopse($event)"></drive-realtime-string>
-             </div>
+                 <drive-realtime-string review-obj="mutation.name_review" uuid="mutation.name_uuid"  es="mutation.name_eStatus" fe="fileEditable" t="'MUTATION_NAME'" object="mutation.name" mutation="mutation" validate-mutation="validateMutation(newMutationName, firstEnter, alert)" ng-click="stopCollopse($event)"></drive-realtime-string>
+              </div>
             <div ng-if="!reviewMode" style="display:inline-block">
                 <comments-dict mutation="{{mutation.name.text}}" gene-name="{{::gene.name.text}}" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)" file-editable="fileEditable" comments="mutation.name_comments" object="mutation" key="name" add-comment="addComment(arg1,arg2,arg3)"></comments-dict>
                 <i class="fa fa-hand-o-left" uib-tooltip-placement="top" uib-tooltip="Red: needs to be curated" ng-show="mutation.oncogenic_eStatus.get('curated')===false || userRole === 8" ng-click="curatedIconClick($event, mutation.oncogenic_eStatus)" ng-class="{'fa-comments-red':mutation.oncogenic_eStatus.get('curated')===false}"></i>
@@ -197,7 +197,7 @@
                   </span>
             </uib-accordion-group>
             <!-- tumor types -->
-            <div ng-repeat="tumor in mutation.tumors.asArray()" ng-init="initGeneStatus(mutation, tumor)" class="accordionMarginTop" ng-hide="status.hideAllObsolete && tumor.name_eStatus.get('obsolete') === 'true'">
+            <div ng-repeat="tumor in mutation.tumors.asArray()" ng-init="initGeneStatus(mutation, tumor); validateTumor(true, mutation, tumor)" class="accordionMarginTop" ng-hide="status.hideAllObsolete && tumor.name_eStatus.get('obsolete') === 'true'">
               <uib-accordion-group ng-init="tmpGeneStatus=getGeneStatusItem(mutation, tumor)" ng-if="displayCheck(null, tumor.name_review, mutation.name_review, tumor.name_review, tumor.cancerTypes_review)" is-open="tmpGeneStatus.isOpen" class="levelTwoHeader">
                 <uib-accordion-heading >
                   <i class="fa  " ng-class="{'fa-chevron-down':tmpGeneStatus.isOpen, 'fa-chevron-right': !tmpGeneStatus.isOpen}"></i>
@@ -207,8 +207,8 @@
                         <p>New Content: </p>
                     </span>
                   <span ng-class="{unEditableBox: true}" contenteditable="false">{{getCancerTypesName(tumor.cancerTypes)}}</span>
-                    <i class="fa fa-edit" ng-click="stopCollopse($event); modifyTumorType(tumor)" ng-if="!reviewMode"></i>
-                    <span style="color:red" ng-if="!reviewMode">{{validateTumor(false, true, mutation, tumor)}}</span>
+                    <i class="fa fa-edit" ng-click="stopCollopse($event); modifyTumorType(tumor, mutation)" ng-if="!reviewMode"></i>
+                    <span style="color:red" ng-if="!reviewMode">{{getErrorMessage(tumor)}}</span>
                     <span class="original-tumor-type"
                           ng-if="getCancerTypesName(tumor.cancerTypes).toLowerCase() !== tumor.name.text.toLowerCase() && tumor.name.text">Original Tumor Type: {{tumor.name.text}}</span>
                     <comments-dict mutation="{{mutation.name.text}}" tumor-type="{{tumor.name.text}}" gene-name="{{::gene.name.text}}"file-editable="fileEditable" comments="tumor.name_comments" object="tumor" key="name" add-comment="addComment(arg1,arg2,arg3)" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)"></comments-dict>
@@ -346,7 +346,7 @@
                               <span>{{treatment.type.text}}: </span>
                               <div ng-if="reviewMode && treatment.name_review.get('lastReviewed')"><br/></div>
                               <div style="display:inline-block">
-                                   <drive-realtime-string review-obj="treatment.name_review" uuid="treatment.name_uuid"  es="treatment.name_eStatus" fe="fileEditable" t="'TREATMENT_NAME'" object="treatment.name" ng-click="stopCollopse($event)" therapy-category="ti" treatment="treatment" validate-treatment="validateTreatment(newTreatmentName, alert, firstEnter, therapyCategory, treatment)"></drive-realtime-string>
+                                   <drive-realtime-string review-obj="treatment.name_review" uuid="treatment.name_uuid"  es="treatment.name_eStatus" fe="fileEditable" t="'TREATMENT_NAME'" object="treatment.name" ng-click="stopCollopse($event)" mutation="mutation" tumor="tumor" therapy-category="ti" treatment="treatment" validate-treatment="validateTreatment(newTreatmentName, firstEnter, alert, mutation, tumor, therapyCategory)"></drive-realtime-string>
                               </div>
                               <span ng-click="stopCollopse($event)" class="curationNoEntry" ng-if="!treatment.level.text && !treatment.indication.text && !treatment.description.text && !treatment.short.text">No Entry</span>
                               <comments-dict gene-name="{{::gene.name.text}}" therapy="{{treatment.name.text}}" mutation="{{mutation.name.text}}" tumor-type="{{tumor.name.text}}" parent-event="$event" file-editable="fileEditable" comments="treatment.name_comments" object="treatment" key="name" add-comment="addComment(arg1,arg2,arg3)" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)"></comments-dict>

--- a/web/yo/app/views/gene.html
+++ b/web/yo/app/views/gene.html
@@ -141,7 +141,7 @@
               <!--<span ng-click="stopCollopse($event)" ng-class="{editableBox:mutationNameEditable(mutation.name.text), unEditableBox:!mutationNameEditable(mutation.name.text)}" contenteditable="{{mutationNameEditable(mutation.name.text)}}" ng-model="mutation.name.text"/></span>-->
              <div ng-if="reviewMode && mutation.name_review.get('lastReviewed')"><br/></div>
               <div style="display:inline-block">
-                 <drive-realtime-string review-obj="mutation.name_review" uuid="mutation.name_uuid"  es="mutation.name_eStatus" fe="fileEditable" t="'MUTATION_NAME'" object="mutation.name" mutation="mutation" validate-mutation="validateMutation(newMutationName, firstEnter, alert)" ng-click="stopCollopse($event)"></drive-realtime-string>
+                 <drive-realtime-string review-obj="mutation.name_review" mutation-messages="mutationMessages" uuid="mutation.name_uuid"  es="mutation.name_eStatus" fe="fileEditable" t="'MUTATION_NAME'" object="mutation.name" mutation="mutation" get-mutation-messages="getMutationMessages()" ng-click="stopCollopse($event)"></drive-realtime-string>
               </div>
             <div ng-if="!reviewMode" style="display:inline-block">
                 <comments-dict mutation="{{mutation.name.text}}" gene-name="{{::gene.name.text}}" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)" file-editable="fileEditable" comments="mutation.name_comments" object="mutation" key="name" add-comment="addComment(arg1,arg2,arg3)"></comments-dict>
@@ -197,7 +197,7 @@
                   </span>
             </uib-accordion-group>
             <!-- tumor types -->
-            <div ng-repeat="tumor in mutation.tumors.asArray()" ng-init="initGeneStatus(mutation, tumor); validateTumor(true, mutation, tumor)" class="accordionMarginTop" ng-hide="status.hideAllObsolete && tumor.name_eStatus.get('obsolete') === 'true'">
+            <div ng-repeat="tumor in mutation.tumors.asArray()" ng-init="initGeneStatus(mutation, tumor); getTumorMessages(mutation)" class="accordionMarginTop" ng-hide="status.hideAllObsolete && tumor.name_eStatus.get('obsolete') === 'true'">
               <uib-accordion-group ng-init="tmpGeneStatus=getGeneStatusItem(mutation, tumor)" ng-if="displayCheck(null, tumor.name_review, mutation.name_review, tumor.name_review, tumor.cancerTypes_review)" is-open="tmpGeneStatus.isOpen" class="levelTwoHeader">
                 <uib-accordion-heading >
                   <i class="fa  " ng-class="{'fa-chevron-down':tmpGeneStatus.isOpen, 'fa-chevron-right': !tmpGeneStatus.isOpen}"></i>
@@ -208,7 +208,7 @@
                     </span>
                   <span ng-class="{unEditableBox: true}" contenteditable="false">{{getCancerTypesName(tumor.cancerTypes)}}</span>
                     <i class="fa fa-edit" ng-click="stopCollopse($event); modifyTumorType(tumor, mutation)" ng-if="!reviewMode"></i>
-                    <span style="color:red" ng-if="!reviewMode">{{getErrorMessage(tumor)}}</span>
+                    <span style="color:red" ng-if="!reviewMode">{{getTumorDuplication(mutation, tumor)}}</span>
                     <span class="original-tumor-type"
                           ng-if="getCancerTypesName(tumor.cancerTypes).toLowerCase() !== tumor.name.text.toLowerCase() && tumor.name.text">Original Tumor Type: {{tumor.name.text}}</span>
                     <comments-dict mutation="{{mutation.name.text}}" tumor-type="{{tumor.name.text}}" gene-name="{{::gene.name.text}}"file-editable="fileEditable" comments="tumor.name_comments" object="tumor" key="name" add-comment="addComment(arg1,arg2,arg3)" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)"></comments-dict>
@@ -319,7 +319,7 @@
 
                   <!-- Theraputic implications -->
                   <div ng-repeat="ti in tumor.TI.asArray()" class="accordionMarginTop" ng-init="initGeneStatus(mutation, tumor, ti)" ng-hide="status.hideAllObsolete && ti.name_eStatus.get('obsolete') === 'true'">
-                    <uib-accordion-group ng-init="tmpGeneStatus=getGeneStatusItem(mutation, tumor, ti)" ng-if="displayCheck(null, ti.name_review, mutation.name_review, tumor.name_review)" is-open="tmpGeneStatus.isOpen" class="levelThreeHeader" ng-hide="(!!tmpGeneStatus.hideEmpty) && !ti.short.text && !ti.description.text && ti.treatments.length === 0">
+                    <uib-accordion-group ng-init="tmpGeneStatus=getGeneStatusItem(mutation, tumor, ti); getTreatmentMessages(mutation, tumor, ti)" ng-if="displayCheck(null, ti.name_review, mutation.name_review, tumor.name_review)" is-open="tmpGeneStatus.isOpen" class="levelThreeHeader" ng-hide="(!!tmpGeneStatus.hideEmpty) && !ti.short.text && !ti.description.text && ti.treatments.length === 0">
                       <uib-accordion-heading>
                         <i class="fa  " ng-class="{'fa-chevron-down': tmpGeneStatus.isOpen, 'fa-chevron-right': !tmpGeneStatus.isOpen}" ng-click="changeIsOpen(tmpGeneStatus.isOpen)"></i>
                         <span>{{::ti.name.text}}: </span>
@@ -346,7 +346,7 @@
                               <span>{{treatment.type.text}}: </span>
                               <div ng-if="reviewMode && treatment.name_review.get('lastReviewed')"><br/></div>
                               <div style="display:inline-block">
-                                   <drive-realtime-string review-obj="treatment.name_review" uuid="treatment.name_uuid"  es="treatment.name_eStatus" fe="fileEditable" t="'TREATMENT_NAME'" object="treatment.name" ng-click="stopCollopse($event)" mutation="mutation" tumor="tumor" therapy-category="ti" treatment="treatment" validate-treatment="validateTreatment(newTreatmentName, firstEnter, alert, mutation, tumor, therapyCategory)"></drive-realtime-string>
+                                   <drive-realtime-string review-obj="treatment.name_review" treatment-messages="treatmentMessages" get-treatment-messages="getTreatmentMessages(mutation, tumor, ti)" uuid="treatment.name_uuid"  es="treatment.name_eStatus" fe="fileEditable" t="'TREATMENT_NAME'" object="treatment.name" ng-click="stopCollopse($event)" mutation="mutation" tumor="tumor" therapy-category="ti" treatment="treatment" validate-treatment="validateTreatment(newTreatmentName, firstEnter, alert, mutation, tumor, therapyCategory)"></drive-realtime-string>
                               </div>
                               <span ng-click="stopCollopse($event)" class="curationNoEntry" ng-if="!treatment.level.text && !treatment.indication.text && !treatment.description.text && !treatment.short.text">No Entry</span>
                               <comments-dict gene-name="{{::gene.name.text}}" therapy="{{treatment.name.text}}" mutation="{{mutation.name.text}}" tumor-type="{{tumor.name.text}}" parent-event="$event" file-editable="fileEditable" comments="treatment.name_comments" object="treatment" key="name" add-comment="addComment(arg1,arg2,arg3)" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)"></comments-dict>

--- a/web/yo/app/views/gene.html
+++ b/web/yo/app/views/gene.html
@@ -141,7 +141,7 @@
               <!--<span ng-click="stopCollopse($event)" ng-class="{editableBox:mutationNameEditable(mutation.name.text), unEditableBox:!mutationNameEditable(mutation.name.text)}" contenteditable="{{mutationNameEditable(mutation.name.text)}}" ng-model="mutation.name.text"/></span>-->
              <div ng-if="reviewMode && mutation.name_review.get('lastReviewed')"><br/></div>
               <div style="display:inline-block">
-                 <drive-realtime-string review-obj="mutation.name_review" uuid="mutation.name_uuid"  es="mutation.name_eStatus" fe="fileEditable" t="'name'" object="mutation.name" ng-click="stopCollopse($event)"></drive-realtime-string>
+                 <drive-realtime-string review-obj="mutation.name_review" uuid="mutation.name_uuid"  es="mutation.name_eStatus" fe="fileEditable" t="'MUTATION_NAME'" object="mutation.name" mutation="mutation" validate-mutation="validateMutation(newMutationName, alert, firstEnter, mutation)" ng-click="stopCollopse($event)"></drive-realtime-string>
              </div>
             <div ng-if="!reviewMode" style="display:inline-block">
                 <comments-dict mutation="{{mutation.name.text}}" gene-name="{{::gene.name.text}}" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)" file-editable="fileEditable" comments="mutation.name_comments" object="mutation" key="name" add-comment="addComment(arg1,arg2,arg3)"></comments-dict>
@@ -208,6 +208,7 @@
                     </span>
                   <span ng-class="{unEditableBox: true}" contenteditable="false">{{getCancerTypesName(tumor.cancerTypes)}}</span>
                     <i class="fa fa-edit" ng-click="stopCollopse($event); modifyTumorType(tumor)" ng-if="!reviewMode"></i>
+                    <span style="color:red" ng-if="!reviewMode">{{validateTumor(false, true, mutation, tumor)}}</span>
                     <span class="original-tumor-type"
                           ng-if="getCancerTypesName(tumor.cancerTypes).toLowerCase() !== tumor.name.text.toLowerCase() && tumor.name.text">Original Tumor Type: {{tumor.name.text}}</span>
                     <comments-dict mutation="{{mutation.name.text}}" tumor-type="{{tumor.name.text}}" gene-name="{{::gene.name.text}}"file-editable="fileEditable" comments="tumor.name_comments" object="tumor" key="name" add-comment="addComment(arg1,arg2,arg3)" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)"></comments-dict>
@@ -345,7 +346,7 @@
                               <span>{{treatment.type.text}}: </span>
                               <div ng-if="reviewMode && treatment.name_review.get('lastReviewed')"><br/></div>
                               <div style="display:inline-block">
-                                   <drive-realtime-string review-obj="treatment.name_review" uuid="treatment.name_uuid"  es="treatment.name_eStatus" fe="fileEditable" t="'name'" object="treatment.name" ng-click="stopCollopse($event)"></drive-realtime-string>
+                                   <drive-realtime-string review-obj="treatment.name_review" uuid="treatment.name_uuid"  es="treatment.name_eStatus" fe="fileEditable" t="'TREATMENT_NAME'" object="treatment.name" ng-click="stopCollopse($event)" therapy-category="ti" treatment="treatment" validate-treatment="validateTreatment(newTreatmentName, alert, firstEnter, therapyCategory, treatment)"></drive-realtime-string>
                               </div>
                               <span ng-click="stopCollopse($event)" class="curationNoEntry" ng-if="!treatment.level.text && !treatment.indication.text && !treatment.description.text && !treatment.short.text">No Entry</span>
                               <comments-dict gene-name="{{::gene.name.text}}" therapy="{{treatment.name.text}}" mutation="{{mutation.name.text}}" tumor-type="{{tumor.name.text}}" parent-event="$event" file-editable="fileEditable" comments="treatment.name_comments" object="treatment" key="name" add-comment="addComment(arg1,arg2,arg3)" ng-click="commentClick($event)" ng-keypress="stopCollopse($event)"></comments-dict>

--- a/web/yo/app/views/modifyTumorTypes.html
+++ b/web/yo/app/views/modifyTumorTypes.html
@@ -39,6 +39,7 @@
         </div>
     </div>
     <div class="modal-footer">
+        <p style="color:red;float:left" ng-if="invalidTumor">Same tumor type already exists</p>
         <button type="button" class="btn btn-default" ng-click="cancel()">Cancel</button>
         <button type="button" class="btn btn-primary" ng-click="save()" ng-disabled="invalidTumor">Save</button>
     </div>

--- a/web/yo/app/views/modifyTumorTypes.html
+++ b/web/yo/app/views/modifyTumorTypes.html
@@ -14,7 +14,8 @@
                                 data-placeholder="Choose a main tumor type"
                                 no-results-text="'Could not find any'"
                                 ng-model="cancerType.mainType"
-                                ng-options="tt.name for tt in meta.oncoTree.mainTypes | orderBy: 'name' track by tt.name">
+                                ng-options="tt.name for tt in meta.oncoTree.mainTypes | orderBy: 'name' track by tt.name"
+                                ng-change="tumorDuplicationCheck()">
                             <option value=""></option>
                         </select>
                     </div>
@@ -27,7 +28,8 @@
                                 data-placeholder="Choose a tumor type"
                                 no-results-text="'Could not find any'"
                                 ng-model="cancerType.subtype"
-                                ng-options="tt.name for tt in cancerType.oncoTreeTumorTypes | orderBy: 'name' track by tt.code">
+                                ng-options="tt.name for tt in cancerType.oncoTreeTumorTypes | orderBy: 'name' track by tt.code"
+                                ng-change="tumorDuplicationCheck()">
                             <option value=""></option>
                         </select>
                     </div>
@@ -38,6 +40,6 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-default" ng-click="cancel()">Cancel</button>
-        <button type="button" class="btn btn-primary" ng-click="save()">Save</button>
+        <button type="button" class="btn btn-primary" ng-click="save()" ng-disabled="invalidTumor">Save</button>
     </div>
 </div>


### PR DESCRIPTION
Display mutation name error message:
1:  when they change mutation name to a mutation that already existed, or in VUS, or invalid mutation name.
2:  when first load up the page, and there are invalid mutations by the rules above.