### PR TITLE
Remove blob from bower

### DIFF
--- a/web/yo/app/index.html
+++ b/web/yo/app/index.html
@@ -172,7 +172,6 @@
     <script src="components/angular-file-upload/angular-file-upload.min.js"></script>
     <script src="components/file-saver.js/FileSaver.js"></script>
     <script src="components/uuid-js/lib/uuid.js"></script>
-    <script src="components/Blob/Blob.js"></script>
     <script src="components/google-diff-match-patch-js/diff_match_patch.js"></script>
     <script src="components/moment/moment.js"></script>
     <script src="components/bootstrap-daterangepicker/daterangepicker.js"></script>

--- a/web/yo/bower.json
+++ b/web/yo/bower.json
@@ -38,7 +38,6 @@
     "file-saver.js": "~1.20150304.1",
     "fontawesome": "~4.4.0",
     "uuid-js": "^0.7.5",
-    "Blob": "*",
     "angularfire": "^2.3.0",
     "angular-ui-notification": "MikhailRoot/angular-ui-notification#0.3.5",
     "google-diff-match-patch-js": "^1.0.0",


### PR DESCRIPTION
Blob.js contains es6 syntax `const`, which cause compile error, and we didn't use it at all so I remove it.