### PR TITLE
solve cursor moving issue

### DIFF
--- a/web/yo/app/scripts/directives/realtimestring.js
+++ b/web/yo/app/scripts/directives/realtimestring.js
@@ -56,8 +56,11 @@ angular.module('oncokbApp')
                         if (n !== o && !_.isUndefined(n)) {
                             if (!scope.data || !scope.data[scope.key+'_editing'] || scope.data[scope.key+'_editing'] === $rootScope.me.name) {
                                 if (!$rootScope.reviewMode || ReviewResource.rejected.indexOf(scope.uuid) === -1) {     
-                                    mainUtils.updateLastModified();
-                                    scope.data[scope.key] = OncoKB.utils.getString(scope.data[scope.key]);                  
+                                    mainUtils.updateLastModified();   
+                                    if (scope.pasting === true) {
+                                        scope.data[scope.key] = OncoKB.utils.getString(scope.data[scope.key]);    
+                                        scope.pasting = false;        
+                                    }   
                                     scope.pContent = scope.data[scope.key];
                                     if (scope.t === 'treatment-select' && scope.key === 'level') {
                                         scope.changePropagation();
@@ -308,6 +311,9 @@ angular.module('oncokbApp')
                         tumor: tumor
                     });
                 };
+                $scope.trimCSS = function() {
+                    $scope.pasting = true;
+                }
             }
         };
     })

--- a/web/yo/app/views/realtimeString.html
+++ b/web/yo/app/views/realtimeString.html
@@ -7,7 +7,8 @@
                     <p contenteditable="{{fe}}"
                         ng-class="getInputClass()"
                         ng-model="data[key]"
-                        ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 2000, 'blur': 0 } }">
+                        ng-paste="trimCSS()"
+                        ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 200, 'blur': 0 } }">
                      </p>
                     <pub-iframe
                             ng-model="pContent">
@@ -19,7 +20,8 @@
                         ng-class="getInputClass()"
                         ng-model="data[key]"
                         ng-click="setTrackSignal()"
-                        ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 2000, 'blur': 0 } }"
+                        ng-paste="trimCSS()"
+                        ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 200, 'blur': 0 } }"
                         class="editEmpty">
                     </p>
                     <!-- <span style="color:red">{{getDuplicationMessage()}}</span> -->
@@ -83,7 +85,8 @@
                     <p contenteditable="{{reviewContentEditable('regular')}}"
                        ng-class="getInputClass()"
                        ng-model="data[key]"
-                       ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 2000, 'blur': 0 } }">
+                       ng-paste="trimCSS()"
+                       ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 200, 'blur': 0 } }">
                     </p>
                     <div ng-if="reviewLayout('regular')">
                         <h4>Difference comparing to the old content:</h4>
@@ -98,7 +101,8 @@
                     <p contenteditable="{{reviewContentEditable('regular')}}"
                           ng-class="editableBox"
                           ng-model="data[key]"
-                          ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 2000, 'blur': 0 } }"
+                          ng-paste="trimCSS()"
+                          ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 200, 'blur': 0 } }"
                           class="editEmpty">
                     </p>
                     <div ng-if="reviewLayout('name')" ng-class="getOldContentDivClass(data[key])">


### PR DESCRIPTION
Two things to highlight:
a) 2 seconds was changed to 0.2 seconds to reduce the risk of a curator losing data in the case that, multiple people edit on the same section at the same time
b) The 2 seconds debouce delay we added should already to keep the cursor stable. But since we re-assign the data[key] value after removing CSS style, the cursor moves to the very beginning. The solution is to only run the function to strip CSS when copy and paste happens.