### PR TITLE
Fetch selected item in ng-change functions

### DIFF
--- a/web/yo/app/scripts/controllers/gene.js
+++ b/web/yo/app/scripts/controllers/gene.js
@@ -2313,13 +2313,29 @@ angular.module('oncokbApp')
                         if (type === 'tumor') {
                             // Do not delete lastReviewed when curators delete a treatment.
                             // If a reviewer reject this change, we can rollback to previous reviewed name.
-                            obj.cancerTypes_review.updatedBy = $rootScope.me.name;
-                            obj.cancerTypes_review.updateTime = new Date().getTime();
-                            obj.cancerTypes_review.removed = true;
+                            if (_.isUndefined(obj.cancerTypes_review)) {
+                                obj.cancerTypes_review = {
+                                    updatedBy: $rootScope.me.name,
+                                    updateTime: new Date().getTime(),
+                                    removed: true
+                                };
+                            } else {
+                                obj.cancerTypes_review.updatedBy = $rootScope.me.name;
+                                obj.cancerTypes_review.updateTime = new Date().getTime();
+                                obj.cancerTypes_review.removed = true;
+                            }
                         } else {
-                            obj.name_review.updatedBy = $rootScope.me.name;
-                            obj.name_review.updateTime = new Date().getTime();
-                            obj.name_review.removed = true;
+                            if (_.isUndefined(obj.name_review)) {
+                                obj.name_review = {
+                                    updatedBy: $rootScope.me.name,
+                                    updateTime: new Date().getTime(),
+                                    removed: true
+                                };
+                            } else {
+                                obj.name_review.updatedBy = $rootScope.me.name;
+                                obj.name_review.updateTime = new Date().getTime();
+                                obj.name_review.removed = true;
+                            }
                         }
                         $scope.geneMeta.review[uuid] = true;
                     }

--- a/web/yo/app/scripts/controllers/tools.js
+++ b/web/yo/app/scripts/controllers/tools.js
@@ -184,7 +184,7 @@ angular.module('oncokbApp')
                 scrollY: 500,
                 scrollCollapse: true
             };
