### PR TITLE
Save all genes bug fix

### DIFF
--- a/web/yo/app/scripts/controllers/genes.js
+++ b/web/yo/app/scripts/controllers/genes.js
@@ -38,7 +38,9 @@ angular.module('oncokbApp')
                         saveGene(++docIndex);
                     }
                 } else {
-                    $scope.status.saveAllGenes = true;
+                    $scope.$apply(function() {
+                        $scope.status.saveAllGenes = true;
+                    });
                     console.log('finished.');
                 }
             }


### PR DESCRIPTION
Solve Issue #1246
After testing, I didn't see the issue mentioned in ##1246 directly, which might already be solved by previous save all genes bug fix.  

But I do notice another issue, which is the spinning loading bar never got set back even after "Save All Genes" function is finished.  That is actually a great example where we should call $apply manually, which was explained perfectly [in this article ](https://www.sitepoint.com/understanding-angulars-apply-digest/). Basically, angular has no way of knowing we want to update status.saveAllGenes after such a long time to finish saving all genes. We need to trigger the $digest cycle manually by calling $apply.