### PR TITLE
R1 only trumps sensitive data when the curation is on a more specific alteration

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/EvidenceQueryRes.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/EvidenceQueryRes.java
@@ -14,6 +14,7 @@ public class EvidenceQueryRes implements java.io.Serializable {
     private String id; //Optional, This id is passed from request. The identifier used to distinguish the query
     private Query query;
     private Gene gene;
+    private Alteration exactMatchedAlteration;
     private List<Alteration> alterations = new ArrayList<>();
     private List<Alteration> alleles = new ArrayList<>();
     private List<TumorType> tumorTypes = new ArrayList<>();
@@ -45,6 +46,14 @@ public class EvidenceQueryRes implements java.io.Serializable {
 
     public void setGene(Gene gene) {
         this.gene = gene;
+    }
+
+    public Alteration getExactMatchedAlteration() {
+        return exactMatchedAlteration;
+    }
+
+    public void setExactMatchedAlteration(Alteration exactMatchedAlteration) {
+        this.exactMatchedAlteration = exactMatchedAlteration;
     }
 
     public List<Alteration> getAlterations() {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -530,6 +530,19 @@ public final class AlterationUtils {
         return isLikelyInferredAlt;
     }
 
+    public static Set<Alteration> getEvidencesAlterations(Set<Evidence> evidences) {
+        Set<Alteration> alterations = new HashSet<>();
+        if (evidences == null) {
+            return alterations;
+        }
+        for (Evidence evidence : evidences) {
+            if (evidence.getAlterations() != null) {
+                alterations.addAll(evidence.getAlterations());
+            }
+        }
+        return alterations;
+    }
+
     public static Set<Alteration> getAlterationsByKnownEffectInGene(Gene gene, String knownEffect, Boolean includeLikely) {
         Set<Alteration> alterations = new HashSet<>();
         if (includeLikely == null) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -579,12 +579,40 @@ public class EvidenceUtils {
         return filtered;
     }
 
-    public static Set<Evidence> getOnlyHighestLevelEvidences(Set<Evidence> evidences) {
+    public static Set<Evidence> getOnlyHighestLevelEvidences(Set<Evidence> evidences, Alteration exactMatch) {
         Map<LevelOfEvidence, Set<Evidence>> levels = separateEvidencesByLevel(evidences);
-
         Set<LevelOfEvidence> keys = levels.keySet();
 
         LevelOfEvidence highestLevel = LevelUtils.getHighestLevel(keys);
+        LevelOfEvidence highestSensitiveLevel = LevelUtils.getHighestSensitiveLevel(keys);
+
+        // When resistance level is not null, we need to consider whether the sensitive/resistance level is alteration specific
+        // if so the resistance level is broader
+        if (highestLevel != highestSensitiveLevel && highestSensitiveLevel != null) {
+            LevelOfEvidence highestResistanceLevel = LevelUtils.getHighestResistanceLevel(keys);
+            Set<Alteration> sensitiveAlterations = AlterationUtils.getEvidencesAlterations(levels.get(highestSensitiveLevel));
+            Set<Alteration> resistanceAlterations = AlterationUtils.getEvidencesAlterations(levels.get(highestResistanceLevel));
+            Set<Alteration> resistanceRelevantAlts = new HashSet<>();
+            for (Alteration alteration : resistanceAlterations) {
+                List<Alteration> relevantAlterations = AlterationUtils.getRelevantAlterations(alteration);
+
+                // we need to remove the ranges that overlap but not fully cover the alteration
+                Iterator<Alteration> i = relevantAlterations.iterator();
+                while (i.hasNext()) {
+                    Alteration relAlt = i.next();
+                    if (relAlt.getConsequence().equals(alteration.getConsequence())) {
+                        if (relAlt.getProteinStart() > alteration.getProteinStart() || relAlt.getProteinEnd() < alteration.getProteinEnd()) {
+                            i.remove();
+                        }
+                    }
+                }
+                resistanceRelevantAlts.addAll(relevantAlterations);
+            }
+            if (exactMatch != null && Collections.disjoint(resistanceRelevantAlts, sensitiveAlterations) && sensitiveAlterations.contains(exactMatch)) {
+                highestLevel = highestSensitiveLevel;
+            }
+        }
+
         if (highestLevel != null) {
             return levels.get(highestLevel);
         } else {
@@ -646,7 +674,7 @@ public class EvidenceUtils {
         return map;
     }
 
-    public static Set<Evidence> keepHighestLevelForSameTreatments(Set<Evidence> evidences) {
+    public static Set<Evidence> keepHighestLevelForSameTreatments(Set<Evidence> evidences, Alteration exactMatch) {
         Map<List<String>, Set<Evidence>> maps = new HashedMap();
         Set<Evidence> filtered = new HashSet<>();
 
@@ -673,38 +701,41 @@ public class EvidenceUtils {
         }
 
         for (Map.Entry<List<String>, Set<Evidence>> entry : maps.entrySet()) {
-            Set<Evidence> highestEvis = EvidenceUtils.getOnlyHighestLevelEvidences(entry.getValue());
+            Set<Evidence> highestEvis = EvidenceUtils.getOnlyHighestLevelEvidences(entry.getValue(), exactMatch);
 
             // If highestEvis has more than 1 items, find highest original level if the level is 2B, 3B
             if (highestEvis.size() > 1) {
                 Set<LevelOfEvidence> checkLevels = new HashSet<>();
                 checkLevels.add(LevelOfEvidence.LEVEL_2B);
                 checkLevels.add(LevelOfEvidence.LEVEL_3B);
-                if (checkLevels.contains(highestEvis.iterator().next().getLevelOfEvidence())) {
-                    Set<Integer> evidenceIds = new HashSet<>();
-                    Set<Gene> genes = new HashSet<>();
 
-                    for (Evidence evidence : highestEvis) {
-                        evidenceIds.add(evidence.getId());
-                        genes.add(evidence.getGene());
-                    }
+                for (Evidence highestEvi : highestEvis) {
+                    if (checkLevels.contains(highestEvi.getLevelOfEvidence())) {
+                        Set<Integer> evidenceIds = new HashSet<>();
+                        Set<Gene> genes = new HashSet<>();
 
-                    Set<Evidence> originalEvis = EvidenceUtils.getEvidencesByGenesAndIds(genes, evidenceIds);
-
-                    Set<Evidence> highestOriginalEvis = EvidenceUtils.getOnlyHighestLevelEvidences(originalEvis);
-                    Set<Integer> filteredIds = new HashSet<>();
-                    for (Evidence evidence : highestOriginalEvis) {
-                        filteredIds.add(evidence.getId());
-                    }
-                    for (Evidence evidence : highestEvis) {
-                        if (filteredIds.contains(evidence.getId())) {
-                            filtered.add(evidence);
-                            // Only add one
-                            break;
+                        for (Evidence evidence : highestEvis) {
+                            evidenceIds.add(evidence.getId());
+                            genes.add(evidence.getGene());
                         }
+
+                        Set<Evidence> originalEvis = EvidenceUtils.getEvidencesByGenesAndIds(genes, evidenceIds);
+
+                        Set<Evidence> highestOriginalEvis = EvidenceUtils.getOnlyHighestLevelEvidences(originalEvis, exactMatch);
+                        Set<Integer> filteredIds = new HashSet<>();
+                        for (Evidence evidence : highestOriginalEvis) {
+                            filteredIds.add(evidence.getId());
+                        }
+                        for (Evidence evidence : highestEvis) {
+                            if (filteredIds.contains(evidence.getId())) {
+                                filtered.add(evidence);
+                                // Only add one
+                                break;
+                            }
+                        }
+                    } else {
+                        filtered.add(highestEvi);
                     }
-                } else {
-                    filtered.add(highestEvis.iterator().next());
                 }
             } else {
                 filtered.addAll(highestEvis);
@@ -850,6 +881,8 @@ public class EvidenceUtils {
                                 requestQuery.getAlteration(), null, requestQuery.getConsequence(),
                                 requestQuery.getProteinStart(), requestQuery.getProteinEnd());
                             AlterationUtils.annotateAlteration(alt, alt.getAlteration());
+                        }else{
+                            query.setExactMatchedAlteration(alt);
                         }
                         List<Alteration> relevantAlts = AlterationUtils.getRelevantAlterations(alt);
 
@@ -894,11 +927,11 @@ public class EvidenceUtils {
 
                 // Get highest sensitive evidences
                 Set<Evidence> sensitiveEvidences = EvidenceUtils.getSensitiveEvidences(allEvidences);
-                filteredEvidences.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(sensitiveEvidences));
+                filteredEvidences.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(sensitiveEvidences, query.getExactMatchedAlteration()));
 
                 // Get highest resistance evidences
                 Set<Evidence> resistanceEvidences = EvidenceUtils.getResistanceEvidences(allEvidences);
-                filteredEvidences.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(resistanceEvidences));
+                filteredEvidences.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(resistanceEvidences, query.getExactMatchedAlteration()));
 
 
                 // Also include all non-treatment evidences
@@ -911,7 +944,7 @@ public class EvidenceUtils {
                 query.setEvidences(filteredEvidences);
             } else {
                 query.setEvidences(
-                    new ArrayList<>(keepHighestLevelForSameTreatments(filterEvidence(evidences, query))));
+                    new ArrayList<>(keepHighestLevelForSameTreatments(filterEvidence(evidences, query), query.getExactMatchedAlteration())));
             }
             CustomizeComparator.sortEvidenceBasedOnPriority(query.getEvidences(), LevelUtils.TREATMENT_SORTING_LEVEL_PRIORITY);
             if (query.getGene() != null && query.getGene().getHugoSymbol().equals("KIT")) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -272,7 +272,7 @@ public class IndicatorUtils {
                 if (hasTreatmentEvidence) {
                     treatmentEvidences = EvidenceUtils.keepHighestLevelForSameTreatments(
                         EvidenceUtils.getRelevantEvidences(query, source, geneStatus, matchedAlt,
-                            selectedTreatmentEvidence, levels));
+                            selectedTreatmentEvidence, levels), matchedAlt);
                 }
             }
 
@@ -288,7 +288,7 @@ public class IndicatorUtils {
                         treatmentEvidences.addAll(EvidenceUtils.keepHighestLevelForSameTreatments(
                             EvidenceUtils.convertEvidenceLevel(
                                 EvidenceUtils.getEvidence(Collections.singletonList(oncogenicMutation),
-                                    selectedTreatmentEvidence, levels), new HashSet<>(oncoTreeTypes))));
+                                    selectedTreatmentEvidence, levels), new HashSet<>(oncoTreeTypes)), matchedAlt));
                     }
                 }
             }
@@ -302,7 +302,7 @@ public class IndicatorUtils {
 
                     // Get highest resistance evidences
                     Set<Evidence> resistanceEvidences = EvidenceUtils.getResistanceEvidences(treatmentEvidences);
-                    filteredEvis.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(resistanceEvidences));
+                    filteredEvis.addAll(EvidenceUtils.getOnlyHighestLevelEvidences(resistanceEvidences, matchedAlt));
 
                     treatmentEvidences = filteredEvis;
                 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/LevelUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/LevelUtils.java
@@ -74,14 +74,25 @@ public class LevelUtils {
     }
 
     public static LevelOfEvidence getHighestLevel(Set<LevelOfEvidence> levels) {
+        return getHighestLevelByType(levels, LEVELS);
+    }
+
+    public static LevelOfEvidence getHighestSensitiveLevel(Set<LevelOfEvidence> levels) {
+        return getHighestLevelByType(levels, SENSITIVE_LEVELS);
+    }
+    public static LevelOfEvidence getHighestResistanceLevel(Set<LevelOfEvidence> levels) {
+        return getHighestLevelByType(levels, RESISTANCE_LEVELS);
+    }
+
+    public static LevelOfEvidence getHighestLevelByType(Set<LevelOfEvidence> levels, List<LevelOfEvidence> levelPool) {
         Integer highestLevelIndex = -1;
         for (LevelOfEvidence levelOfEvidence : levels) {
             if (levelOfEvidence != null) {
-                Integer _index = LEVELS.indexOf(levelOfEvidence);
+                Integer _index = levelPool.indexOf(levelOfEvidence);
                 highestLevelIndex = _index > highestLevelIndex ? _index : highestLevelIndex;
             }
         }
-        return highestLevelIndex > -1 ? LEVELS.get(highestLevelIndex) : null;
+        return highestLevelIndex > -1 ? levelPool.get(highestLevelIndex) : null;
     }
 
     public static LevelOfEvidence getHighestLevelFromEvidenceByLevels(Set<Evidence> evidences, Set<LevelOfEvidence> levels) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/TreatmentUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/TreatmentUtils.java
@@ -62,7 +62,7 @@ public final class TreatmentUtils {
     public static List<Treatment> sortTreatmentsByName(List<Treatment> treatments) {
         Collections.sort(treatments, new Comparator<Treatment>() {
             public int compare(Treatment t1, Treatment t2) {
-                return t1.getName() .compareTo(t2.getName());
+                return t1.getName().compareTo(t2.getName());
             }
         });
         return treatments;

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
@@ -129,6 +129,14 @@ public class EvidenceUtilsTest extends TestCase {
         Evidence e4 = new Evidence();
         Evidence e5 = new Evidence();
 
+        Alteration alteration = AlterationUtils.findAlteration(GeneUtils.getGeneByHugoSymbol("BRAF"), "V600E");
+
+        e1.setAlterations(Collections.singleton(alteration));
+        e2.setAlterations(Collections.singleton(alteration));
+        e3.setAlterations(Collections.singleton(alteration));
+        e4.setAlterations(Collections.singleton(alteration));
+        e5.setAlterations(Collections.singleton(alteration));
+
         e1.setId(1);
         e2.setId(2);
         e3.setId(3);
@@ -190,21 +198,21 @@ public class EvidenceUtilsTest extends TestCase {
         sets.add(e1);
         sets.add(e2);
 
-        Set<Evidence> filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        Set<Evidence> filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("1,2", getIds(filtered));
 
         sets.add(e3);
-        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("1,2,3", getIds(filtered));
 
         sets = new HashSet<>();
         sets.add(e1);
         sets.add(e4);
-        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("1", getIds(filtered));
 
         e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_3A);
-        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("4", getIds(filtered));
 
         sets = new HashSet<>();
@@ -213,17 +221,17 @@ public class EvidenceUtilsTest extends TestCase {
 
         e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_1);
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R1);
-        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("5", getIds(filtered));
 
         e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_2A);
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R1);
-        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("5", getIds(filtered));
 
         e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_2A);
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R2);
-        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("1", getIds(filtered));
     }
 

