### PR TITLE
Avoid Name Updated happening when delete mutations

### DIFF
--- a/web/yo/app/index.html
+++ b/web/yo/app/index.html
@@ -225,6 +225,7 @@
     <script src="scripts/directives/reportviewrecursioncell.js"></script>
     <script src="scripts/services/mainutils.js"></script>
     <script src="scripts/services/numofreviewitems.js"></script>
+    <script src="scripts/services/checknamechange.js"></script>
     <!-- endbuild -->
 
 </body>

--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('oncokbApp')
-    .controller('GeneCtrl', ['_', 'S', '$resource', '$interval', '$timeout', '$scope', '$rootScope', '$location', '$route', '$routeParams', '$window', '$q', 'dialogs', 'OncoKB', 'DatabaseConnector', 'SecretEmptyKey', '$sce', 'jspdf', 'FindRegex', 'mainUtils', 'ReviewResource', 'loadFiles', '$firebaseObject', '$firebaseArray', 'FirebaseModel', 'user', 'numOfReviewItems',
-        function (_, S, $resource, $interval, $timeout, $scope, $rootScope, $location, $route, $routeParams, $window, $q, dialogs, OncoKB, DatabaseConnector, SecretEmptyKey, $sce, jspdf, FindRegex, mainUtils, ReviewResource, loadFiles, $firebaseObject, $firebaseArray, FirebaseModel, user, numOfReviewItems) {
+    .controller('GeneCtrl', ['_', 'S', '$resource', '$interval', '$timeout', '$scope', '$rootScope', '$location', '$route', '$routeParams', '$window', '$q', 'dialogs', 'OncoKB', 'DatabaseConnector', 'SecretEmptyKey', '$sce', 'jspdf', 'FindRegex', 'mainUtils', 'ReviewResource', 'loadFiles', '$firebaseObject', '$firebaseArray', 'FirebaseModel', 'user', 'numOfReviewItems', 'checkNameChange',
+        function (_, S, $resource, $interval, $timeout, $scope, $rootScope, $location, $route, $routeParams, $window, $q, dialogs, OncoKB, DatabaseConnector, SecretEmptyKey, $sce, jspdf, FindRegex, mainUtils, ReviewResource, loadFiles, $firebaseObject, $firebaseArray, FirebaseModel, user, numOfReviewItems, checkNameChange) {
             checkReadPermission();
             // Check permission for user who can only read and write specific genes.
             function checkReadPermission() {
@@ -30,6 +30,7 @@ angular.module('oncokbApp')
             $window.onbeforeunload = function () {
                 removeCollaborator();
             }
+            checkNameChange.clear();
             function checkValidUrl() {
                 $scope.hugoSymbols = _.without(_.keys($rootScope.metaData), 'collaborators');
                 if (!$scope.hugoSymbols.includes($routeParams.geneName)) {
@@ -371,6 +372,7 @@ angular.module('oncokbApp')
             };
             $scope.exitReview = function () {
                 numOfReviewItems.clear();
+                checkNameChange.clear();
                 $scope.geneMeta.review.currentReviewer = '';
                 $rootScope.fileEditable = true;
                 evidencesAllUsers = {};
@@ -1961,6 +1963,9 @@ angular.module('oncokbApp')
                     removeModel({ type: type, indicies: indicies, uuids: allUUIDs });
                     ReviewResource.loading = _.without(ReviewResource.loading, loadingUUID);
                     numOfReviewItems.minus(updatedBy);
+                    if (type === 'mutation') {
+                        checkNameChange.set(true);
+                    }
                 }, function (error) {
                     dialogs.error('Error', 'Failed to update to database! Please contact the developer.');
                     ReviewResource.loading = _.without(ReviewResource.loading, loadingUUID);

--- a/web/yo/app/scripts/directives/realtimestring.js
+++ b/web/yo/app/scripts/directives/realtimestring.js
@@ -7,7 +7,7 @@
  * # driveRealtimeString
  */
 angular.module('oncokbApp')
-    .directive('realtimeString', function ($timeout, _, $rootScope, mainUtils, ReviewResource, $firebaseObject) {
+    .directive('realtimeString', function ($timeout, _, $rootScope, mainUtils, ReviewResource, $firebaseObject, checkNameChange) {
         return {
             templateUrl: 'views/realtimeString.html',
             restrict: 'AE',
@@ -55,25 +55,25 @@ angular.module('oncokbApp')
                     scope.$watch('data[key]', function (n, o) {
                         if (n !== o && !_.isUndefined(n)) {
                             if (!scope.data || !scope.data[scope.key+'_editing'] || scope.data[scope.key+'_editing'] === $rootScope.me.name) {
-                                if (!$rootScope.reviewMode || ReviewResource.rejected.indexOf(scope.uuid) === -1) {     
-                                    mainUtils.updateLastModified();   
+                                if (!$rootScope.reviewMode || ReviewResource.rejected.indexOf(scope.uuid) === -1) {
+                                    mainUtils.updateLastModified();
                                     if (scope.pasting === true) {
-                                        scope.data[scope.key] = OncoKB.utils.getString(scope.data[scope.key]);    
-                                        scope.pasting = false;        
-                                    }   
+                                        scope.data[scope.key] = OncoKB.utils.getString(scope.data[scope.key]);
+                                        scope.pasting = false;
+                                    }
                                     scope.pContent = scope.data[scope.key];
                                     if (scope.t === 'treatment-select' && scope.key === 'level') {
                                         scope.changePropagation();
                                     }
-                                    if (scope.key !== 'short' && !(scope.key === 'name' && $rootScope.movingSection)) {
+                                    if (scope.key !== 'short' && !(scope.key === 'name' && ($rootScope.movingSection || checkNameChange.get()))) {
                                         scope.setReviewRelatedContent(n, o, false);
                                     }
-                                }  
+                                }
                                 if (n !== o && (scope.key === 'level' || scope.key === 'summary' && scope.mutation && scope.tumor)) {
                                     $timeout(function() {
                                         scope.indicateMutationContent(scope.mutation);
                                         scope.indicateTumorContent(scope.tumor);
-                                    }, 500);                            
+                                    }, 500);
                                 }
                             }
                             if (scope.t === 'p' || scope.t === 'short') {
@@ -92,7 +92,7 @@ angular.module('oncokbApp')
                             if ($rootScope.reviewMode && ['p', 'MUTATION_NAME', 'TREATMENT_NAME'].indexOf(scope.t) !== -1) {
                                 scope.calculateDiff();
                             }
-                        }                                               
+                        }
                     });
                     $rootScope.$watch('fileEditable', function(n, o) {
                         if (n !== o) {
@@ -117,7 +117,7 @@ angular.module('oncokbApp')
                         scope.data[key + '_review'].updateTime = new Date().getTime();
                         if ((!$rootScope.reviewMeta[uuid] || _.isUndefined(scope.data[key + '_review'].lastReviewed)) && !_.isUndefined(o)) {
                             scope.data[key + '_review'].lastReviewed = o;
-                            mainUtils.setUUIDInReview(uuid);                                    
+                            mainUtils.setUUIDInReview(uuid);
                             ReviewResource.rollback = _.without(ReviewResource.rollback, uuid);
                         } else if (n === scope.data[key + '_review'].lastReviewed) {
                             delete scope.data[key + '_review'].lastReviewed;
@@ -162,7 +162,7 @@ angular.module('oncokbApp')
                         } else {
                             $scope.fe = false;
                             $scope.editingMessage = 'Please wait. ' + $scope.data[$scope.key+'_editing'] + ' is editing this section...';
-                        }                        
+                        }
                     } else {
                         $scope.fe = $rootScope.fileEditable;
                     }
@@ -176,7 +176,7 @@ angular.module('oncokbApp')
                     if (!initial && $scope.data.propagation_review) {
                         delete $scope.data.propagation_review.lastReviewed;
                         mainUtils.deleteUUID($scope.data.propagation_uuid);
-                    }                    
+                    }
                     var _propagationOpts = [];
                     if ($scope.data[$scope.key] === '1' || $scope.data[$scope.key] === '2A') {
                         _propagationOpts = [
@@ -256,7 +256,7 @@ angular.module('oncokbApp')
                         if (_.isUndefined($scope.data[$scope.key+'_review']) || _.isUndefined($scope.data[$scope.key+'_review'].lastReviewed)) {
                             return $scope.data[$scope.key] === checkbox;
                         }
-                    } 
+                    }
                     return $scope.data && $scope.data[$scope.key+'_review'] && $scope.data[$scope.key+'_review'].lastReviewed === checkbox;
                 }
                 $scope.reviewLayout = function (type) {

--- a/web/yo/app/scripts/services/checknamechange.js
+++ b/web/yo/app/scripts/services/checknamechange.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * @ngdoc factory
+ * @name oncokbApp.checkNameChange
+ * @description
+ * # checkNameChange
+ * This factory is used for checking if mutations are deleted in Review mode.
+ * If mutations are deleted, we should avoid setReviewRelatedContent() triggered in realtimestring.js.
+ * Otherwise, each mutation will be moved forward 1 index in firebase which mislead plenty of "Name Updated" changes in review mode.
+ */
+angular.module('oncokbApp')
+    .factory('checkNameChange', function() {
+        var hasDeletedMutation = false;
+
+        function clear() {
+            hasDeletedMutation = false;
+        }
+        function get() {
+            return hasDeletedMutation;
+        }
+        function set(bool) {
+            hasDeletedMutation = bool;
+        }
+
+        return {
+            clear: clear,
+            get: get,
+            set: set
+        };
+    });


### PR DESCRIPTION
Issue: 
If mutations are deleted, we should avoid setReviewRelatedContent() triggered in realtimestring.js. Otherwise, each mutation will be moved forward 1 index in firebase which mislead plenty of "Name Updated" changes in review mode.

![screen shot 2018-07-31 at 5 23 25 pm](https://user-images.githubusercontent.com/14971266/43534098-7dfe2d02-9584-11e8-8921-67acdca4719a.png)
