### PR TITLE
Remove KIT special rules && Change the portal alteration source && Always include R2

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,12 +4,9 @@ categories:
   - title: '🧬 Features'
     labels:
       - 'feature'
-      - 'enhancement'
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
-      - 'bugfix'
-      - 'bug'
   - title: '🏎 Performance Tweaks'
     labels:
       - 'performance'

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -373,19 +373,6 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                 alterations.add(alt);
             }
         }
-
-        // Remove exon 17 for KIT D816
-        if (isKIT816(alteration)) {
-            Iterator<Alteration> iter = alterations.iterator();
-            while (iter.hasNext()) {
-                Alteration alt = iter.next();
-                if (alt.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm("any"))
-                    && alt.getProteinStart() != null && alt.getProteinStart().equals(788)
-                    && alt.getProteinEnd() != null && alt.getProteinEnd().equals(828)) {
-                    iter.remove();
-                }
-            }
-        }
         return alterations;
     }
 
@@ -411,7 +398,6 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
     private boolean addOncogenicMutations(Alteration exactAlt, Set<Alteration> relevantAlts) {
         boolean add = false;
-        if (!isKitSpecialVariants(exactAlt)) {
             if (!exactAlt.getAlteration().trim().equalsIgnoreCase("amplification")) {
                 Set<Oncogenicity> oncogenicities = AlterationUtils.getCuratedOncogenicity(exactAlt);
                 boolean has = AlterationUtils.hasImportantCuratedOncogenicity(oncogenicities);
@@ -428,35 +414,14 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                     for (Alteration alt : AlterationUtils.excludeVUS(new ArrayList<>(relevantAlts))) {
                         Boolean isOncogenic = AlterationUtils.isOncogenicAlteration(alt);
 
-                        if (isOncogenic != null && isOncogenic && !isKitSpecialVariants(alt)) {
+                        if (isOncogenic != null && isOncogenic) {
                             add = true;
                             break;
                         }
                     }
                 }
             }
-        }
         return add;
-    }
-
-    private boolean isKitSpecialVariants(Alteration alteration) {
-        boolean isSpecial = false;
-        if (alteration != null && alteration.getGene().getEntrezGeneId() == 3815) {
-            String[] speicalVariants = {"V654A", "T670I"};
-            VariantConsequence consequence = VariantConsequenceUtils.findVariantConsequenceByTerm(MISSENSE_VARIANT);
-            for (int i = 0; i < speicalVariants.length; i++) {
-                if (alteration.getGene() != null && alteration.getGene().getEntrezGeneId() == 3815
-                    && alteration.getAlteration() != null && alteration.getAlteration().equals(speicalVariants[i])
-                    && alteration.getConsequence().equals(consequence)) {
-                    isSpecial = true;
-                    break;
-                }
-            }
-            if (!isSpecial) {
-                isSpecial = isInExon17(alteration);
-            }
-        }
-        return isSpecial;
     }
 
     private boolean isVariantByLocation(Alteration alteration, int entrezGeneId, int proteinStart, int proteinEnd, VariantConsequence variantConsequence) {
@@ -467,10 +432,6 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             return true;
         }
         return false;
-    }
-
-    private boolean isKIT816(Alteration alteration) {
-        return isVariantByLocation(alteration, 3815, 816, 816, VariantConsequenceUtils.findVariantConsequenceByTerm(MISSENSE_VARIANT));
     }
 
     private boolean isInExon17(Alteration alteration) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/importer/PortalAlterationImporter.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/importer/PortalAlterationImporter.java
