### PR TITLE
Improve performance based on JProfiler

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/AlterationBo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/AlterationBo.java
@@ -44,7 +44,7 @@ public interface AlterationBo extends GenericBo<Alteration> {
      * @param end
      * @return
      */
-    List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end, List<Alteration> alterations);
+    List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end, Collection<Alteration> alterations);
 
     /**
      *

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -55,7 +55,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
     }
 
     @Override
-    public List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end, List<Alteration> alterations) {
+    public List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end, Collection<Alteration> alterations) {
         Set<Alteration> result = new HashSet<>();
 
         // Don't search for NA cases
@@ -209,14 +209,14 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         //Find Alternative Alleles for missense variant
         if (includeAlternativeAllele && alteration.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm("missense_variant"))) {
             alterations.addAll(AlterationUtils.getAlleleAlterations(alteration, fullAlterations));
-            List<Alteration> includeRangeAlts = findMutationsByConsequenceAndPosition(alteration.getGene(), alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), new ArrayList<>(fullAlterations));
+            List<Alteration> includeRangeAlts = findMutationsByConsequenceAndPosition(alteration.getGene(), alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations);
             for (Alteration alt : includeRangeAlts) {
                 if (!alterations.contains(alt)) {
                     alterations.add(alt);
                 }
             }
         } else {
-            alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), new ArrayList<>(fullAlterations)));
+            alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations));
         }
 
 
@@ -226,7 +226,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
         // Match all variants with `any` as consequence. Currently, only format start_end mut is supported.
         VariantConsequence anyConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm("any");
-        alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), anyConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), new ArrayList<>(fullAlterations)));
+        alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), anyConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations));
 
         // Remove all range mutations as relevant for truncating mutations in oncogenes
         oncogeneTruncMuts(alteration, alterations);
@@ -249,7 +249,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
         if (addTruncatingMutations) {
             VariantConsequence truncatingVariantConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm("feature_truncation");
-            alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), truncatingVariantConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), new ArrayList<>(fullAlterations)));
+            alterations.addAll(findMutationsByConsequenceAndPosition(alteration.getGene(), truncatingVariantConsequence, alteration.getProteinStart(), alteration.getProteinEnd(), fullAlterations));
         }
 
         if (addOncogenicMutations(alteration, alterations)) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/EvidenceBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/EvidenceBoImpl.java
@@ -10,6 +10,7 @@ import org.mskcc.cbio.oncokb.dao.EvidenceDao;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.util.CacheUtils;
 import org.mskcc.cbio.oncokb.model.oncotree.TumorType;
+import org.mskcc.cbio.oncokb.util.EvidenceUtils;
 
 import java.util.*;
 
@@ -23,8 +24,8 @@ public class EvidenceBoImpl extends GenericBoImpl<Evidence, EvidenceDao> impleme
         Set<Evidence> set = new LinkedHashSet<Evidence>();
         if (CacheUtils.isEnabled()) {
             Set<Alteration> alterationSet = new HashSet<>(alterations);
-            for (Evidence evidence : getAllEvidencesByAlterationsGenes(alterations)) {
-                if (Sets.intersection(evidence.getAlterations(), alterationSet).size() > 0) {
+            for (Evidence evidence : EvidenceUtils.getAllEvidencesByAlterationsGenes(alterations)) {
+                if (!Collections.disjoint(evidence.getAlterations(), alterationSet)) {
                     set.add(evidence);
                 }
             }
@@ -41,8 +42,8 @@ public class EvidenceBoImpl extends GenericBoImpl<Evidence, EvidenceDao> impleme
         Set<Evidence> set = new LinkedHashSet<Evidence>();
         Set<Alteration> altsSet = new HashSet<>(alterations);
         if (CacheUtils.isEnabled()) {
-            for (Evidence evidence : getAllEvidencesByAlterationsGenes(alterations)) {
-                if (!Collections.disjoint(evidence.getAlterations(), altsSet) && evidenceTypes.contains(evidence.getEvidenceType())) {
+            for (Evidence evidence : EvidenceUtils.getAllEvidencesByAlterationsGenes(alterations)) {
+                if (evidenceTypes.contains(evidence.getEvidenceType()) && !Collections.disjoint(evidence.getAlterations(), altsSet)) {
                     set.add(evidence);
                 }
             }
@@ -64,7 +65,7 @@ public class EvidenceBoImpl extends GenericBoImpl<Evidence, EvidenceDao> impleme
         Set<Evidence> set = new LinkedHashSet<Evidence>();
 
         if (CacheUtils.isEnabled()) {
-            for (Evidence evidence : getAllEvidencesByAlterationsGenes(alterations)) {
+            for (Evidence evidence : EvidenceUtils.getAllEvidencesByAlterationsGenes(alterations)) {
                 if (Sets.intersection(evidence.getAlterations(), new HashSet(alterations)).size() > 0
                     && evidenceTypes.contains(evidence.getEvidenceType())
                     && levelOfEvidences.contains(evidence.getLevelOfEvidence())) {
@@ -399,17 +400,5 @@ public class EvidenceBoImpl extends GenericBoImpl<Evidence, EvidenceDao> impleme
         } else {
             return getDao().findEvidenceByUUIDs(uuids);
         }
-    }
-
-    private Set<Evidence> getAllEvidencesByAlterationsGenes(Collection<Alteration> alterations) {
-        Set<Gene> genes = new HashSet<>();
-        Set<Evidence> evidences = new HashSet<>();
-        for (Alteration alteration : alterations) {
-            genes.add(alteration.getGene());
-        }
-        for (Gene gene : genes) {
-            evidences.addAll(CacheUtils.getEvidences(gene));
-        }
-        return evidences;
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -603,18 +603,14 @@ public final class AlterationUtils {
     }
 
     private static List<Alteration> getAlleleAlterationsSub(Alteration alteration, Set<Alteration> fullAlterations) {
-        List<Alteration> alterations = new ArrayList<>();
-
         if (alteration == null || alteration.getConsequence() == null ||
             !alteration.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm("missense_variant"))) {
-            return alterations;
+            return new ArrayList<>();
         }
-
-        alterations = new ArrayList<>(fullAlterations);
 
         List<Alteration> missenseVariants = alterationBo.findMutationsByConsequenceAndPosition(
             alteration.getGene(), VariantConsequenceUtils.findVariantConsequenceByTerm("missense_variant"), alteration.getProteinStart(),
-            alteration.getProteinEnd(), alterations);
+            alteration.getProteinEnd(), fullAlterations);
 
         List<Alteration> alleles = new ArrayList<>();
         for (Alteration alt : missenseVariants) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -271,10 +271,7 @@ public class EvidenceUtils {
         List<Evidence> evidences = new ArrayList<>();
 
         if (CacheUtils.isEnabled()) {
-            Set<Evidence> geneEvidences = new HashSet<>();
-            for (Alteration alteration : alterations) {
-                geneEvidences.addAll(CacheUtils.getEvidences(alteration.getGene()));
-            }
+            Set<Evidence> geneEvidences = getAllEvidencesByAlterationsGenes(alterations);
             for (Evidence evidence : geneEvidences) {
                 if (!Collections.disjoint(evidence.getAlterations(), alterations)) {
                     evidences.add(evidence);
@@ -997,6 +994,21 @@ public class EvidenceUtils {
 
         if (isDesc) {
             Collections.reverse(evidences);
+        }
+        return evidences;
+    }
+
+    public static Set<Evidence> getAllEvidencesByAlterationsGenes(Collection<Alteration> alterations) {
+        Set<Gene> genes = new HashSet<>();
+        Set<Evidence> evidences = new HashSet<>();
+        for (Alteration alteration : alterations) {
+            genes.add(alteration.getGene());
+        }
+        if (genes.size() == 1) {
+            return CacheUtils.getEvidences(genes.iterator().next());
+        }
+        for (Gene gene : genes) {
+            evidences.addAll(CacheUtils.getEvidences(gene));
         }
         return evidences;
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
@@ -407,7 +407,6 @@ public class TumorTypeUtils {
                                                 String key, String keyword, Boolean exactMatch, Boolean includeParent) {
         Map<String, TumorType> childrenTumorTypes = currentTumorType.getChildren();
         Boolean match = false;
-        Integer keywordAsInteger = convertStringToInteger(keyword);
 
         if (includeParent == null) {
             includeParent = false;
@@ -477,6 +476,7 @@ public class TumorTypeUtils {
                 }
                 break;
             case "level":
+                Integer keywordAsInteger = convertStringToInteger(keyword);
                 match = currentTumorType == null ? false :
                     (currentTumorType.getLevel() == null ? false :
                         (currentTumorType.getLevel() == null ? false :


### PR DESCRIPTION
1. Only parse string to integer when query by level
2. Try to avoid addAll when there is only one gene among alterations
3. Avoid converting set to list when Collection could be used as
parameter