### PR TITLE
Do not send validation status via websocket

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/CurationValidationApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/websocket/CurationValidationApiController.java
@@ -22,15 +22,12 @@ public class CurationValidationApiController {
     public void onOpen(Session session) throws IOException {
         // Get session and WebSocket connection
         this.session = session;
-        sendText("Validation started");
 
         validateGeneInfo();
 
         validateEmptyClinicalVariants();
 
         validateEmptyBiologicalVariants();
-
-        sendText("Validation is finished.");
 
         this.session.close();
     }


### PR DESCRIPTION
The status is no longer used by frontend and could trigger the message event