@@ -33,9 +33,9 @@ public class PortalAlterationImporter {
             String sampleListId = jObject.getString("sampleListId");
             if (category != null && category.equalsIgnoreCase("other") && sampleListId != null && !sampleListId.equalsIgnoreCase("msk_impact_2017_NA")) {
                 String cancerType = jObject.getString("name");
-                String mutationUrl = "http://www.cbioportal.org/api/molecular-profiles/msk_impact_2017_mutations/mutations?sampleListId=" + sampleListId + "&projection=DETAILED";
-                String muttionResult = FileUtils.readRemote(mutationUrl);
-                JSONArray mutationJSONResult = new JSONArray(muttionResult);
+                String mutationUrl = "https://cbioportal.mskcc.org/api/molecular-profiles/msk_impact_2017_mutations/mutations?sampleListId=" + sampleListId + "&projection=DETAILED";
+                String mutationResult = FileUtils.readMSKPortal(mutationUrl);
+                JSONArray mutationJSONResult = new JSONArray(mutationResult);
                 System.out.println("*****************************************************************************");
                 System.out.println("Importing for " + cancerType);
                 for (int j = 0; j < mutationJSONResult.length(); j++) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -948,7 +948,7 @@ public final class AlterationUtils {
                     int proteinStart = alteration.getProteinStart() + i;
                     List<Alteration> alterations = alterationBo.findMutationsByConsequenceAndPosition(alteration.getGene(), alteration.getConsequence(), proteinStart, proteinStart, allAlterations);
                     for (Alteration alt : alterations) {
-                        if (alt.getVariantResidues().charAt(0) == varAA) {
+                        if (alt.getVariantResidues() != null && alt.getVariantResidues().charAt(0) == varAA) {
                             matches.add(alt);
                         }
                     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.*;
 import static org.mskcc.cbio.oncokb.model.RelevantTumorTypeDirection.DOWNWARD;
+import static org.mskcc.cbio.oncokb.util.LevelUtils.INFO_LEVELS;
 
 /**
  * Created by Hongxin on 8/10/15.
@@ -621,6 +622,11 @@ public class EvidenceUtils {
         LevelOfEvidence highestLevel = LevelUtils.getHighestLevel(keys);
         LevelOfEvidence highestSensitiveLevel = LevelUtils.getHighestSensitiveLevel(keys);
 
+        Set<Evidence> tagAlongEvidences = (highestLevel == null || INFO_LEVELS.contains(highestLevel)) ? new HashSet<>() :
+            evidences.stream().filter(
+                evidence -> INFO_LEVELS.contains(evidence.getLevelOfEvidence())
+            ).collect(Collectors.toSet());
+
         // When resistance level is not null, we need to consider whether the sensitive/resistance level is alteration specific
         // if so the resistance level is broader
         if (highestLevel != highestSensitiveLevel && highestSensitiveLevel != null) {
@@ -649,7 +655,14 @@ public class EvidenceUtils {
         }
 
         if (highestLevel != null) {
-            return levels.get(highestLevel);
+            if (tagAlongEvidences.size() > 0) {
+                Set<Evidence> mergeResult = new HashSet<>();
+                mergeResult.addAll(levels.get(highestLevel));
+                mergeResult.addAll(tagAlongEvidences);
+                return mergeResult;
+            } else {
+                return levels.get(highestLevel);
+            }
         } else {
             return new HashSet<>();
         }
@@ -741,7 +754,8 @@ public class EvidenceUtils {
         for (Map.Entry<String, Set<Evidence>> entry : maps.entrySet()) {
             Set<Evidence> highestEvis = EvidenceUtils.getOnlyHighestLevelEvidences(entry.getValue(), exactMatch);
 
-            // If highestEvis has more than 1 items, find highest original level if the level is 2B, 3B
+            // If highestEvis has more than 1 items, find highest original level if the level is 3B
+            // We also return R2 when the same treatment has sensitive level
             if (highestEvis.size() > 1) {
                 Set<LevelOfEvidence> checkLevels = new HashSet<>();
                 checkLevels.add(LevelOfEvidence.LEVEL_3B);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -654,14 +654,15 @@ public class EvidenceUtils {
             }
         }
 
+        // if the levels include more than one evidence, we only return one
         if (highestLevel != null) {
             if (tagAlongEvidences.size() > 0) {
                 Set<Evidence> mergeResult = new HashSet<>();
-                mergeResult.addAll(levels.get(highestLevel));
+                mergeResult.add(levels.get(highestLevel).iterator().next());
                 mergeResult.addAll(tagAlongEvidences);
                 return mergeResult;
             } else {
-                return levels.get(highestLevel);
+                return Collections.singleton(levels.get(highestLevel).iterator().next());
             }
         } else {
             return new HashSet<>();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/FileUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/FileUtils.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,6 +68,14 @@ public class FileUtils {
     public static String readRemote(String urlToFile) throws IOException {
         URL url = new URL(urlToFile);
         return readStream(url.openStream());
+    }
+
+    public static String readMSKPortal(String urlToFile) throws IOException {
+        URL myURL = new URL(urlToFile);
+        HttpURLConnection myURLConnection = (HttpURLConnection)myURL.openConnection();
+        myURLConnection.setRequestProperty ("Authorization", "Bearer " + PropertiesUtils.getProperties("cbioportal.token"));
+        myURLConnection.setRequestMethod("GET");
+        return readStream(myURLConnection.getInputStream());
     }
 
     public static String readPublicOncoKBRemote(String urlToFile) throws IOException {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -735,8 +735,9 @@ public class IndicatorUtils {
 
     private static boolean treatmentExist(List<IndicatorQueryTreatment> treatments, LevelOfEvidence newTreatmentLevel,  List<Drug> newTreatment) {
         boolean exists = false;
+        // Info level treatment can be included even the drug(s) is the same
         for (IndicatorQueryTreatment treatment : treatments) {
-            if (getSortedTreatmentName(treatment.getDrugs()).equals(getSortedTreatmentName(newTreatment)) && newTreatmentLevel.getLevel().equals(treatment.getLevel())) {
+            if (getSortedTreatmentName(treatment.getDrugs()).equals(getSortedTreatmentName(newTreatment)) && !LevelUtils.INFO_LEVELS.contains(newTreatmentLevel)) {
                 exists = true;
                 break;
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -714,7 +714,7 @@ public class IndicatorUtils {
                     List<Treatment> list = new ArrayList<>(sameLevelTreatments);
                     TreatmentUtils.sortTreatmentsByPriority(list);
                     for (Treatment treatment : list) {
-                        if (!treatmentExist(treatments, treatment.getDrugs())) {
+                        if (!treatmentExist(treatments, level, treatment.getDrugs())) {
                             IndicatorQueryTreatment indicatorQueryTreatment = new IndicatorQueryTreatment();
                             indicatorQueryTreatment.setDrugs(treatment.getDrugs());
                             indicatorQueryTreatment.setApprovedIndications(treatment.getApprovedIndications());
@@ -733,10 +733,10 @@ public class IndicatorUtils {
         return treatments;
     }
 
-    private static boolean treatmentExist(List<IndicatorQueryTreatment> treatments, List<Drug> newTreatment) {
+    private static boolean treatmentExist(List<IndicatorQueryTreatment> treatments, LevelOfEvidence newTreatmentLevel,  List<Drug> newTreatment) {
         boolean exists = false;
         for (IndicatorQueryTreatment treatment : treatments) {
-            if (getSortedTreatmentName(treatment.getDrugs()).equals(getSortedTreatmentName(newTreatment))) {
+            if (getSortedTreatmentName(treatment.getDrugs()).equals(getSortedTreatmentName(newTreatment)) && newTreatmentLevel.getLevel().equals(treatment.getLevel())) {
                 exists = true;
                 break;
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/LevelUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/LevelUtils.java
@@ -60,6 +60,11 @@ public class LevelUtils {
         Arrays.asList(LevelOfEvidence.LEVEL_Dx3, LevelOfEvidence.LEVEL_Dx2, LevelOfEvidence.LEVEL_Dx1)
     );
 
+    // levels that should be provided as additional info. Highest level calculation should not remove it.
+    public static final List<LevelOfEvidence> INFO_LEVELS = Collections.unmodifiableList(
+        Arrays.asList(LevelOfEvidence.LEVEL_R2)
+    );
+
     public static Integer compareLevel(LevelOfEvidence a, LevelOfEvidence b) {
         return compareLevel(a, b, PUBLIC_LEVELS);
     }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/EvidenceUtilsTest.java
@@ -245,12 +245,12 @@ public class EvidenceUtilsTest extends TestCase {
         e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_2);
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R2);
         filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
-        assertEquals("1", getIds(filtered));
+        assertEquals("1,5", getIds(filtered));
 
         e1.setLevelOfEvidence(LevelOfEvidence.LEVEL_4);
         e5.setLevelOfEvidence(LevelOfEvidence.LEVEL_R2);
         filtered = EvidenceUtils.keepHighestLevelForSameTreatments(sets, alteration);
-        assertEquals("1", getIds(filtered));
+        assertEquals("1,5", getIds(filtered));
     }
 
     private String getIds(Set<Evidence> evidences) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/TreatmentParameterizedTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/TreatmentParameterizedTest.java
@@ -62,7 +62,9 @@ public class TreatmentParameterizedTest {
         }
         String tl = stringBuilder.toString().trim();
 
-//        System.out.println("New: " + gene + "&&" + variant + "&&" + tumorType + "&&" + tl);
+        if (!treatmentLevel.equalsIgnoreCase(tl) || treatmentLevel.equalsIgnoreCase("")) {
+            System.out.println("New: " + gene + "&&" + variant + "&&" + tumorType + "&&" + treatmentLevel + "&&" + tl);
+        }
 
         assertEquals("Gene summary, Query: " + gene + " " + variant + " " + tumorType, treatmentLevel, tl);
 

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/TreatmentParameterizedTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/TreatmentParameterizedTest.java
@@ -62,9 +62,7 @@ public class TreatmentParameterizedTest {
         }
         String tl = stringBuilder.toString().trim();
 
-        if (!treatmentLevel.equalsIgnoreCase(tl) || treatmentLevel.equalsIgnoreCase("")) {
-            System.out.println("New: " + gene + "&&" + variant + "&&" + tumorType + "&&" + treatmentLevel + "&&" + tl);
-        }
+//        System.out.println("New: " + gene + "&&" + variant + "&&" + tumorType + "&&" + treatmentLevel + "&&" + tl);
 
         assertEquals("Gene summary, Query: " + gene + " " + variant + " " + tumorType, treatmentLevel, tl);
 

--- a/core/src/test/resources/test_treatments.txt
+++ b/core/src/test/resources/test_treatments.txt
@@ -71,6 +71,33 @@ KIT	D816A	Melanoma	2: Imatinib; 3B: Regorafenib; 3B: Sorafenib; 3B: Avapritinib;
 KIT	D816A	Colorectal Cancer 3B: Regorafenib; 3B: Sorafenib;
 KIT	D816A	Mastocytosis	3A: Avapritinib;
 KIT	D816A	Thymic Tumor	2: Sunitinib; 3B: Regorafenib; 3B: Sorafenib; 3B: Avapritinib;
+KIT	Y823D	Gatrointestinal stromal tumor
+KIT	Y823D	Melanoma
+KIT	Y823D	Thymic Tumor
+KIT	Y823D	Colorectal Cancer
+KIT	Y823G	Gatrointestinal stromal tumor
+KIT	Y823G	Melanoma
+KIT	Y823G	Thymic Tumor
+KIT	Y823G	Colorectal Cancer
+KIT	A829P	Gatrointestinal stromal tumor
+KIT	A829P	Melanoma
+KIT	A829P	Thymic Tumor
+KIT	A829P	Colorectal Cancer
+KIT	A829P	Gatrointestinal stromal tumor
+KIT	A829P	Melanoma
+KIT	A829P	Thymic Tumor
+KIT	A829P	Colorectal Cancer
+KIT	D820G	Gatrointestinal stromal tumor
+KIT	D820G	Melanoma
+KIT	D820G	Thymic Tumor
+KIT	D820G	Colorectal Cancer
+KIT	D820G	Mastocytosis
+KIT	N822E	Gatrointestinal stromal tumor
+KIT	N822E	Melanoma
+KIT	N822E	Thymic Tumor
+KIT	N822E	Colorectal Cancer
+
+
 MTOR	L2427Q	Renal Clear Cell Carcinoma	3A: Temsirolimus; 4: Everolimus;
 PDGFRA	D842I	GIST	2: Imatinib;
 PDGFRA	D842I	Thymic Tumor	3B: Imatinib;

--- a/core/src/test/resources/test_treatments.txt
+++ b/core/src/test/resources/test_treatments.txt
@@ -71,28 +71,24 @@ KIT	D816A	Melanoma	2: Imatinib; 3B: Regorafenib; 3B: Sorafenib; 3B: Avapritinib;
 KIT	D816A	Colorectal Cancer 3B: Regorafenib; 3B: Sorafenib;
 KIT	D816A	Mastocytosis	3A: Avapritinib;
 KIT	D816A	Thymic Tumor	2: Sunitinib; 3B: Regorafenib; 3B: Sorafenib; 3B: Avapritinib;
-KIT	Y823D	Gatrointestinal stromal tumor
+KIT	Y823D	Gastrointestinal Stromal Tumor
 KIT	Y823D	Melanoma
 KIT	Y823D	Thymic Tumor
 KIT	Y823D	Colorectal Cancer
-KIT	Y823G	Gatrointestinal stromal tumor
+KIT	Y823G	Gastrointestinal Stromal Tumor
 KIT	Y823G	Melanoma
 KIT	Y823G	Thymic Tumor
 KIT	Y823G	Colorectal Cancer
-KIT	A829P	Gatrointestinal stromal tumor
+KIT	A829P	Gastrointestinal Stromal Tumor
 KIT	A829P	Melanoma
 KIT	A829P	Thymic Tumor
 KIT	A829P	Colorectal Cancer
-KIT	A829P	Gatrointestinal stromal tumor
-KIT	A829P	Melanoma
-KIT	A829P	Thymic Tumor
-KIT	A829P	Colorectal Cancer
-KIT	D820G	Gatrointestinal stromal tumor
+KIT	D820G	Gastrointestinal Stromal Tumor
 KIT	D820G	Melanoma
 KIT	D820G	Thymic Tumor
 KIT	D820G	Colorectal Cancer
 KIT	D820G	Mastocytosis
-KIT	N822E	Gatrointestinal stromal tumor
+KIT	N822E	Gastrointestinal Stromal Tumor
 KIT	N822E	Melanoma
 KIT	N822E	Thymic Tumor
 KIT	N822E	Colorectal Cancer

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -80,7 +80,7 @@
         <profile>
             <id>curate</id>
             <properties>
-                <frontend.version>5e87fed167</frontend.version>
+                <frontend.version>56940c136d</frontend.version>
                 <frontend.groupId>com.github.oncokb</frontend.groupId>
                 <frontend.artifactId>curation-platform</frontend.artifactId>
             </properties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -80,7 +80,7 @@
         <profile>
             <id>curate</id>
             <properties>
-                <frontend.version>56940c136d</frontend.version>
+                <frontend.version>bfc6670a99</frontend.version>
                 <frontend.groupId>com.github.oncokb</frontend.groupId>
                 <frontend.artifactId>curation-platform</frontend.artifactId>
             </properties>


### PR DESCRIPTION
- Remove KIT special rules
- Change the portal alteration source. The MSK portal has the alterations with the same transcript OncoKB using
- Always include R2 evidences even the same treatment is sensitizing. R2 has been treated as information level. 