### PR TITLE
check uuid to prevent the undefined

### DIFF
--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -453,7 +453,7 @@ angular.module('oncokbApp')
             function isChangedSection(uuids) {
                 var result = false;
                 _.some(uuids, function (uuid) {
-                    if ($scope.geneMeta.review[uuid]) {
+                    if (uuid && $scope.geneMeta.review[uuid]) {
                         result = true;
                         return true;
                     }


### PR DESCRIPTION
For some reason geneMeta has undefined in the object and it returns the true