### PR TITLE
fix the issue that only first abstract got displayed

### DIFF
--- a/web/yo/app/scripts/services/findregex.js
+++ b/web/yo/app/scripts/services/findregex.js
@@ -19,7 +19,8 @@ angular.module('oncokbApp')
                 link: 'https://clinicaltrials.gov/show/'
             },
             abstract: {
-                regex: /\(\s*Abstract\s*:([^\)]*\s*);?\s*\)/ig
+                regex: /\(\s*Abstract\s*:([^\)]*\s*);?\s*\)/ig,
+                localRegex: /\(\s*Abstract\s*:([^\)]*\s*);?\s*\)/i
             }
         };
 
@@ -121,7 +122,7 @@ angular.module('oncokbApp')
                                 uniqueResultA.push({type: 'nct', id: _datum});
                                 break;
                             case 2:
-                                var abstractPattern = regex[2];
+                                var abstractPattern = allRegex.abstract.localRegex;
                                 var match = abstractPattern.exec(_datum);
                                 if (_.isArray(match) && match.length > 1) {
                                     _datum = match[1];


### PR DESCRIPTION
When matching single abstract input string, we shouldn't use global flag, since the global flag will keep track of the lastIndex where a match occured, and start the next matching from there instead of 0. And that caused the subsequent abstracts after the first one are not found.