### PR TITLE
Use npm ci to install public

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -47,7 +47,7 @@
                                     <goal>npm</goal>
                                 </goals>
                                 <configuration>
-                                    <arguments>install</arguments>
+                                    <arguments>ci</arguments>
                                 </configuration>
                             </execution>
 


### PR DESCRIPTION
This way it will error when the lock file is out of sync. To avoid getting
unreproducible builds.

See: https://github.com/oncokb/oncokb-public/pull/233