### PR TITLE
Sort relevant alterations

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -85,7 +85,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         List<Alteration> resultList = new ArrayList<>(result);
-        AlterationUtils.sortAlterationsByTheRange(resultList);
+        AlterationUtils.sortAlterationsByTheRange(resultList, start, end);
         return resultList;
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -8,7 +8,6 @@ import com.mysql.jdbc.StringUtils;
 import org.mskcc.cbio.oncokb.bo.AlterationBo;
 import org.mskcc.cbio.oncokb.bo.EvidenceBo;
 import org.mskcc.cbio.oncokb.dao.AlterationDao;
-import org.mskcc.cbio.oncokb.dao.EvidenceDao;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.util.*;
 
@@ -85,7 +84,9 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             }
         }
 
-        return new ArrayList<>(result);
+        List<Alteration> resultList = new ArrayList<>(result);
+        AlterationUtils.sortAlterationsByTheRange(resultList);
+        return resultList;
     }
 
     @Override

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -690,6 +690,27 @@ public final class AlterationUtils {
         });
     }
 
+    public static void sortAlterationsByTheRange(List<Alteration> alterations) {
+        Collections.sort(alterations, new Comparator<Alteration>() {
+            @Override
+            public int compare(Alteration a1, Alteration a2) {
+                if (a1.getProteinStart() == null || a1.getProteinEnd() == null) {
+                    if (a2.getProteinStart() == null || a2.getProteinEnd() == null) {
+                        return 0;
+                    } else {
+                        return 1;
+                    }
+                }
+                if (a2.getProteinStart() == null || a2.getProteinEnd() == null) {
+                    return -1;
+                }
+                int range1 = a1.getProteinEnd() - a1.getProteinStart();
+                int range2 = a2.getProteinEnd() - a2.getProteinStart();
+                return range1 - range2;
+            }
+        });
+    }
+
     public static List<Alteration> getAlleleAndRelevantAlterations(Alteration alteration) {
         List<Alteration> alleles = getAlleleAlterations(alteration);
         Alteration oncogenicAllele = AlterationUtils.findOncogenicAllele(alleles);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -690,7 +690,7 @@ public final class AlterationUtils {
         });
     }
 
