### PR TITLE
Look for alteration based on protein change and name

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/AlterationBo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/AlterationBo.java
@@ -4,31 +4,30 @@
  */
 package org.mskcc.cbio.oncokb.bo;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.mskcc.cbio.oncokb.model.Alteration;
 import org.mskcc.cbio.oncokb.model.AlterationType;
 import org.mskcc.cbio.oncokb.model.Gene;
 import org.mskcc.cbio.oncokb.model.VariantConsequence;
 
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
- *
  * @author jgao
  */
 public interface AlterationBo extends GenericBo<Alteration> {
 
     /**
      * Get set of alterations by entrez gene Ids.
+     *
      * @param genes
      * @return
      */
     List<Alteration> findAlterationsByGene(Collection<Gene> genes);
 
     /**
-     *
      * @param gene
      * @param alterationType
      * @param alteration
@@ -36,8 +35,27 @@ public interface AlterationBo extends GenericBo<Alteration> {
      */
     Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration);
 
+    Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration, String name);
+
     /**
-     *
+     * @param gene
+     * @param alterationType
+     * @param alteration
+     * @return
+     */
+    Alteration findAlterationFromDao(Gene gene, AlterationType alterationType, String alteration);
+
+    /**
+     * @param gene
+     * @param alterationType
+     * @param alteration
+     * @param name
+     * @return
+     */
+    Alteration findAlterationFromDao(Gene gene, AlterationType alterationType, String alteration, String name);
+
+
+    /**
      * @param gene
      * @param consequence
      * @param start
@@ -47,7 +65,6 @@ public interface AlterationBo extends GenericBo<Alteration> {
     List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end, Collection<Alteration> alterations);
 
     /**
-     *
      * @param gene
      * @param consequence
      * @param start
@@ -57,14 +74,12 @@ public interface AlterationBo extends GenericBo<Alteration> {
     List<Alteration> findMutationsByConsequenceAndPositionOnSamePosition(Gene gene, VariantConsequence consequence, int start, int end, Collection<Alteration> alterations);
 
     /**
-     *
      * @param alteration
      * @return
      */
     LinkedHashSet<Alteration> findRelevantAlterations(Alteration alteration, boolean includeAlternativeAllele);
 
     /**
-     *
      * @param alteration
      * @return
      */

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -413,6 +413,8 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                     if (isOncogenic != null && isOncogenic) {
                         add = true;
                     }
+                } else if (HotspotUtils.isHotspot(exactAlt)) {
+                    add = true;
                 } else {
                     // When we look at the oncogenicity, the VUS relevant variants should be excluded.
                     for (Alteration alt : AlterationUtils.excludeVUS(new ArrayList<>(relevantAlts))) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -45,13 +45,44 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         return null;
     }
 
+    private Alteration findAlteration(String alteration, String name, Set<Alteration> fullAlterations) {
+        if (alteration == null) {
+            return null;
+        }
+        for (Alteration alt : fullAlterations) {
+            if (alt.getAlteration() != null && alt.getAlteration().equalsIgnoreCase(alteration) && alt.getName().equalsIgnoreCase(name)) {
+                return alt;
+            }
+        }
+        return null;
+    }
+
     @Override
     public Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration) {
         if (CacheUtils.isEnabled()) {
             return findAlteration(alteration, CacheUtils.getAlterations(gene.getEntrezGeneId()));
         } else {
-            return getDao().findAlteration(gene, alterationType, alteration);
+            return findAlterationFromDao(gene, alterationType, alteration);
         }
+    }
+
+    @Override
+    public Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration, String name) {
+        if (CacheUtils.isEnabled()) {
+            return findAlteration(alteration, name, CacheUtils.getAlterations(gene.getEntrezGeneId()));
+        } else {
+            return findAlterationFromDao(gene, alterationType, alteration, name);
+        }
+    }
+
+    @Override
+    public Alteration findAlterationFromDao(Gene gene, AlterationType alterationType, String alteration) {
+        return getDao().findAlteration(gene, alterationType, alteration);
+    }
+
+    @Override
+    public Alteration findAlterationFromDao(Gene gene, AlterationType alterationType, String alteration, String name) {
+        return getDao().findAlteration(gene, alterationType, alteration, name);
     }
 
     @Override
