### PR TITLE
Support evidence type in api/search

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -20,7 +20,7 @@ public class IndicatorUtils {
         highestLevelOnly = highestLevelOnly == null ? false : highestLevelOnly;
 
         if (evidenceTypes == null || evidenceTypes.isEmpty()) {
-            evidenceTypes.addAll(MainUtils.getAllEvidenceTypes());
+            evidenceTypes = new HashSet<>(MainUtils.getAllEvidenceTypes());
         }
 
         Set<EvidenceType> selectedTreatmentEvidence = new HashSet<>(CollectionUtils.intersection(evidenceTypes, MainUtils.getTreatmentEvidenceTypes()));

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -14,9 +14,18 @@ import java.util.*;
  */
 public class IndicatorUtils {
     public static IndicatorQueryResp processQuery(Query query, String geneStatus,
-                                                  Set<LevelOfEvidence> levels, String source, Boolean highestLevelOnly) {
+                                                  Set<LevelOfEvidence> levels, String source, Boolean highestLevelOnly,
+                                                  Set<EvidenceType> evidenceTypes) {
         geneStatus = geneStatus != null ? geneStatus : "complete";
         highestLevelOnly = highestLevelOnly == null ? false : highestLevelOnly;
+
+        if (evidenceTypes == null || evidenceTypes.isEmpty()) {
+            evidenceTypes.addAll(MainUtils.getAllEvidenceTypes());
+        }
+
+        Set<EvidenceType> selectedTreatmentEvidence = new HashSet<>(CollectionUtils.intersection(evidenceTypes, MainUtils.getTreatmentEvidenceTypes()));
+        boolean hasTreatmentEvidence = !selectedTreatmentEvidence.isEmpty();
+        boolean hasOncogenicEvidence = evidenceTypes.contains(EvidenceType.ONCOGENIC);
 
         IndicatorQueryResp indicatorQuery = new IndicatorQueryResp();
         indicatorQuery.setQuery(query);
@@ -98,7 +107,7 @@ public class IndicatorUtils {
                     tmpGene.getHugoSymbol(), query.getAlteration(), null, query.getSvType(),
                     query.getTumorType(), query.getConsequence(), query.getProteinStart(),
                     query.getProteinEnd(), query.getHgvs());
-                result.add(IndicatorUtils.processQuery(tmpQuery, geneStatus, levels, source, highestLevelOnly));
+                result.add(IndicatorUtils.processQuery(tmpQuery, geneStatus, levels, source, highestLevelOnly, evidenceTypes));
             }
             return result.iterator().next();
         }
@@ -111,8 +120,12 @@ public class IndicatorUtils {
             indicatorQuery.setGeneExist(gene.getEntrezGeneId() > 0);
 
             // Gene summary
-            indicatorQuery.setGeneSummary(SummaryUtils.geneSummary(gene));
-            allQueryRelatedEvidences.addAll(EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENE_SUMMARY)));
+
+            if (evidenceTypes.contains(EvidenceType.GENE_SUMMARY)) {
+                indicatorQuery.setGeneSummary(SummaryUtils.geneSummary(gene));
+                allQueryRelatedEvidences.addAll(EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENE_SUMMARY)));
+            }
+
             alteration = AlterationUtils.getAlteration(gene.getHugoSymbol(), query.getAlteration(),
                 null, query.getConsequence(), query.getProteinStart(), query.getProteinEnd());
             AlterationUtils.annotateAlteration(alteration, alteration.getAlteration());
