### PR TITLE
Adding Oncogenic Mutations as relevant alt when alt is oncogenic

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -276,11 +276,18 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         boolean add = false;
         if (!isKitSpecialVariants(exactAlt)) {
             if (!exactAlt.getAlteration().trim().equalsIgnoreCase("amplification")) {
-                for (Alteration alt : relevantAlts) {
-                    Boolean isOncogenic = AlterationUtils.isOncogenicAlteration(alt);
-                    if (isOncogenic != null && isOncogenic && !isKitSpecialVariants(alt)) {
+                if (AlterationUtils.hasImportantCuratedOncogenicity(exactAlt)) {
+                    Boolean isOncogenic = AlterationUtils.isOncogenicAlteration(exactAlt);
+                    if (isOncogenic != null && isOncogenic && !isKitSpecialVariants(exactAlt)) {
                         add = true;
-                        break;
+                    }
+                } else {
+                    for (Alteration alt : relevantAlts) {
+                        Boolean isOncogenic = AlterationUtils.isOncogenicAlteration(alt);
+                        if (isOncogenic != null && isOncogenic && !isKitSpecialVariants(alt)) {
+                            add = true;
+                            break;
+                        }
                     }
                 }
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -784,6 +784,26 @@ public final class AlterationUtils {
         return isOncogenic;
     }
 
+    public static Boolean hasImportantCuratedOncogenicity(Alteration alteration) {
+        Set<Oncogenicity> curatedOncogenicities = new HashSet<>();
+        curatedOncogenicities.add(Oncogenicity.YES);
+        curatedOncogenicities.add(Oncogenicity.LIKELY);
+        curatedOncogenicities.add(Oncogenicity.LIKELY_NEUTRAL);
+
+        EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
+        List<Evidence> oncogenicEvs = evidenceBo.findEvidencesByAlteration(Collections.singleton(alteration), Collections.singleton(EvidenceType.ONCOGENIC));
+        Boolean isImportantCuratedOcnogenicity = false;
+
+        for (Evidence evidence : oncogenicEvs) {
+            Oncogenicity oncogenicity = Oncogenicity.getByEvidence(evidence);
+            if (oncogenicity != null && curatedOncogenicities.contains(oncogenicity)) {
+                isImportantCuratedOcnogenicity = true;
+                break;
+            }
+        }
+        return isImportantCuratedOcnogenicity;
+    }
+
     public static Set<Alteration> getOncogenicMutations(Alteration alteration) {
         Set<Alteration> oncogenicMutations = new HashSet<>();
         Alteration alt = findAlteration(alteration.getGene(), "oncogenic mutations");

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -151,7 +151,15 @@ public class IndicatorUtilsTest {
         // EGFR A289D is manually curated as likely neutral.
         query = new Query(null, null, null, "EGFR", "A289D", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);
         indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
-        assertEquals("The Oncogenicity is not Predicted Oncogenic, but it should be.", Oncogenicity.LIKELY_NEUTRAL.getOncogenic(), indicatorQueryResp.getOncogenic());
+        assertEquals("The Oncogenicity is not likely neutral, but it should be.", Oncogenicity.LIKELY_NEUTRAL.getOncogenic(), indicatorQueryResp.getOncogenic());
+
+        // BRAF R462I is manually curated as Likely Neutral, then the oncogenic mutations shouldn't be associated.
+        query = new Query(null, null, null, "BRAF", "R462I", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true);
+        assertEquals("The Oncogenicity is not likely neutral, but it should be.", Oncogenicity.LIKELY_NEUTRAL.getOncogenic(), indicatorQueryResp.getOncogenic());
+        assertEquals("The highest sensitive level of BRAF R462I should be null.", null, indicatorQueryResp.getHighestSensitiveLevel());
+        assertEquals("The highest resistance level of BRAF R462I should be null.", null, indicatorQueryResp.getHighestResistanceLevel());
+        assertEquals("The tumor type summary does not match.", "There are no FDA-approved or NCCN-compendium listed treatments specifically for patients with BRAF R462I mutant gastrointestinal stromal tumors.", indicatorQueryResp.getTumorTypeSummary());
 
         // Oncogenicity of Alternative Allele overwrites Inconclusive
         // C24Y is annotated as Inconclusive but C24R is Likely Oncogenic


### PR DESCRIPTION
If the alteration is manually curated not oncogenic. The Oncogenic
Mutations shouldn’t be mapped even the alternative alleles are oncogenic