### PR TITLE
Open web socket session and report empty clinical variant info

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
@@ -235,6 +235,20 @@ public class TumorTypeUtils {
         return null;
     }
 
+    public static String getTumorTypeName(TumorType tumorType) {
+        if (tumorType == null) {
+            return "";
+        }
+        if (tumorType.getName() != null) {
+            return tumorType.getName();
+        }
+        if (tumorType.getMainType() != null && tumorType.getMainType().getName() != null) {
+            return tumorType.getMainType().getName();
+        } else {
+            return "";
+        }
+    }
+
     /**
      * The 'All Tumors' OncoTree instance
      *

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/ValidationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/ValidationUtils.java
@@ -1,0 +1,61 @@
+package org.mskcc.cbio.oncokb.util;
+
+import com.mysql.jdbc.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.mskcc.cbio.oncokb.model.ClinicalVariant;
+import org.mskcc.cbio.oncokb.model.Gene;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class ValidationUtils {
+
+    public static JSONArray getEmptyClinicalVariants() {
+        final String NO_LEVEL = "No level is specified";
+        final String NO_REFERENCE = "No reference is specified";
+        final String NO_TREATMENT = "No treatment is specified";
+        JSONArray data = new JSONArray();
+        for (Gene gene : GeneUtils.getAllGenes()) {
+            Set<ClinicalVariant> variants = MainUtils.getClinicalVariants(gene);
+            for (ClinicalVariant variant : variants) {
+                if (StringUtils.isNullOrEmpty(variant.getLevel())) {
+                    data.put(getErrorMessage(getTargetByClinicalVariant(variant), NO_LEVEL));
+                }
+                if (variant.getDrugAbstracts().isEmpty() && variant.getDrugPmids().isEmpty()) {
+                    data.put(getErrorMessage(getTargetByClinicalVariant(variant), NO_REFERENCE));
+                }
+                if (variant.getDrug().isEmpty()) {
+                    data.put(getErrorMessage(getTargetByClinicalVariant(variant), NO_TREATMENT));
+                }
+            }
+        }
+        return data;
+    }
+
+    private static String getTargetByClinicalVariant(ClinicalVariant variant) {
+        return getTarget(variant.getVariant().getGene().getHugoSymbol(), variant.getVariant().getAlteration(), TumorTypeUtils.getTumorTypeName(variant.getOncoTreeType()));
+    }
+
+    private static JSONObject getErrorMessage(String target, String reason) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.append("target", target);
+        jsonObject.append("reason", reason);
+        return jsonObject;
+    }
+
+    private static String getTarget(String hugoSymbol, String alteration, String tumorType) {
+        List<String> items = new ArrayList<>();
+        if (!StringUtils.isNullOrEmpty(hugoSymbol)) {
+            items.add(hugoSymbol);
+        }
+        if (!StringUtils.isNullOrEmpty(alteration)) {
+            items.add(alteration);
+        }
+        if (!StringUtils.isNullOrEmpty(tumorType)) {
+            items.add(tumorType);
+        }
+        return String.join("-", items);
+    }
+}

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -254,6 +254,12 @@
             <artifactId>sentry-spring</artifactId>
             <version>1.7.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>1.1</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/CurationValidationApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/CurationValidationApiController.java
@@ -1,0 +1,76 @@
+package org.mskcc.cbio.oncokb.api.websocket;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.mskcc.cbio.oncokb.util.ValidationUtils;
+
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import static org.mskcc.cbio.oncokb.api.websocket.ValidationTest.MISSING_CLINICAL_INFO_VARIANTS;
+
+/**
+ * Created by Hongxin on 12/12/16.
+ */
+
+@ServerEndpoint(value = "/websocket/curation/validation")
+public class CurationValidationApiController {
+    private Session session;
+
+    @OnOpen
+    public void onOpen(Session session) throws IOException {
+        // Get session and WebSocket connection
+        this.session = session;
+        sendText("Validation started");
+
+        validateEmptyClinicalVariants();
+
+        sendText("Validation is finished.");
+    }
+
+    @OnMessage
+    public void onMessage(String message, Session session) throws IOException {
+        // Handle new messages
+    }
+
+    @OnClose
+    public void onClose(Session session) throws IOException {
+//        allAvailableRequests.remove(session);
+        session.close();
+    }
+
+    @OnError
+    public void onError(Session session, Throwable throwable) {
+        // Do error handling here
+    }
+
+    private void sendText(String text) throws IOException {
+        this.session.getBasicRemote().sendText(text);
+    }
+
+    private void validateEmptyClinicalVariants() throws IOException {
+        sendText(generateInfo(MISSING_CLINICAL_INFO_VARIANTS, ValidationStatus.IS_PENDING, new JSONArray()));
+
+        JSONArray data = ValidationUtils.getEmptyClinicalVariants();
+        if (data.length() == 0) {
+            sendText(generateInfo(MISSING_CLINICAL_INFO_VARIANTS, ValidationStatus.IS_COMPLETE, new JSONArray()));
+        } else {
+            sendText(generateInfo(MISSING_CLINICAL_INFO_VARIANTS, ValidationStatus.IS_ERROR, data));
+        }
+    }
+
+    private static final String TEST_KEY = "test";
+    private static final String STATUS_KEY = "status";
+    private static final String DATA_KEY = "data";
+
+    private static String generateInfo(ValidationTest test, ValidationStatus status, JSONArray data) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.append(TEST_KEY, test);
+        jsonObject.append(STATUS_KEY, status);
+        jsonObject.append(DATA_KEY, data);
+        return jsonObject.toString();
+    }
+}

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/ValidationStatus.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/ValidationStatus.java
@@ -1,0 +1,8 @@
+package org.mskcc.cbio.oncokb.api.websocket;
+
+/**
+ * Created by Hongxin Zhang on 3/6/20.
+ */
+public enum ValidationStatus {
+    IS_PENDING, IS_ERROR, IS_COMPLETE
+}

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/ValidationTest.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/ValidationTest.java
@@ -1,0 +1,20 @@
+package org.mskcc.cbio.oncokb.api.websocket;
+
+/**
+ * Created by Hongxin Zhang on 3/6/20.
+ */
+public enum ValidationTest {
+    MISSING_CLINICAL_INFO_VARIANTS(""),
+    MISSING_BIOLOGICAL_INFO_VARIANTS("")
+    ;
+
+    ValidationTest(String name) {
+        this.name = name;
+    }
+
+    String name;
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
The following message format will be given when reporting the status
```
{
  "test": "",
  "status": "isPending | isError | isComplete",
  // when isError
  "data": [{
  	"target": "",
  	"reason": ""
  }]
}
```
This fixes https://github.com/oncokb/oncokb/issues/1935