--- a/core/src/test/resources/test_treatments.txt
+++ b/core/src/test/resources/test_treatments.txt
@@ -76,3 +76,9 @@ PDGFRA	D842I	GIST	2A: Imatinib;
 PDGFRA	D842I	Thymic Tumor	2B: Imatinib;
 PDGFRA	D842V	GIST	R1: Imatinib; 2A: Dasatinib;
 PDGFRA	D842V	Thymic Tumor	2B: Dasatinib; 2B: Imatinib;
+EGFR	A763_Y764insFQEA	NSCLC	1: Afatinib; 1: Erlotinib; 1: Gefitinib; 3A: Poziotinib;
+# this one overlaps with A763_Y764insFQEA, but the rule only applies to exact match, so R1 will be used
+EGFR	Y764_D770dup	NSCLC	R1: Afatinib; R1: Erlotinib; R1: Gefitinib; 3A: Poziotinib;
+# this one does not overlap with A763_Y764insFQEA, so R1 for sure
+EGFR	N771delinsSTH	Lung Adenocarcinoma	R1: Afatinib; R1: Erlotinib; R1: Gefitinib; 3A: Poziotinib;
+

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -286,8 +286,8 @@ public class UtilsApiController implements UtilsApi {
             String highestSensitiveLevel = "";
             String highestResistanceLevel = "";
             Set<Evidence> therapeuticEvidences = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, EvidenceTypeUtils.getTreatmentEvidenceTypes());
-            Set<Evidence> highestSensitiveLevelEvidences = EvidenceUtils.getOnlyHighestLevelEvidences(EvidenceUtils.getSensitiveEvidences(therapeuticEvidences));
-            Set<Evidence> highestResistanceLevelEvidences = EvidenceUtils.getOnlyHighestLevelEvidences(EvidenceUtils.getResistanceEvidences(therapeuticEvidences));
+            Set<Evidence> highestSensitiveLevelEvidences = EvidenceUtils.getOnlyHighestLevelEvidences(EvidenceUtils.getSensitiveEvidences(therapeuticEvidences), null);
+            Set<Evidence> highestResistanceLevelEvidences = EvidenceUtils.getOnlyHighestLevelEvidences(EvidenceUtils.getResistanceEvidences(therapeuticEvidences), null);
             if (!highestSensitiveLevelEvidences.isEmpty()) {
                 highestSensitiveLevel = highestSensitiveLevelEvidences.iterator().next().getLevelOfEvidence().getLevel();
             }


### PR DESCRIPTION
This solves #1496 