### PR TITLE
Fix docker container image generation for AWS/Kubernetes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
             wget -O - http://www-us.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
                 tar -C ~/maven/$MAVEN_VERSION --strip-components=1 -xzf -; }
 script:
-    - mvn -Pbackend,docker -DskipTests clean install
+    - mvn -Pbackend -DskipTests clean install
 after_success:
     - |
         if [[ "$TRAVIS_TAG" ]]

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,12 +50,6 @@
                 <artifactId>dom4j</artifactId>
                 <version>1.6.1</version>
         </dependency>
-
-	 <dependency>
-	  <groupId>javax.transaction</groupId>
-	  <artifactId>jta</artifactId>
-	  <version>1.0.1B</version>
-	 </dependency>
 	 <dependency>
 	  <groupId>mysql</groupId>
 	  <artifactId>mysql-connector-java</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,11 +52,6 @@
         </dependency>
 
 	 <dependency>
-	  <groupId>javax.sql</groupId>
-	  <artifactId>jdbc-stdext</artifactId>
-	  <version>2.0</version>
-	 </dependency>
-	 <dependency>
 	  <groupId>javax.transaction</groupId>
 	  <artifactId>jta</artifactId>
 	  <version>1.0.1B</version>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - "JAVA_OPTS=-Djdbc.driverClassName=com.mysql.jdbc.Driver -Djdbc.url='jdbc:mysql://db:3306/oncokb?useUnicode=yes&characterEncoding=UTF-8' -Djdbc.username=root -Djdbc.password='test'"
+      - "JAVA_OPTS=-Djdbc.driverClassName=com.mysql.jdbc.Driver -Djdbc.url=jdbc:mysql://db:3306/oncokb?useUnicode=yes&characterEncoding=UTF-8&useSSL=false -Djdbc.username=root -Djdbc.password=test"
     depends_on:
       - db
   db:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jre
+COPY target/dependency/webapp-runner.jar /webapp-runner.jar
+COPY target/*.war /app.war
+# specify default command
+ENTRYPOINT /usr/bin/java ${JAVA_OPTS} -jar /webapp-runner.jar ${WEBAPPRUNNER_OPTS} /app.war

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -254,16 +254,6 @@
             <version>1.1</version>
         </dependency>
         <dependency>
-            <groupId>javax.sql</groupId>
-            <artifactId>jdbc-stdext</artifactId>
-            <version>2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>jta</artifactId>
-            <version>1.0.1B</version>
-        </dependency>
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.6</version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -24,6 +24,38 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.0</version>
+
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- See https://nodejs.org/en/download/ for latest node and npm (lts) versions -->
+                                    <nodeVersion>v8.12.0</nodeVersion>
+                                    <npmVersion>6.4.1</npmVersion>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>npm install</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <workingDirectory>${web.folder}</workingDirectory>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>com.github.trecloux</groupId>
                         <artifactId>yeoman-maven-plugin</artifactId>
                         <version>0.5</version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -50,25 +50,40 @@
                                     <arguments>install</arguments>
                                 </configuration>
                             </execution>
-                        </executions>
-                        <configuration>
-                            <workingDirectory>${web.folder}</workingDirectory>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>com.github.trecloux</groupId>
-                        <artifactId>yeoman-maven-plugin</artifactId>
-                        <version>0.5</version>
-                        <executions>
+
                             <execution>
+                                <id>bower install</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>bower</goal>
                                 </goals>
+
+                                <configuration>
+                                    <!-- optional: The default argument is actually
+                                    "install", so unless you need to run some other bower command,
+                                    you can remove this whole <configuration> section.
+                                    -->
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>grunt build</id>
+                                <goals>
+                                    <goal>grunt</goal>
+                                </goals>
+
+                                <!-- optional: the default phase is "generate-resources" -->
+                                <phase>generate-resources</phase>
+
+                                <configuration>
+                                    <!-- optional: if not specified, it will run Grunt's default
+                                    task (and you can remove this whole <configuration> section.) -->
+                                    <arguments>build</arguments>
+                                </configuration>
                             </execution>
                         </executions>
                         <configuration>
-                            <skipTests>true</skipTests>
-                            <yeomanProjectDirectory>${web.folder}</yeomanProjectDirectory>
+                            <workingDirectory>${web.folder}</workingDirectory>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -185,43 +185,6 @@
         <profile>
             <id>backend</id>
         </profile>
-        <profile>
-            <id>docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.4.13</version>
-                        <configuration>
-                            <imageName>cbioportal/oncokb</imageName>
-                            <baseImage>tomcat:8-alpine</baseImage>
-                            <entryPoint>["catalina.sh", "run"]</entryPoint>
-                            <imageTags>
-                                <imageTag>${project.version}</imageTag>
-                                <imageTag>latest</imageTag>
-                            </imageTags>
-                            <resources>
-                                <resource>
-                                    <targetPath>/usr/local/tomcat/webapps</targetPath>
-                                    <directory>${project.build.directory}</directory>
-                                    <include>${project.build.finalName}.war</include>
-                                </resource>
-                            </resources>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>build-image</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <properties>
@@ -404,6 +367,50 @@
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.github.jsimone</groupId>
+                                    <artifactId>webapp-runner</artifactId>
+                                    <version>8.0.24.0</version>
+                                    <destFileName>webapp-runner.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <groupId>com.spotify</groupId>
+              <artifactId>dockerfile-maven-plugin</artifactId>
+              <version>1.4.8</version>
+              <executions>
+                <execution>
+                  <id>default</id>
+                  <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <repository>cbioportal/oncokb</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                  <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+              </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- Changed the docker generation to use spotify/dockerfile-maven, this is
recommended new way to generate docker files using maven.
- Using webapp-runner provides an easier command line interface to tomcat imo.
- Change the docker image also to mount at root instead of at /oncokb/ path.
- Remove dependencies that are no longer on maven central (javax.{sql,transaction})