-    public static void sortAlterationsByTheRange(List<Alteration> alterations) {
+    public static void sortAlterationsByTheRange(List<Alteration> alterations, final int proteinStart, final int proteinEnd) {
         Collections.sort(alterations, new Comparator<Alteration>() {
             @Override
             public int compare(Alteration a1, Alteration a2) {
@@ -704,9 +704,16 @@ public final class AlterationUtils {
                 if (a2.getProteinStart() == null || a2.getProteinEnd() == null) {
                     return -1;
                 }
-                int range1 = a1.getProteinEnd() - a1.getProteinStart();
-                int range2 = a2.getProteinEnd() - a2.getProteinStart();
-                return range1 - range2;
+
+                int overlap1 = Math.min(a1.getProteinEnd(), proteinEnd) - Math.max(a1.getProteinStart(), proteinStart);
+                int overlap2 = Math.min(a2.getProteinEnd(), proteinEnd) - Math.max(a2.getProteinStart(), proteinStart);
+
+                if (overlap1 == overlap2) {
+                    int diff = a1.getProteinEnd() - a1.getProteinStart() - (a2.getProteinEnd() - a2.getProteinStart());
+                    return diff == 0 ? a1.getAlteration().compareTo(a2.getAlteration()) : diff;
+                } else {
+                    return overlap2 - overlap1;
+                }
             }
         });
     }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 public class AlterationUtilsTest extends TestCase
 {
     public void testSortAlterationsByTheRange() throws Exception {
+        int start = 8;
+        int end = 8;
         Integer[] starts = {0, 8, 8, null, 8};
         Integer[] ends = {10, 9, 8, 8, null};
         List<Alteration> alterationList = new ArrayList<>();
@@ -22,7 +24,7 @@ public class AlterationUtilsTest extends TestCase
             alt.setName(Integer.toString(i));
             alterationList.add(alt);
         }
-        AlterationUtils.sortAlterationsByTheRange(alterationList);
+        AlterationUtils.sortAlterationsByTheRange(alterationList, start, end);
         assertEquals(5, alterationList.size());
         assertEquals(alterationList.get(0).getProteinStart().intValue(), 8);
         assertEquals(alterationList.get(0).getProteinEnd().intValue(), 8);

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
@@ -3,10 +3,39 @@ package org.mskcc.cbio.oncokb.util;
 import junit.framework.TestCase;
 import org.mskcc.cbio.oncokb.model.Alteration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by Hongxin Zhang on 6/20/18.
  */
-public class AlterationUtilsTest extends TestCase {
+public class AlterationUtilsTest extends TestCase
+{
+    public void testSortAlterationsByTheRange() throws Exception {
+        Integer[] starts = {0, 8, 8, null, 8};
+        Integer[] ends = {10, 9, 8, 8, null};
+        List<Alteration> alterationList = new ArrayList<>();
+        for(int i = 0 ; i < starts.length;i++) {
+            Alteration alt = new Alteration();
+            alt.setProteinStart(starts[i]);
+            alt.setProteinEnd(ends[i]);
+            alt.setName(Integer.toString(i));
+            alterationList.add(alt);
+        }
+        AlterationUtils.sortAlterationsByTheRange(alterationList);
+        assertEquals(5, alterationList.size());
+        assertEquals(alterationList.get(0).getProteinStart().intValue(), 8);
+        assertEquals(alterationList.get(0).getProteinEnd().intValue(), 8);
+        assertEquals(alterationList.get(1).getProteinStart().intValue(), 8);
+        assertEquals(alterationList.get(1).getProteinEnd().intValue(), 9);
+        assertEquals(alterationList.get(2).getProteinStart().intValue(), 0);
+        assertEquals(alterationList.get(2).getProteinEnd().intValue(), 10);
+        assertEquals(alterationList.get(3).getProteinStart(), null);
+        assertEquals(alterationList.get(3).getProteinEnd().intValue(), 8);
+        assertEquals(alterationList.get(4).getProteinStart().intValue(), 8);
+        assertEquals(alterationList.get(4).getProteinEnd(), null);
+    }
+
     public void testIsPositionVariant() throws Exception {
         Alteration alteration = AlterationUtils.getAlteration("AKT1", "E17", null, "NA", null, null);
         assertTrue("This variant should be position variant.", AlterationUtils.isPositionVariant(alteration));

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
@@ -49,6 +49,9 @@ public class FindRelevantAlterationsTest {
                 // General truncating consequence should be associated with Truncating Mutations
                 // Check splice
                 {"TP53", "X33_splice", null, "X33_splice, Truncating Mutations, Oncogenic Mutations"},
+                {"MET", "X1010_splice", null, "X1010_splice, 981_1028splice, 963_D1010splice, Oncogenic Mutations"},
+                {"MET", "X1010splice", null, "X1010_splice, 981_1028splice, 963_D1010splice, Oncogenic Mutations"},
+
                 // Check stop_gained
                 {"MAP2K4", "R304*", null, "R304*, Truncating Mutations, Oncogenic Mutations"},
 

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
@@ -49,8 +49,8 @@ public class FindRelevantAlterationsTest {
                 // General truncating consequence should be associated with Truncating Mutations
                 // Check splice
                 {"TP53", "X33_splice", null, "X33_splice, Truncating Mutations, Oncogenic Mutations"},
-                {"MET", "X1010_splice", null, "X1010_splice, 981_1028splice, 963_D1010splice, Oncogenic Mutations"},
-                {"MET", "X1010splice", null, "X1010_splice, 981_1028splice, 963_D1010splice, Oncogenic Mutations"},
+                {"MET", "X1010_splice", null, "X1010_splice, 963_D1010splice, 981_1028splice, Oncogenic Mutations"},
+                {"MET", "X1010splice", null, "X1010_splice, 963_D1010splice, 981_1028splice, Oncogenic Mutations"},
 
                 // Check stop_gained
                 {"MAP2K4", "R304*", null, "R304*, Truncating Mutations, Oncogenic Mutations"},
@@ -75,8 +75,8 @@ public class FindRelevantAlterationsTest {
                 // Range missense variant
                 {"PDGFRA", "D842I", null, "D842I, D842H, D842V, D842Y, D842_I843delinsIM, Oncogenic Mutations"},
 
-                // Check whether the overlapped variants(with the same consequencwe) will be mapped
-                {"MAP2K1", "E41_F53del", null, "E41_F53del, E41_L54del, F53_Q58del, F53_Q58delinsL, E51_Q58del, Oncogenic Mutations"},
+                // Check whether the overlapped variants(with the same consequence) will be mapped
+                {"MAP2K1", "E41_F53del", null, "E41_F53del, E41_L54del, E51_Q58del, F53_Q58del, F53_Q58delinsL, Oncogenic Mutations"},
 
                 // Truncating Mutations in the Oncogene should not be mapped to any range mutation unless the consequence is truncating
                 {"KIT", "K509Nfs*2", null, ""},

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -209,6 +209,7 @@ public class IndicatorUtilsTest {
         assertEquals("The Oncogenicity is not oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The variant summary is not expected.", "The EGFR kinase domain duplication (KDD) alteration is known to be oncogenic.", indicatorQueryResp.getVariantSummary());
         assertEquals("The highest sensitive level should be 1", LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
+
         // Check FLT3 ITD
         query = new Query(null, null, null, "FLT3", "ITD", null, null, "AML", null, null, null, null);
         indicatorQueryResp = IndicatorUtils.processQuery(query, null, null, "cbioportal", true, null);


### PR DESCRIPTION
1. Sort based on the length of the overlap if the relevant is range mutation, the bigger overlap range will be prioritized.
2. Sort based on the length of the range mutation, the shorter range mutation will be prioritized.

Checked the system that we do support range splice mutation
Related to #1257