@@ -154,60 +167,64 @@ public class IndicatorUtils {
             Set<Evidence> treatmentEvidences = new HashSet<>();
 
             if (nonVUSRelevantAlts.size() > 0) {
-                Oncogenicity oncogenicity = null;
-                Evidence oncogenicityEvidence = null;
+                if (hasOncogenicEvidence) {
+                    Oncogenicity oncogenicity = null;
+                    Evidence oncogenicityEvidence = null;
 
 
-                // Find alteration specific oncogenicity
-                List<Evidence> selfAltOncogenicEvis = EvidenceUtils.getEvidence(Collections.singletonList(alteration),
-                    Collections.singleton(EvidenceType.ONCOGENIC), null);
-                if (selfAltOncogenicEvis != null) {
-                    oncogenicityEvidence = MainUtils.findHighestOncogenicEvidenceByEvidences(new HashSet<>(selfAltOncogenicEvis));
-                    if (oncogenicityEvidence != null) {
-                        oncogenicity = Oncogenicity.getByEffect(oncogenicityEvidence.getKnownEffect());
-                    }
-                }
-
-                // Find Oncogenicity from alternative alleles
-                if ((oncogenicity == null || oncogenicity.equals(Oncogenicity.INCONCLUSIVE))
-                    && indicatorQuery.getAlleleExist()) {
-                    oncogenicityEvidence = MainUtils.findHighestOncogenicEvidenceByEvidences(new HashSet<>(EvidenceUtils.getEvidence(new ArrayList<>(alleles), Collections.singleton(EvidenceType.ONCOGENIC), null)));
-                    if (oncogenicityEvidence != null) {
-                        Oncogenicity tmpOncogenicity = MainUtils.setToAlleleOncogenicity(Oncogenicity.getByEffect(oncogenicityEvidence.getKnownEffect()));
-                        if (tmpOncogenicity != null) {
-                            oncogenicity = tmpOncogenicity;
+                    // Find alteration specific oncogenicity
+                    List<Evidence> selfAltOncogenicEvis = EvidenceUtils.getEvidence(Collections.singletonList(alteration),
+                        Collections.singleton(EvidenceType.ONCOGENIC), null);
+                    if (selfAltOncogenicEvis != null) {
+                        oncogenicityEvidence = MainUtils.findHighestOncogenicEvidenceByEvidences(new HashSet<>(selfAltOncogenicEvis));
+                        if (oncogenicityEvidence != null) {
+                            oncogenicity = Oncogenicity.getByEffect(oncogenicityEvidence.getKnownEffect());
                         }
                     }
+
+                    // Find Oncogenicity from alternative alleles
+                    if ((oncogenicity == null || oncogenicity.equals(Oncogenicity.INCONCLUSIVE))
+                        && indicatorQuery.getAlleleExist()) {
+                        oncogenicityEvidence = MainUtils.findHighestOncogenicEvidenceByEvidences(new HashSet<>(EvidenceUtils.getEvidence(new ArrayList<>(alleles), Collections.singleton(EvidenceType.ONCOGENIC), null)));
+                        if (oncogenicityEvidence != null) {
+                            Oncogenicity tmpOncogenicity = MainUtils.setToAlleleOncogenicity(Oncogenicity.getByEffect(oncogenicityEvidence.getKnownEffect()));
+                            if (tmpOncogenicity != null) {
+                                oncogenicity = tmpOncogenicity;
+                            }
+                        }
+                    }
+
+                    // If there is no oncogenic info available for this variant, find oncogenicity from relevant variants
+                    if (oncogenicity == null || oncogenicity.equals(Oncogenicity.INCONCLUSIVE)) {
+                        oncogenicityEvidence = MainUtils.findHighestOncogenicEvidenceByEvidences(
+                            EvidenceUtils.getRelevantEvidences(query, source, geneStatus,
+                                Collections.singleton(EvidenceType.ONCOGENIC), null));
+                        if (oncogenicityEvidence != null) {
+                            Oncogenicity tmpOncogenicity = Oncogenicity.getByEffect(oncogenicityEvidence.getKnownEffect());
+                            if (tmpOncogenicity != null) {
+                                oncogenicity = tmpOncogenicity;
+                            }
+                        }
+                    }
+
+                    if (oncogenicityEvidence != null) {
+                        allQueryRelatedEvidences.add(oncogenicityEvidence);
+                    }
+
+                    // Only set oncogenicity if no previous data assigned.
+                    if (indicatorQuery.getOncogenic() == null && oncogenicity != null) {
+                        indicatorQuery.setOncogenic(oncogenicity.getOncogenic());
+                    }
                 }
 
-                // If there is no oncogenic info available for this variant, find oncogenicity from relevant variants
-                if (oncogenicity == null || oncogenicity.equals(Oncogenicity.INCONCLUSIVE)) {
-                    oncogenicityEvidence = MainUtils.findHighestOncogenicEvidenceByEvidences(
+                if (hasTreatmentEvidence) {
+                    treatmentEvidences = EvidenceUtils.keepHighestLevelForSameTreatments(
                         EvidenceUtils.getRelevantEvidences(query, source, geneStatus,
-                            Collections.singleton(EvidenceType.ONCOGENIC), null));
-                    if (oncogenicityEvidence != null) {
-                        Oncogenicity tmpOncogenicity = Oncogenicity.getByEffect(oncogenicityEvidence.getKnownEffect());
-                        if (tmpOncogenicity != null) {
-                            oncogenicity = tmpOncogenicity;
-                        }
-                    }
+                            selectedTreatmentEvidence,
+                            (levels != null ?
+                                new HashSet<LevelOfEvidence>(CollectionUtils.intersection(levels,
+                                    LevelUtils.getPublicAndOtherIndicationLevels())) : LevelUtils.getPublicAndOtherIndicationLevels())));
                 }
-
-                if (oncogenicityEvidence != null) {
-                    allQueryRelatedEvidences.add(oncogenicityEvidence);
-                }
-
-                // Only set oncogenicity if no previous data assigned.
-                if (indicatorQuery.getOncogenic() == null && oncogenicity != null) {
-                    indicatorQuery.setOncogenic(oncogenicity.getOncogenic());
-                }
-
-                treatmentEvidences = EvidenceUtils.keepHighestLevelForSameTreatments(
-                    EvidenceUtils.getRelevantEvidences(query, source, geneStatus,
-                        MainUtils.getTreatmentEvidenceTypes(),
-                        (levels != null ?
-                            new HashSet<LevelOfEvidence>(CollectionUtils.intersection(levels,
-                                LevelUtils.getPublicAndOtherIndicationLevels())) : LevelUtils.getPublicAndOtherIndicationLevels())));
             }
 
             // Set hotspot oncogenicity to Predicted Oncogenic
@@ -218,17 +235,19 @@ public class IndicatorUtils {
                 Alteration oncogenicMutation = AlterationUtils.findAlteration(gene, "Oncogenic Mutations");
                 if (oncogenicMutation != null) {
                     relevantAlterations.add(oncogenicMutation);
-                    treatmentEvidences.addAll(EvidenceUtils.keepHighestLevelForSameTreatments(
-                        EvidenceUtils.convertEvidenceLevel(
-                            EvidenceUtils.getEvidence(Collections.singletonList(oncogenicMutation),
-                                MainUtils.getTreatmentEvidenceTypes(),
-                                (levels != null ?
-                                    new HashSet<>(CollectionUtils.intersection(levels,
-                                        LevelUtils.getPublicAndOtherIndicationLevels())) : LevelUtils.getPublicAndOtherIndicationLevels())), new HashSet<>(oncoTreeTypes))));
+                    if (hasTreatmentEvidence) {
+                        treatmentEvidences.addAll(EvidenceUtils.keepHighestLevelForSameTreatments(
+                            EvidenceUtils.convertEvidenceLevel(
+                                EvidenceUtils.getEvidence(Collections.singletonList(oncogenicMutation),
+                                    selectedTreatmentEvidence,
+                                    (levels != null ?
+                                        new HashSet<>(CollectionUtils.intersection(levels,
+                                            LevelUtils.getPublicAndOtherIndicationLevels())) : LevelUtils.getPublicAndOtherIndicationLevels())), new HashSet<>(oncoTreeTypes))));
+                    }
                 }
             }
 
-            if (treatmentEvidences != null && !treatmentEvidences.isEmpty()) {
+            if (hasTreatmentEvidence && treatmentEvidences != null && !treatmentEvidences.isEmpty()) {
                 if (highestLevelOnly) {
                     Set<Evidence> filteredEvis = new HashSet<>();
                     // Get highest sensitive evidences
@@ -256,7 +275,7 @@ public class IndicatorUtils {
             }
 
             // Tumor type summary
-            if (query.getTumorType() != null) {
+            if (evidenceTypes.contains(EvidenceType.TUMOR_TYPE_SUMMARY) && query.getTumorType() != null) {
                 Map<String, Object> tumorTypeSummary = SummaryUtils.tumorTypeSummary(gene, query, matchedAlt,
                     new ArrayList<>(relevantAlterations),
                     oncoTreeTypes);
@@ -272,8 +291,10 @@ public class IndicatorUtils {
             }
 
             // Mutation summary
-            indicatorQuery.setVariantSummary(SummaryUtils.oncogenicSummary(gene, matchedAlt,
-                new ArrayList<>(relevantAlterations), query));
+            if (evidenceTypes.contains(EvidenceType.MUTATION_SUMMARY)) {
+                indicatorQuery.setVariantSummary(SummaryUtils.oncogenicSummary(gene, matchedAlt,
+                    new ArrayList<>(relevantAlterations), query));
+            }
 
             // This is special case for KRAS wildtype. May need to come up with a better plan for this.
             if (gene != null && (gene.getHugoSymbol().equals("KRAS") || gene.getHugoSymbol().equals("NRAS"))

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -399,8 +399,6 @@ public class MainUtils {
                 EvidenceType et = EvidenceType.valueOf(type);
                 evidenceTypes.add(et);
             }
-        } else {
-            return null;
         }
         return evidenceTypes;
     }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -21,19 +21,19 @@ public class IndicatorUtilsTest {
 
         // Gene not exists
         Query query = new Query(null, null, null, "TEST", "V123M", null, null, "Pancreatic Adenocarcinoma", null, null, null, null);
-        IndicatorQueryResp indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        IndicatorQueryResp indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertTrue("The geneExist in the response is not false, but it should be.", indicatorQueryResp.getGeneExist() == false);
         assertEquals("The oncogenicity is not empty, but it should.", "", indicatorQueryResp.getOncogenic());
         assertTrue("There is treatment(s) in the response, but it should no have any.", indicatorQueryResp.getTreatments().size() == 0);
 
         query = new Query(null, null, null, "CD74-CD74", null, "structural_variant", StructuralVariantType.DELETION, "Pancreatic Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("Gene should not exist, but it does.", false, indicatorQueryResp.getGeneExist());
         assertEquals("The oncogenicity is not empty, but it should.", "", indicatorQueryResp.getOncogenic());
         assertTrue("There is treatment(s) in the response, but it should no have any.", indicatorQueryResp.getTreatments().size() == 0);
 
         query = new Query(null, null, null, "CD74-CD74", null, "structural_variant", StructuralVariantType.DELETION, "Pancreatic Adenocarcinoma", "fusion", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("Gene should not exist, but it does.", false, indicatorQueryResp.getGeneExist());
         assertEquals("The oncogenicity is not empty, but it should.", "", indicatorQueryResp.getOncogenic());
         assertTrue("There is treatment(s) in the response, but it should no have any.", indicatorQueryResp.getTreatments().size() == 0);
@@ -50,15 +50,15 @@ public class IndicatorUtilsTest {
 
         // Oncogenic should always match with oncogenic summary, similar to likely oncogenic
         query = new Query(null, null, null, "TP53", "R248Q", null, null, "Pancreatic Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The oncogenicity is not matched in variant summary.", "The TP53 R248Q mutation is likely oncogenic.", indicatorQueryResp.getVariantSummary());
         query = new Query(null, null, null, "KRAS", "V14I", null, null, "Pancreatic Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The oncogenicity is not matched in variant summary.", "The KRAS V14I mutation is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
 
         // Check critical case
         query = new Query(null, null, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertTrue("The geneExist in the response is not true, but it should.", indicatorQueryResp.getGeneExist() == true);
         assertTrue("The variantExist in the response is not true, but it should.", indicatorQueryResp.getVariantExist() == true);
         assertTrue("The alleleExist in the response is not true, but it should.", indicatorQueryResp.getAlleleExist() == true);
@@ -71,30 +71,30 @@ public class IndicatorUtilsTest {
 
         // Check fusion.
         query = new Query(null, null, null, "BRAF", "CUL1-BRAF Fusion", null, null, "Ovarian Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The highest sensitive level of CUL1-BRAF fusion should be Level 3A", LevelOfEvidence.LEVEL_3A, indicatorQueryResp.getHighestSensitiveLevel());
         assertEquals("The oncogenicity of CUL1-BRAF fusion should be Likely Oncogenic", "Likely Oncogenic", indicatorQueryResp.getOncogenic());
 
         // Both genes have relevant alterations, should return highest level then highest oncogenicity
         query = new Query(null, null, null, "BRAF-TMPRSS2", null, "fusion", null, "Prostate Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The highest sensitive level of CUL1-BRAF fusion should be Level 3A", LevelOfEvidence.LEVEL_3B, indicatorQueryResp.getHighestSensitiveLevel());
         assertEquals("The oncogenicity of BRAF-TMPRSS2 fusion should be Likely Oncogenic", "Likely Oncogenic", indicatorQueryResp.getOncogenic());
 
         // Test Intragenic Mutation
         query = new Query(null, null, null, "CTCF", "CTCF-intragenic", null, null, "Ovarian Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The oncogenicity of CTCF-intragenic should be Likely Oncogenic", "Likely Oncogenic", indicatorQueryResp.getOncogenic());
 
         // Check other significant level
         query = new Query(null, null, null, "BRAF", "V600E", null, null, "Colorectal Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The highest sensitive level should be 2B", LevelOfEvidence.LEVEL_2B, indicatorQueryResp.getHighestSensitiveLevel());
         assertTrue("The highest resistance level should be null", indicatorQueryResp.getHighestResistanceLevel() == null);
         assertTrue(treatmentsContainLevel(indicatorQueryResp.getTreatments(), LevelOfEvidence.LEVEL_2B));
 
         query = new Query(null, null, null, "BRAF", "V600E", null, null, "Breast Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The highest sensitive level should be 2B", LevelOfEvidence.LEVEL_2B, indicatorQueryResp.getHighestSensitiveLevel());
         assertTrue("The highest resistance level should be null", indicatorQueryResp.getHighestResistanceLevel() == null);
         assertTrue("Shouldn't have any significant level", indicatorQueryResp.getOtherSignificantSensitiveLevels().size() == 0);
@@ -102,12 +102,12 @@ public class IndicatorUtilsTest {
 
         // Test for predicted oncogenic
         query = new Query(null, null, null, "PIK3R1", "K567E", null, null, "Pancreatic Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, false);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, false, null);
         assertEquals("The oncogenicity should be 'Predicted Oncogenic'", Oncogenicity.PREDICTED.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The isHotspot is not true, but it should be.", Boolean.TRUE, indicatorQueryResp.getHotspot());
 
         query = new Query(null, null, null, "ALK", "R401Q", null, null, "Colon Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, false);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, false, null);
         assertEquals("The oncogenicity should be 'Predicted Oncogenic'", Oncogenicity.PREDICTED.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "As of 10/06/2017, there was no available functional data about the ALK R401Q mutation. However, it has been identified as a statistically significant hotspot and is predicted to be oncogenic.", indicatorQueryResp.getVariantSummary());
         assertEquals("The isHotspot is not true, but it should be.", Boolean.TRUE, indicatorQueryResp.getHotspot());
@@ -117,7 +117,7 @@ public class IndicatorUtilsTest {
 //            null, indicatorQueryResp.getHighestSensitiveLevel());
 
         query = new Query(null, null, null, "KRAS", "Q61K", null, null, "Colorectal Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, false);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, false, null);
         assertEquals("The oncogenicity should be 'Likely Oncogenic'", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level should be 4",
             LevelOfEvidence.LEVEL_4, indicatorQueryResp.getHighestSensitiveLevel());
@@ -127,7 +127,7 @@ public class IndicatorUtilsTest {
 
         // Test cases generated through MSK-IMPACT reports which ran into issue before
         query = new Query(null, null, null, "EGFR", "S768_V769delinsIL", null, null, "Non-Small Cell Lung Cancer", "missense_variant", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("Gene should exist", true, indicatorQueryResp.getGeneExist());
         assertEquals("Variant should not exist", false, indicatorQueryResp.getVariantExist());
         assertEquals("Is expected to be likely oncogenic", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
@@ -135,14 +135,14 @@ public class IndicatorUtilsTest {
             LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
 
         query = new Query(null, null, null, "TMPRSS2-ERG", null, "Fusion", null, "Prostate Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("Gene should exist", true, indicatorQueryResp.getGeneExist());
         assertEquals("The Oncogenicity is not YES, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level should be null",
             null, indicatorQueryResp.getHighestSensitiveLevel());
 
         query = new Query(null, null, null, "CDKN2A", "M1?", null, null, "Colon Adenocarcinoma", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("Gene should exist", true, indicatorQueryResp.getGeneExist());
         assertEquals("The Oncogenicity is not Likely Oncogenic, but it should be.", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
 
@@ -151,7 +151,7 @@ public class IndicatorUtilsTest {
         // PDGFRA D842Y Gastrointestinal Stromal Tumor
         // Dasatinib should not be listed as D842V has resistance treatment
         query = new Query(null, null, null, "PDGFRA", "D842Y", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("Gene should exist", true, indicatorQueryResp.getGeneExist());
         assertEquals("The Oncogenicity is not Likely Oncogenic, but it should be.", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level should be 2A, but it is not.",
@@ -164,12 +164,12 @@ public class IndicatorUtilsTest {
         // Manually curated likely neutral should overwrite hotspot predicted oncogenic rule
         // EGFR A289D is manually curated as likely neutral.
         query = new Query(null, null, null, "EGFR", "A289D", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not likely neutral, but it should be.", Oncogenicity.LIKELY_NEUTRAL.getOncogenic(), indicatorQueryResp.getOncogenic());
 
         // BRAF R462I is manually curated as Likely Neutral, then the oncogenic mutations shouldn't be associated.
         query = new Query(null, null, null, "BRAF", "R462I", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not likely neutral, but it should be.", Oncogenicity.LIKELY_NEUTRAL.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level of BRAF R462I should be null.", null, indicatorQueryResp.getHighestSensitiveLevel());
         assertEquals("The highest resistance level of BRAF R462I should be null.", null, indicatorQueryResp.getHighestResistanceLevel());
@@ -177,36 +177,36 @@ public class IndicatorUtilsTest {
 
         // Check EGFRvIII
         query = new Query(null, null, null, "EGFR", "EGFRvIII", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "The EGFRvIII mutation is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
 
         query = new Query(null, null, null, "EGFR-EGFR", "EGFRvIII", "structural_variant", StructuralVariantType.DELETION, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "The EGFRvIII mutation is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
 
         query = new Query(null, null, null, "EGFR-EGFR", "EGFRvIII", "structural_variant", StructuralVariantType.DELETION, "Gastrointestinal Stromal Tumor", "", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "The EGFRvIII mutation is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
 
         query = new Query(null, null, null, "EGFR", "EGFRvIII", "structural_variant", StructuralVariantType.DELETION, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "The EGFRvIII mutation is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
 
         query = new Query(null, null, null, "EGFR", "", "structural_variant", StructuralVariantType.DELETION, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not empty.", "", indicatorQueryResp.getOncogenic());
 
         query = new Query(null, null, null, "EGFR", "", "structural_variant", StructuralVariantType.DELETION, "Gastrointestinal Stromal Tumor", "fusion", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not likely oncogenic, but it should be.", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
 
         // Check EGFRvII
         query = new Query(null, null, null, "EGFR", "EGFRvII", "structural_variant", StructuralVariantType.DELETION, "Gastrointestinal Stromal Tumor", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "The EGFRvII mutation is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
 
@@ -214,7 +214,7 @@ public class IndicatorUtilsTest {
         // The hotspot range is 65_77indel.
         // In original design, if the caller calls the duplication happened at 78, this variant will not be qualified for predicted oncogenic. But it could be treated the insertion happened at 68.
         query = new Query(null, null, null, "AKT1", "P68_C77dup", null, null, "Gastrointestinal Stromal Tumor", "In_Frame_Ins", 78, 78, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);
         assertEquals("The Oncogenicity is not Predicted Oncogenic, but it should be.", Oncogenicity.PREDICTED.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The isHotspot is not true, but it should be.", Boolean.TRUE, indicatorQueryResp.getHotspot());
 
@@ -235,16 +235,16 @@ public class IndicatorUtilsTest {
         // Match Gain with Amplification
         query1 = new Query("PTEN", "Gain", null);
         query2 = new Query("PTEN", "Amplification", null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, false);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, false);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, false, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, false, null);
         assertTrue("The oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("The treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
 
         // Match Loss with Deletion
         query1 = new Query("PTEN", "Loss", null);
         query2 = new Query("PTEN", "Deletion", null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, false);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, false);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, false, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, false, null);
         assertTrue("The oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("The treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
 
@@ -253,16 +253,16 @@ public class IndicatorUtilsTest {
         // continue annotating process.
         query1 = new Query("MAP3K1", "T779*", null);
         query2 = new Query("MAP3K1", "Deletion", null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, false);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, false);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, false, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, false, null);
         assertTrue("The oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("The treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
 
         // Check unknown denominator fusion, it should return same data as querying specific fusion.
         query1 = new Query(null, null, null, "BRAF", "CUL1-BRAF Fusion", null, null, "Ovarian Cancer", null, null, null, null);
         query2 = new Query(null, null, null, "CUL1-BRAF", null, "fusion", null, "Ovarian Cancer", null, null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true, null);
         assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
         assertTrue("Highest sensitive levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestSensitiveLevel(), resp2.getHighestSensitiveLevel()));
@@ -271,8 +271,8 @@ public class IndicatorUtilsTest {
         // Check hugoSymbol and entrezGene pair
         query1 = new Query(null, null, 673, null, "V600E", null, null, "Melanoma", null, null, null, null);
         query2 = new Query(null, null, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true, null);
         assertTrue("Genes are not the same, but they should.", resp1.getGeneSummary().equals(resp2.getGeneSummary()));
         assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
@@ -283,8 +283,8 @@ public class IndicatorUtilsTest {
         //EntrezGeneId has higher priority then hugoSymbol
         query1 = new Query(null, null, 673, "EGFR", "V600E", null, null, "Melanoma", null, null, null, null);
         query2 = new Query(null, null, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true, null);
         assertTrue("Genes are not the same, but they should.", resp1.getGeneSummary().equals(resp2.getGeneSummary()));
         assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
@@ -294,8 +294,8 @@ public class IndicatorUtilsTest {
         //Check whether empty hugoSymbol will effect the result
         query1 = new Query(null, null, 673, "", "V600E", null, null, "Melanoma", null, null, null, null);
         query2 = new Query(null, null, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true, null);
         assertTrue("Genes are not the same, but they should.", resp1.getGeneSummary().equals(resp2.getGeneSummary()));
         assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
@@ -304,7 +304,7 @@ public class IndicatorUtilsTest {
 
         //Other Biomarker tests
         query = new Query(null, null, null, null, "MSI-H", null, null, "Colorectal Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertTrue("The geneExist is not false, but it should be.", indicatorQueryResp.getGeneExist() == false);
         assertEquals("The oncogenicity is not Oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level is not 1, but it should be.", LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
@@ -312,15 +312,15 @@ public class IndicatorUtilsTest {
 
         // Test indicator endpoint supports HGVS
         query = new Query(null, null, null, null, null, null, null, "Melanoma", null, null, null, "7:g.140453136A>T");
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertTrue("The geneExist is not true, but it should be.", indicatorQueryResp.getGeneExist() == true);
         assertEquals("The oncogenicity is not Oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level is not 1, but it should be.", LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
 
         query1 = new Query(null, null, null, null, null, null, null, "Melanoma", null, null, null, "7:g.140453136A>T");
         query2 = new Query(null, null, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true, null);
         assertTrue("Genes are not the same, but they should.", resp1.getGeneSummary().equals(resp2.getGeneSummary()));
         assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
@@ -330,7 +330,7 @@ public class IndicatorUtilsTest {
         // Test HGVS has higher priority than gene/variant pair
         // 7:g.140453136A>T is BRAF V600E
         query = new Query(null, null, null, "ALK", "R401Q", null, null, "Melanoma", null, null, null, "7:g.140453136A>T");
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertTrue("The geneExist is not true, but it should be.", indicatorQueryResp.getGeneExist() == true);
         assertEquals("The oncogenicity is not Oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level is not 1, but it should be.", LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
@@ -338,29 +338,29 @@ public class IndicatorUtilsTest {
         // Check structural variant fusion
         // a) BRAF is oncogenic gene. No Truncating Mutations is curated.
         query = new Query(null, null, null, "BRAF-BRAF", null, "structural_variant", StructuralVariantType.INSERTION, "Ovarian Cancer", "fusion", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The highest sensitive level of BRAF insertion should be Level 3A", LevelOfEvidence.LEVEL_3A, indicatorQueryResp.getHighestSensitiveLevel());
         assertEquals("The oncogenicity of BRAF insertion functional fusion should be Likely Oncogenic", "Likely Oncogenic", indicatorQueryResp.getOncogenic());
 
         query = new Query(null, null, null, "BRAF-BRAF", null, "structural_variant", StructuralVariantType.INSERTION, "Ovarian Cancer", null, null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The highest sensitive level of BRAF insertion should be null", null, indicatorQueryResp.getHighestSensitiveLevel());
         assertEquals("The oncogenicity of BRAF insertion non-functional fusion should be empty", "", indicatorQueryResp.getOncogenic());
 
         // b)  KMT2A is tumor suppressor gene, it has both fusions and Truncating Mutations curated. Functional fusion should have fusions mapped, non-functional genes should have Truncating Mutations mapped. And both of them are likely oncogenic.
         query = new Query(null, null, null, "KMT2A-MLLT3", null, "structural_variant", StructuralVariantType.TRANSLOCATION, "Acute Myeloid Leukemia", "fusion", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The oncogenicity of KMT2A translocation functional fusion should be likely oncogenic", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
         query = new Query(null, null, null, "KMT2A-MLLT3", null, "structural_variant", StructuralVariantType.TRANSLOCATION, "Acute Myeloid Leukemia", "fusion", null, null, null);
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, null, true, null);
         assertEquals("The oncogenicity of KMT2A translocation non-functional fusion should be likely oncogenic", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
 
         // Test Structural Variants
         // Fusion as alteration type should have same result from structural variant as alteration type and fusion as consequence
         query1 = new Query(null, null, null, "EGFR-RAD51", null, "fusion", null, "Ovarian Cancer", null, null, null, null);
         query2 = new Query(null, null, null, "EGFR-RAD51", null, "structural_variant", StructuralVariantType.INSERTION, "Ovarian Cancer", "fusion", null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true);
+        resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, null, null, true, null);
 
         assertTrue("The gene exist should be the same.", resp1.getGeneExist().equals(resp2.getGeneExist()));
         assertTrue("The oncogenicity should be the same.", resp1.getOncogenic().equals(resp2.getOncogenic()));

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/StructuralVariantParameterizedTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/StructuralVariantParameterizedTest.java
@@ -61,8 +61,8 @@ public class StructuralVariantParameterizedTest {
             query2.setTumorType(tumorType);
 
             // if it is functional fusion. The result should be the same as passing as fusion
-            IndicatorQueryResp resp1 = IndicatorUtils.processQuery(query1, null, null, null, true);
-            IndicatorQueryResp resp2 = IndicatorUtils.processQuery(query2, null, null, null, false);
+            IndicatorQueryResp resp1 = IndicatorUtils.processQuery(query1, null, null, null, true, null);
+            IndicatorQueryResp resp2 = IndicatorUtils.processQuery(query2, null, null, null, false, null);
 
             assertEquals("Oncogenicities are not matched.", resp1.getOncogenic(), resp2.getOncogenic());
             assertEquals("Highest sensitive levels are not matched.", resp1.getHighestSensitiveLevel(), resp2.getHighestSensitiveLevel());
@@ -81,7 +81,7 @@ public class StructuralVariantParameterizedTest {
 
         String _query = fusionPair + " " + svClass + " " + tumorType + " " + isFunctionalFusion;
 
-        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, true);
+        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, true, null);
 
         assertEquals("Oncogenicities are not matched. Query: " + _query, oncogenicity, resp.getOncogenic());
         assertEquals("Gene summaries are not matched. Query: " + _query, geneSummary, resp.getGeneSummary());

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/SummaryUtilsParameterizedTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/SummaryUtilsParameterizedTest.java
@@ -46,7 +46,7 @@ public class SummaryUtilsParameterizedTest {
         query.setHugoSymbol(gene);
         query.setTumorType(tumorType);
 
-        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, false);
+        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, false, null);
         String _query = gene + " " + variant + " " + tumorType;
         String _geneSummary = resp.getGeneSummary();
         String _variantSummary = resp.getVariantSummary();

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/TreatmentParameterizedTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/TreatmentParameterizedTest.java
@@ -44,7 +44,7 @@ public class TreatmentParameterizedTest {
         query.setHugoSymbol(gene);
         query.setTumorType(tumorType);
 
-        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, false);
+        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, false, null);
         List<IndicatorQueryTreatment> resps = resp.getTreatments();
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < resps.size(); i++) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/SearchApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/SearchApi.java
@@ -38,6 +38,7 @@ public interface SearchApi {
         , @ApiParam(value = "Level of evidences.") @RequestParam(value = "levels", required = false) String levels
         , @ApiParam(value = "Only show treatments of highest level") @RequestParam(value = "highestLevelOnly", required = false, defaultValue = "FALSE") Boolean highestLevelOnly
         , @ApiParam(value = "Query type. There maybe slight differences between different query types. Currently support web or regular.") @RequestParam(value = "queryType", required = false, defaultValue = "regular") String queryType
+        , @ApiParam(value = "Evidence type.") @RequestParam(value = "evidenceType", required = false) String evidenceType
         , @ApiParam(value = "HGVS varaint. Its priority is higher than entrezGeneId/hugoSymbol + variant combination") @RequestParam(value = "hgvs", required = false) String hgvs
         , @ApiParam(value = "The fields to be returned.") @RequestParam(value = "fields", required = false) String fields
     );

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/SearchApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/SearchApiController.java
@@ -6,6 +6,9 @@ import org.mskcc.cbio.oncokb.service.JsonResultFactory;
 import org.mskcc.cbio.oncokb.util.GeneUtils;
 import org.mskcc.cbio.oncokb.util.IndicatorUtils;
 import org.mskcc.cbio.oncokb.util.LevelUtils;
+import org.mskcc.cbio.oncokb.util.MainUtils;
+import org.mskcc.oncotree.model.MainType;
+import org.mskcc.oncotree.utils.MainTypesUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,8 +16,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.mskcc.cbio.oncokb.util.MainUtils.stringToEvidenceTypes;
 
 
 @javax.annotation.Generated(value = "class io.swagger.codegen.languages.SpringCodegen", date = "2016-10-19T19:28:21.941Z")
@@ -36,6 +42,7 @@ public class SearchApiController implements SearchApi {
         , @ApiParam(value = "Level of evidences.") @RequestParam(value = "levels", required = false) String levels
         , @ApiParam(value = "Only show treatments of highest level") @RequestParam(value = "highestLevelOnly", required = false, defaultValue = "FALSE") Boolean highestLevelOnly
         , @ApiParam(value = "Query type. There maybe slight differences between different query types. Currently support web or regular.") @RequestParam(value = "queryType", required = false, defaultValue = "regular") String queryType
+        , @ApiParam(value = "Evidence type.") @RequestParam(value = "evidenceType", required = false) String evidenceType
         , @ApiParam(value = "HGVS varaint. Its priority is higher than entrezGeneId/hugoSymbol + variant combination") @RequestParam(value = "hgvs", required = false) String hgvs
         , @ApiParam(value = "The fields to be returned.") @RequestParam(value = "fields", required = false) String fields
     ) {
@@ -49,7 +56,7 @@ public class SearchApiController implements SearchApi {
             source = source == null ? "oncokb" : source;
 
             Set<LevelOfEvidence> levelOfEvidences = levels == null ? LevelUtils.getPublicAndOtherIndicationLevels() : LevelUtils.parseStringLevelOfEvidences(levels);
-            indicatorQueryResp = IndicatorUtils.processQuery(query, null, levelOfEvidences, source, highestLevelOnly);
+            indicatorQueryResp = IndicatorUtils.processQuery(query, null, levelOfEvidences, source, highestLevelOnly, new HashSet<>(MainUtils.stringToEvidenceTypes(evidenceType, ",")));
         }
         return ResponseEntity.status(status.value()).body(JsonResultFactory.getIndicatorQueryResp(indicatorQueryResp, fields));
     }
@@ -71,7 +78,7 @@ public class SearchApiController implements SearchApi {
             for (Query query : body.getQueries()) {
                 result.add(IndicatorUtils.processQuery(query, null,
                     body.getLevels() == null ? LevelUtils.getPublicAndOtherIndicationLevels() : body.getLevels(),
-                    source, body.getHighestLevelOnly()));
+                    source, body.getHighestLevelOnly(), new HashSet<>(stringToEvidenceTypes(body.getEvidenceTypes(), ","))));
             }
         }
         return ResponseEntity.status(status.value()).body(JsonResultFactory.getIndicatorQueryResp(result, fields));

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateSearchApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateSearchApiController.java
@@ -242,7 +242,7 @@ public class PrivateSearchApiController implements PrivateSearchApi {
         query.setEntrezGeneId(alteration.getGene().getEntrezGeneId());
         query.setAlteration(alteration.getAlteration());
 
-        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, false);
+        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, null, null, null, false, null);
         typeaheadSearchResp.setOncogenicity(resp.getOncogenic());
         typeaheadSearchResp.setVUS(resp.getVUS());
         typeaheadSearchResp.setAnnotation(resp.getVariantSummary());

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.*;
 import javax.xml.parsers.ParserConfigurationException;
 import java.util.*;
 
+import static org.mskcc.cbio.oncokb.util.MainUtils.stringToEvidenceTypes;
+
 /**
  * @author jgao
  */
@@ -78,10 +80,7 @@ public class EvidenceController {
             Set<EvidenceType> evidenceTypes = new HashSet<>();
 
             if (body.getEvidenceTypes() != null) {
-                for (String type : body.getEvidenceTypes().split("\\s*,\\s*")) {
-                    EvidenceType et = EvidenceType.valueOf(type);
-                    evidenceTypes.add(et);
-                }
+                evidenceTypes = new HashSet<>(stringToEvidenceTypes(body.getEvidenceTypes(), ","));
             } else if (body.getEvidenceTypes().isEmpty()) {
                 // If the evidenceTypes has been defined but is empty, no result should be returned.
                 return result;

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/IndicatorController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/IndicatorController.java
@@ -13,8 +13,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.mskcc.cbio.oncokb.util.MainUtils.stringToEvidenceTypes;
 
 /**
  * @author jgao
@@ -47,7 +50,7 @@ public class IndicatorController {
     ) {
         Query query = new Query(id, queryType, entrezGeneId, hugoSymbol, alteration, alterationType, svType, tumorType, consequence, proteinStart, proteinEnd, hgvs);
         Set<LevelOfEvidence> levelOfEvidences = levels == null ? LevelUtils.getPublicAndOtherIndicationLevels() : LevelUtils.parseStringLevelOfEvidences(levels);
-        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, geneStatus, levelOfEvidences, source, highestLevelOnly);
+        IndicatorQueryResp resp = IndicatorUtils.processQuery(query, geneStatus, levelOfEvidences, source, highestLevelOnly, null);
 
         return JsonResultFactory.getIndicatorQueryResp(resp, fields);
     }
@@ -71,7 +74,7 @@ public class IndicatorController {
         for (Query query : body.getQueries()) {
             result.add(IndicatorUtils.processQuery(query, null,
                 body.getLevels() == null ? LevelUtils.getPublicAndOtherIndicationLevels() : body.getLevels(),
-                source, body.getHighestLevelOnly()));
+                source, body.getHighestLevelOnly(),  new HashSet<>(stringToEvidenceTypes(body.getEvidenceTypes(), ","))));
         }
 
         return JsonResultFactory.getIndicatorQueryResp(result, fields);


### PR DESCRIPTION
Not all indicator calls may require all information queried especially when only oncogenic is needed, all therapeutics info any be ignored