-            $scope.evidenceType = '';
+            $scope.data = { evidenceType: ''};
             $scope.evidenceTypes = [{
                 label: 'Gene Summary',
                 value: 'geneSummary'
@@ -285,26 +285,25 @@ angular.module('oncokbApp')
                 $scope.loadingReviewed = false;
                 $scope.displayReviewedData = true;
             }
-            $scope.updateReviewData = function(selected) {
-                $scope.evidenceType = selected;
+            $scope.updateReviewData = function() {
                 $scope.displayReviewedData = false;
             };
             $scope.generateEvidences = function () {
                 $scope.loadingReviewed = true;
 
-                DatabaseConnector.getReviewedData($scope.reviewedData[$scope.evidenceType].evidenceTypes).then(function(response) {
-                    if ($scope.evidenceType === 'geneSummary' || $scope.evidenceType === 'geneBackground') {
+                DatabaseConnector.getReviewedData($scope.reviewedData[$scope.data.evidenceType].evidenceTypes).then(function(response) {
+                    if ($scope.data.evidenceType === 'geneSummary' || $scope.data.evidenceType === 'geneBackground') {
                         // key = 'summary' or key = 'background'
-                        var key = $scope.reviewedData[$scope.evidenceType].keys[1];
+                        var key = $scope.reviewedData[$scope.data.evidenceType].keys[1];
                         _.each(response.data, function(item) {
                             var tempObj = {
                                 gene: item.gene.hugoSymbol
                             };
                             tempObj[key] = item.description;
-                            $scope.reviewedData[$scope.evidenceType].body.push(tempObj);
+                            $scope.reviewedData[$scope.data.evidenceType].body.push(tempObj);
                         });
                         finishLoadingReviewedData();
-                    } else if ($scope.evidenceType === 'geneType') {
+                    } else if ($scope.data.evidenceType === 'geneType') {
                         var variantLookupBody = _.map(response.data, function(item) {
                             return {
                                 hugoSymbol: item.hugoSymbol
@@ -354,7 +353,7 @@ angular.module('oncokbApp')
                             });
                             finishLoadingReviewedData();
                         });
-                    } else if ($scope.evidenceType === 'mutationEffect') {
+                    } else if ($scope.data.evidenceType === 'mutationEffect') {
                         _.each(response.data, function (item) {
                             var flag = false;
                             for (var i = 0; i < $scope.reviewedData.mutationEffect.body.length; i++) {
@@ -382,7 +381,7 @@ angular.module('oncokbApp')
                                     subtypeMapping[item.code] = item.name;
                                 });
                             });
-                            if ($scope.evidenceType === 'tumorSummary') {
+                            if ($scope.data.evidenceType === 'tumorSummary') {
                                 _.each(response.data, function (item) {
                                     var tempObj =  {
                                         gene: item.gene.hugoSymbol,
@@ -396,7 +395,7 @@ angular.module('oncokbApp')
                                     }
                                     $scope.reviewedData.tumorSummary.body.push(tempObj);
                                 });
-                            } else if ($scope.evidenceType === 'drugs') {
+                            } else if ($scope.data.evidenceType === 'drugs') {
                                 _.each(response.data, function(item) {
                                     var drugs = [];
                                     if (item.treatments.length > 0) {
@@ -420,7 +419,7 @@ angular.module('oncokbApp')
                                         $scope.reviewedData.drugs.body.push(tempObj);
                                     }
                                 });
-                            } else if ($scope.evidenceType === 'ttsDrugs') {
+                            } else if ($scope.data.evidenceType === 'ttsDrugs') {
                                 var drugsMapping = {};
                                 _.each(response.data, function(item) {
                                     if (item.evidenceType !== 'TUMOR_TYPE_SUMMARY') {
@@ -520,13 +519,13 @@ angular.module('oncokbApp')
                 var content = [];
                 var tempArr = [];
                 var fileName = 'Reviewed.xls';
-                if ($scope.evidenceType && $scope.reviewedData[$scope.evidenceType]) {
-                    content.push($scope.reviewedData[$scope.evidenceType].header.join('\t'));
-                    fileName = $scope.reviewedData[$scope.evidenceType].fileName;
+                if ($scope.data.evidenceType && $scope.reviewedData[$scope.data.evidenceType]) {
+                    content.push($scope.reviewedData[$scope.data.evidenceType].header.join('\t'));
+                    fileName = $scope.reviewedData[$scope.data.evidenceType].fileName;
                 }
-                _.each($scope.reviewedData[$scope.evidenceType].body, function(item) {
+                _.each($scope.reviewedData[$scope.data.evidenceType].body, function(item) {
                     tempArr = [];
-                    _.each($scope.reviewedData[$scope.evidenceType].keys, function(key) {
+                    _.each($scope.reviewedData[$scope.data.evidenceType].keys, function(key) {
                         tempArr.push(item[key]);
                     });
                     content.push(tempArr.join('\t'));

--- a/web/yo/app/scripts/controllers/tools.js
+++ b/web/yo/app/scripts/controllers/tools.js
@@ -175,7 +175,7 @@ angular.module('oncokbApp')
                 } else {
                     return 'Submit';
                 }
-            }
+            };
 
             $scope.reviewedDT = {};
             $scope.reviewedDT.dtOptions = {
@@ -200,6 +200,12 @@ angular.module('oncokbApp')
             }, {
                 label: 'Tumor Type Summary',
                 value: 'tumorSummary'
+            }, {
+                label: 'Diagnostic Summary',
+                value: 'diagnosticSummary'
+            }, {
+                label: 'Prognostic Summary',
+                value: 'prognosticSummary'
             }, {
                 label: 'Tumor Type Summary + Therapeutics',
                 value: 'ttsDrugs'
@@ -244,14 +250,14 @@ angular.module('oncokbApp')
                     evidenceTypes: 'TUMOR_TYPE_SUMMARY'
                 },
                 diagnosticSummary: {
-                    header: ['Gene', 'Mutation', 'Tumor Type', 'Tumor Summary'],
+                    header: ['Gene', 'Mutation', 'Tumor Type', 'Diagnostic Summary'],
                     body: [],
                     keys: ['gene', 'mutation', 'tumorType', 'diagnosticSummary'],
                     fileName: 'DiagnosticSummary.xls',
                     evidenceTypes: 'DIAGNOSTIC_SUMMARY'
                 },
                 prognosticSummary: {
-                    header: ['Gene', 'Mutation', 'Tumor Type', 'Tumor Summary'],
+                    header: ['Gene', 'Mutation', 'Tumor Type', 'Prognostic Summary'],
                     body: [],
                     keys: ['gene', 'mutation', 'tumorType', 'prognosticSummary'],
                     fileName: 'PrognosticSummary.xls',
@@ -279,9 +285,10 @@ angular.module('oncokbApp')
                 $scope.loadingReviewed = false;
                 $scope.displayReviewedData = true;
             }
-            $scope.updateReviewData = function() {
+            $scope.updateReviewData = function(selected) {
+                $scope.evidenceType = selected;
                 $scope.displayReviewedData = false;
-            }
+            };
             $scope.generateEvidences = function () {
                 $scope.loadingReviewed = true;
 

--- a/web/yo/app/scripts/services/user.js
+++ b/web/yo/app/scripts/services/user.js
@@ -11,7 +11,7 @@
  * gmail.com will be used as standard email format, googlemail address will be converted to gmail
  */
 angular.module('oncokbApp')
-    .service('user', function user($routeParams, $q, $firebaseAuth, $firebaseObject, $rootScope, mainUtils, firebaseConnector) {
+    .service('user', function user($routeParams, $q, $firebaseAuth, $firebaseObject, $rootScope, mainUtils, firebaseConnector, dialogs) {
         // me is used only inside user.js to share user information
         var me = {
             admin: false,

--- a/web/yo/app/views/tools.html
+++ b/web/yo/app/views/tools.html
@@ -99,7 +99,7 @@
             <select ng-model="evidenceType"
                     ng-options="m.value as m.label for m in evidenceTypes"
                     class="form-control"
-                    ng-change="updateReviewData()">
+                    ng-change="updateReviewData(evidenceType)">
             </select>
         </div>
         <div class="col-sm-2">

--- a/web/yo/app/views/tools.html
+++ b/web/yo/app/views/tools.html
@@ -96,14 +96,14 @@
     <div class="row" style="margin-top:30px; margin-bottom:30px;">
         <div class="col-sm-2 queryLabel">Query Type:</div>
         <div class="col-sm-4">
-            <select ng-model="evidenceType"
+            <select ng-model="data.evidenceType"
                     ng-options="m.value as m.label for m in evidenceTypes"
                     class="form-control"
-                    ng-change="updateReviewData(evidenceType)">
+                    ng-change="updateReviewData()">
             </select>
         </div>
         <div class="col-sm-2">
-            <button type="button" class="btn btn-default" ng-click="generateEvidences()" ng-disabled="!evidenceType" ng-bind-html="getReviewButtonContent()"></button>
+            <button type="button" class="btn btn-default" ng-click="generateEvidences()" ng-disabled="!data.evidenceType" ng-bind-html="getReviewButtonContent()"></button>
         </div>
         <div class="col-sm-1" ng-if="displayReviewedData">
             <button type="button" class="btn btn-default" ng-click="downloadReviewedData()"> Download </button>
@@ -113,17 +113,17 @@
         <table datatable="ng" class="row-border hover" dt-options="reviewedDT.dtOptions">
             <thead>
             <tr>
-                <th ng-repeat="x in reviewedData[evidenceType].header">{{ x }}</th>
+                <th ng-repeat="x in reviewedData[data.evidenceType].header">{{ x }}</th>
             </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="item in reviewedData[evidenceType].body">
-                    <td ng-repeat="key in reviewedData[evidenceType].keys">
+                <tr ng-repeat="item in reviewedData[data.evidenceType].body">
+                    <td ng-repeat="key in reviewedData[data.evidenceType].keys">
                         <div ng-switch on="key">
                             <div ng-switch-when="gene">
                                 <strong><a href="#!/gene/{{item.gene}}">{{ item.gene }}</a></strong>
                             </div>
-                            <div ng-if="evidenceType !== 'drugs'">
+                            <div ng-if="data.evidenceType !== 'drugs'">
                                 <div class="reviewedData" ng-switch-when="mutation">{{item.mutation}}</div>
                                 <div class="reviewedData" ng-switch-when="drugs">{{item.drugs}}</div>
                             </div>


### PR DESCRIPTION
ng-model doesn't work in <select> tool.html. $scope.evidenceType cannot fetch the selected option. I need to manually bind it in ng-change function updateReviewData().
This is related to map rollback. In prevent to lose content of lastReview, we assign the value of obj.name_review instead of init obj.name_review. However, it will run into issues when an obj doesn’t have `name_review`. We should check if name_review is undefined first.