### PR TITLE
Add additional test on R2 vs other lower sensitive level

### DIFF
--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
@@ -233,6 +233,11 @@ public class EvidenceUtilsTest extends TestCase {
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R2);
         filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
         assertEquals("1", getIds(filtered));
+
+        e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_4);
+        e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R2);
+        filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
+        assertEquals("1", getIds(filtered));
     }
 
     private String getIds(Set<Evidence> evidences) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/LevelUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/LevelUtilsTest.java
@@ -13,6 +13,7 @@ public class LevelUtilsTest extends TestCase {
         assertTrue(LevelUtils.compareLevel(null, LevelOfEvidence.LEVEL_1) > 0);
         assertTrue(LevelUtils.compareLevel(LevelOfEvidence.LEVEL_1, LevelOfEvidence.LEVEL_1) == 0);
         assertTrue(LevelUtils.compareLevel(LevelOfEvidence.LEVEL_1, LevelOfEvidence.LEVEL_3B) < 0);
+        assertTrue(LevelUtils.compareLevel(LevelOfEvidence.LEVEL_1, LevelOfEvidence.LEVEL_R2) < 0);
         assertTrue(LevelUtils.compareLevel(LevelOfEvidence.LEVEL_R1, LevelOfEvidence.LEVEL_3B) < 0);
         assertTrue(LevelUtils.compareLevel(LevelOfEvidence.LEVEL_R1, LevelOfEvidence.LEVEL_1) < 0);
         assertTrue(LevelUtils.compareLevel(LevelOfEvidence.LEVEL_R2, LevelOfEvidence.LEVEL_4) > 0);


### PR DESCRIPTION
This insures the R2 will not cancel other sensitive treatments.
This fixes https://github.com/oncokb/oncokb/issues/1621