### PR TITLE
Select the evidence with the most frequently occurred tumor type

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
@@ -404,6 +404,20 @@ public class TumorTypeUtils {
         return new ArrayList<>(new LinkedHashSet<>(mappedTumorTypesFromSource));
     }
 
+    public static String getTumorTypeName(TumorType tumorType) {
+        if (tumorType == null) {
+            return "";
+        } else {
+            if (tumorType.getName() != null) {
+                return tumorType.getName();
+            } else if (tumorType.getMainType() != null && tumorType.getMainType().getName() != null) {
+                return tumorType.getMainType().getName();
+            } else {
+                return "";
+            }
+        }
+    }
+
     public static String getOncoTreeVersion() {
         return ONCO_TREE_ONCOKB_VERSION;
     }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
@@ -3,6 +3,8 @@ package org.mskcc.cbio.oncokb.util;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.model.*;
+import org.mskcc.cbio.oncokb.model.tumor_type.MainType;
+import org.mskcc.cbio.oncokb.model.tumor_type.TumorType;
 
 import java.util.*;
 
@@ -148,6 +150,17 @@ public class EvidenceUtilsTest extends TestCase {
         e3.setLevelOfEvidence(LevelOfEvidence.LEVEL_1);
         e4.setLevelOfEvidence(LevelOfEvidence.LEVEL_2);
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R1);
+
+        TumorType tumorType = new TumorType();
+        MainType mainType = new MainType();
+        mainType.setName("Melanoma");
+        tumorType.setName("Melanoma");
+
+        e1.setOncoTreeType(tumorType);
+        e2.setOncoTreeType(tumorType);
+        e3.setOncoTreeType(tumorType);
+        e4.setOncoTreeType(tumorType);
+        e5.setOncoTreeType(tumorType);
 
         Drug d1 = new Drug("Vemurafinib");
         Drug d2 = new Drug("Dabrafinib");


### PR DESCRIPTION
When evidences have the same level, same treatment, we need to pick the one with the most frequently occurred tumor type among the selected evidences.

This fixes https://github.com/oncokb/oncokb/issues/1985