@@ -140,7 +171,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
      */
     @Override
     public LinkedHashSet<Alteration> findRelevantAlterations(Alteration alteration, Set<Alteration> fullAlterations, boolean includeAlternativeAllele) {
-        if(fullAlterations == null) {
+        if (fullAlterations == null) {
             return new LinkedHashSet<>();
         }
         return findRelevantAlterationsSub(alteration, fullAlterations, includeAlternativeAllele);
@@ -151,11 +182,11 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
         Set<Alteration> relatedAlts = new HashSet<>();
         List<Alteration> noMappingAlts = new ArrayList<>();
-        for(Evidence evidence : evidenceBo.findEvidencesByGeneFromDB(Collections.singleton(gene))) {
+        for (Evidence evidence : evidenceBo.findEvidencesByGeneFromDB(Collections.singleton(gene))) {
             relatedAlts.addAll(evidence.getAlterations());
         }
-        for(Alteration alteration : findAlterationsByGene(Collections.singleton(gene))){
-            if(!relatedAlts.contains(alteration)) {
+        for (Alteration alteration : findAlterationsByGene(Collections.singleton(gene))) {
+            if (!relatedAlts.contains(alteration)) {
                 noMappingAlts.add(alteration);
             }
         }
@@ -291,7 +322,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         if (addDeletion) {
-            Alteration deletion = findAlteration( "Deletion", fullAlterations);
+            Alteration deletion = findAlteration("Deletion", fullAlterations);
             if (deletion != null) {
                 alterations.add(deletion);
 
@@ -306,7 +337,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         if (addOncogenicMutations(alteration, alterations)) {
-            Alteration oncogenicMutations = findAlteration( "oncogenic mutations", fullAlterations);
+            Alteration oncogenicMutations = findAlteration("oncogenic mutations", fullAlterations);
             if (oncogenicMutations != null) {
                 alterations.add(oncogenicMutations);
             }
@@ -329,7 +360,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         for (String effect : effects) {
-            Alteration alt = findAlteration( effect + " mutations", fullAlterations);
+            Alteration alt = findAlteration(effect + " mutations", fullAlterations);
             if (alt != null) {
                 alterations.add(alt);
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/dao/AlterationDao.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/dao/AlterationDao.java
@@ -4,27 +4,27 @@
  */
 package org.mskcc.cbio.oncokb.dao;
 
-import java.util.List;
 import org.mskcc.cbio.oncokb.model.Alteration;
 import org.mskcc.cbio.oncokb.model.AlterationType;
 import org.mskcc.cbio.oncokb.model.Gene;
 import org.mskcc.cbio.oncokb.model.VariantConsequence;
 
+import java.util.List;
+
 /**
- *
  * @author jgao
  */
 public interface AlterationDao extends GenericDao<Alteration, Integer> {
 
     /**
      * Get set of alterations by entrez gene Id.
+     *
      * @param gene
      * @return
      */
     List<Alteration> findAlterationsByGene(Gene gene);
 
     /**
-     *
      * @param gene
      * @param alterationType
      * @param alteration
@@ -32,8 +32,17 @@ public interface AlterationDao extends GenericDao<Alteration, Integer> {
      */
     Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration);
 
+
     /**
-     *
+     * @param gene
+     * @param alterationType
+     * @param alteration
+     * @param name
+     * @return
+     */
+    Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration, String name);
+
+    /**
      * @param gene
      * @param consequence
      * @param start
@@ -43,7 +52,6 @@ public interface AlterationDao extends GenericDao<Alteration, Integer> {
     List<Alteration> findMutationsByConsequenceAndPosition(Gene gene, VariantConsequence consequence, int start, int end);
 
     /**
-     *
      * @param gene
      * @param consequence
      * @param start

--- a/core/src/main/java/org/mskcc/cbio/oncokb/dao/impl/AlterationDaoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/dao/impl/AlterationDaoImpl.java
@@ -4,12 +4,13 @@
  */
 package org.mskcc.cbio.oncokb.dao.impl;
 
-import java.util.List;
 import org.mskcc.cbio.oncokb.dao.AlterationDao;
 import org.mskcc.cbio.oncokb.model.Alteration;
 import org.mskcc.cbio.oncokb.model.AlterationType;
 import org.mskcc.cbio.oncokb.model.Gene;
 import org.mskcc.cbio.oncokb.model.VariantConsequence;
+
+import java.util.List;
 
 /**
  *
@@ -24,6 +25,12 @@ public class AlterationDaoImpl extends GenericDaoImpl<Alteration, Integer> imple
     @Override
     public Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration) {
         List<Alteration> alterations = findByNamedQuery("findAlteration", gene, alteration);
+        return alterations.isEmpty() ? null : alterations.get(0);
+    }
+
+    @Override
+    public Alteration findAlteration(Gene gene, AlterationType alterationType, String alteration, String name) {
+        List<Alteration> alterations = findByNamedQuery("findAlterationByAlterationAndName", gene, alteration, name);
         return alterations.isEmpty() ? null : alterations.get(0);
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Alteration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Alteration.java
@@ -26,6 +26,10 @@ import java.util.Set;
         query = "select a from Alteration a where a.gene=? and a.alteration=?"
     ),
     @NamedQuery(
+        name = "findAlterationByAlterationAndName",
+        query = "select a from Alteration a where a.gene=? and a.alteration=? and a.name=?"
+    ),
+    @NamedQuery(
         name = "findMutationsByConsequence",
         query = "select a from Alteration a where a.gene=? and a.consequence=?"
     ),
@@ -204,24 +208,27 @@ public class Alteration implements java.io.Serializable {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Alteration)) return false;
+
+        Alteration that = (Alteration) o;
+
+        if (getUuid() != null ? !getUuid().equals(that.getUuid()) : that.getUuid() != null) return false;
+        if (getGene() != null ? !getGene().equals(that.getGene()) : that.getGene() != null) return false;
+        if (getAlterationType() != that.getAlterationType()) return false;
+        if (getConsequence() != null ? !getConsequence().equals(that.getConsequence()) : that.getConsequence() != null)
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (getAlteration() != null ? !getAlteration().equals(that.getAlteration()) : that.getAlteration() != null)
             return false;
-        }
-        final Alteration other = (Alteration) obj;
-        if (this.gene != other.gene && (this.gene == null || !this.gene.equals(other.gene))) {
+        if (getName() != null ? !getName().equals(that.getName()) : that.getName() != null) return false;
+        if (getRefResidues() != null ? !getRefResidues().equals(that.getRefResidues()) : that.getRefResidues() != null)
             return false;
-        }
-        if ((this.alteration == null) ? (other.alteration != null) : !this.alteration.equals(other.alteration)) {
+        if (getProteinStart() != null ? !getProteinStart().equals(that.getProteinStart()) : that.getProteinStart() != null)
             return false;
-        }
-        if ((this.alterationType == null) ? (other.alterationType != null) : !this.alterationType.equals(other.alterationType)) {
+        if (getProteinEnd() != null ? !getProteinEnd().equals(that.getProteinEnd()) : that.getProteinEnd() != null)
             return false;
-        }
-        return true;
+        return getVariantResidues() != null ? getVariantResidues().equals(that.getVariantResidues()) : that.getVariantResidues() == null;
     }
 
     @Override

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -896,7 +896,7 @@ public class EvidenceUtils {
             for (Alteration alt : queryAlterations) {
                 String proteinChange = alt.getAlteration();
                 String displayName = alt.getName();
-                Alteration alteration = alterationBo.findAlteration(gene, type, proteinChange);
+                Alteration alteration = alterationBo.findAlterationFromDao(gene, type, proteinChange, displayName);
                 if (alteration == null) {
                     alteration = new Alteration();
                     alteration.setGene(gene);
@@ -950,9 +950,8 @@ public class EvidenceUtils {
     }
 
     /**
-     *
      * @param evidences
-     * @param isDesc default is false
+     * @param isDesc    default is false
      * @return
      */
     public static List<Evidence> sortTumorTypeEvidenceBasedNumOfAlts(List<Evidence> evidences, Boolean isDesc) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
@@ -34,6 +34,7 @@ public class FindRelevantAlterationsTest {
             new String[][]{
                 // Critical cases
                 {"BRAF", "V600E", null, "V600E, V600A, V600D, V600G, V600K, V600L, V600M, V600Q, V600R, VK600EI, Oncogenic Mutations"},
+                {"SMARCB1", "R374Q", null, "R374Q, R374W, Oncogenic Mutations"},
 
                 // Check Fusions
                 {"BRAF", "PAPSS1-BRAF Fusion", null, "PAPSS1-BRAF Fusion, Fusions, Oncogenic Mutations"},


### PR DESCRIPTION
This solves issue #1284
The issue is when we looking for alteration, we compare the protein change only. When we try to update the display name, since you always get the same alteration then you will use the old one assigned to new evidence which the new alteration should be created.

This solves issue #1194
The issue is caused when checking whether to add Oncogenic Mutations.