### PR TITLE
bug fix about curation queue articles count

### DIFF
--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -583,8 +583,15 @@ angular.module('oncokbApp')
                 }
 
                 if($scope.status.hasReviewContent === false) {
+                    var articlesToCurate = 0;
+                    if ($rootScope.geneMetaData.has('CurationQueueArticles')) {
+                        articlesToCurate = $rootScope.geneMetaData.get('CurationQueueArticles');
+                    }
                     $rootScope.geneMetaData.clear();
                     $rootScope.geneMetaData.set('currentReviewer', $rootScope.metaModel.createString(''));
+                    if (articlesToCurate > 0) {
+                        $rootScope.geneMetaData.set('CurationQueueArticles', articlesToCurate);
+                    }
                     dialogs.notify('Warning', 'No changes need to be reviewed');
                 } else {
                     $rootScope.geneMetaData.get('currentReviewer').setText(User.name);

--- a/web/yo/app/scripts/directives/curationQueue.js
+++ b/web/yo/app/scripts/directives/curationQueue.js
@@ -50,6 +50,7 @@ angular.module('oncokbApp')
                         });
                     });
                     scope.getArticleList();
+                    scope.setArticlesNumberInMeta();
                     scope.dtOptions = {
                         hasBootstrap: true,
                         paging: false,
@@ -152,7 +153,7 @@ angular.module('oncokbApp')
                     $scope.predictedArticle = '';
                     $scope.validPMID = false;
                     $scope.getArticleList();
-                    setArticlesNumberInMeta();
+                    $scope.setArticlesNumberInMeta();
                     if (item.get('curator')) {
                         $scope.sendEmail(item);
                     }
@@ -226,7 +227,7 @@ angular.module('oncokbApp')
                     if (queueModelItem.get('addedAt') === queueItem.addedAt) {
                         queueModelItem.set('curated', true);
                         queueItem.curated = true;
-                        setArticlesNumberInMeta();
+                        $scope.setArticlesNumberInMeta();
                     }
                 };
                 $scope.deleteCuration = function(index) {
@@ -234,7 +235,7 @@ angular.module('oncokbApp')
                         $scope.queueModel.remove(index);
                         $scope.queue.splice(index, 1);
                         $scope.getArticleList();
-                        setArticlesNumberInMeta();
+                        $scope.setArticlesNumberInMeta();
                     }
                 };
                 $scope.getArticle = function(pmid) {
@@ -327,7 +328,7 @@ angular.module('oncokbApp')
                         return annotationLocation[x.article].join('; ');
                     }
                 };
-                function setArticlesNumberInMeta() {
+                $scope.setArticlesNumberInMeta = function() {
                     var count = 0;
                     _.each($scope.queue, function(item) {
                         if (!item.curated) {


### PR DESCRIPTION
When there is no content need to be reviewed, we will clean up the gene meta file. But I forgot to spare CurationQueueArticles key, which we use to keep track of how many articles we have in the curation queue.