### PR TITLE
Switch to spotify/dockerfile-maven + webapp-runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
             wget -O - http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
                 tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
 script:
-    - mvn -Pbackend,docker -DskipTests clean install
+    - mvn -Pbackend -DskipTests clean install
 after_success:
     - |
         if [[ "$TRAVIS_TAG" ]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - "JAVA_OPTS=-Djdbc.driverClassName=com.mysql.jdbc.Driver -Djdbc.url='jdbc:mysql://db:3306/oncokb?useUnicode=yes&characterEncoding=UTF-8' -Djdbc.username=root -Djdbc.password='test'"
+      - "JAVA_OPTS=-Djdbc.driverClassName=com.mysql.jdbc.Driver -Djdbc.url=jdbc:mysql://db:3306/oncokb?useUnicode=yes&characterEncoding=UTF-8&useSSL=false -Djdbc.username=root -Djdbc.password=test"
     depends_on:
       - db
   db:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jre
+COPY target/dependency/webapp-runner.jar /webapp-runner.jar
+COPY target/*.war /app.war
+# specify default command
+ENTRYPOINT /usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEBAPPRUNNER_OPTS} /app.war

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -185,43 +185,6 @@
         <profile>
             <id>backend</id>
         </profile>
-        <profile>
-            <id>docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.4.13</version>
-                        <configuration>
-                            <imageName>cbioportal/oncokb</imageName>
-                            <baseImage>tomcat:8-alpine</baseImage>
-                            <entryPoint>["catalina.sh", "run"]</entryPoint>
-                            <imageTags>
-                                <imageTag>${project.version}</imageTag>
-                                <imageTag>latest</imageTag>
-                            </imageTags>
-                            <resources>
-                                <resource>
-                                    <targetPath>/usr/local/tomcat/webapps</targetPath>
-                                    <directory>${project.build.directory}</directory>
-                                    <include>${project.build.finalName}.war</include>
-                                </resource>
-                            </resources>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <properties>
@@ -404,6 +367,50 @@
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.github.jsimone</groupId>
+                                    <artifactId>webapp-runner</artifactId>
+                                    <version>8.0.24.0</version>
+                                    <destFileName>webapp-runner.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <groupId>com.spotify</groupId>
+              <artifactId>dockerfile-maven-plugin</artifactId>
+              <version>1.4.8</version>
+              <executions>
+                <execution>
+                  <id>default</id>
+                  <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <repository>cbioportal/oncokb</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                  <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+              </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Using webapp-runner provides an easier command line interface to tomcat imo.
Change the docker image also to mount at root instead of at /oncokb/ path.
Changed the docker generation to use spotify/dockerfile-maven, this is
recommended new way to generate docker files using maven.