### PR TITLE
Fix issue when positional variant forced to be missense variant

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_MINOR_VERSION'
-tag-template: 'v$NEXT_MINOR_VERSION'
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🧬 Features'
     labels:
@@ -34,5 +34,5 @@ template: |
 
   ## 🕵️‍♀️ Full commit logs
 
-  - https://github.com/oncokb/oncokb/compare/$PREVIOUS_TAG...v$NEXT_MINOR_VERSION
+  - https://github.com/oncokb/oncokb/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -723,8 +723,15 @@ public final class AlterationUtils {
         // the alternative alleles do not only include the different variant allele, but also include the delins but it's essentially the same thing.
         // For instance, S768_V769delinsIL. This is equivalent to S768I + V769L, S768I should be listed relevant and not be excluded.
         if (alteration != null && alteration.getConsequence() != null && alteration.getConsequence().getTerm().equals(MISSENSE_VARIANT)) {
+            // check for positional variant when the consequence is forced to be missense variant
+            boolean isMissensePositionalVariant = StringUtils.isEmpty(alteration.getVariantResidues()) && alteration.getProteinStart() != null && alteration.getProteinEnd() != null && alteration.getProteinStart().equals(alteration.getProteinEnd());
             List<Alteration> alternativeAlleles = alterationBo.findMutationsByConsequenceAndPosition(alteration.getGene(), alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), new HashSet<>(relevantAlterations));
             for (Alteration allele : alternativeAlleles) {
+                // remove all alleles if the alteration variant residue is empty
+                if (isMissensePositionalVariant && !StringUtils.isEmpty(allele.getVariantResidues())) {
+                    relevantAlterations.remove(allele);
+                    return;
+                }
                 if (allele.getConsequence() != null && allele.getConsequence().getTerm().equals(MISSENSE_VARIANT)) {
                     if (alteration.getProteinStart().equals(alteration.getProteinEnd())) {
                         if (allele.getProteinStart().equals(allele.getProteinEnd())) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -590,6 +590,14 @@ public class IndicatorUtilsTest {
         resp1 = IndicatorUtils.processQuery(query1, null, true, null);
         resp2 = IndicatorUtils.processQuery(query2, null, true, null);
         pairComparison(resp1, resp2);
+
+        // Test positional variant but with a missense variant consequence
+        query1 = new Query(null, null, null, "TP53", "R248", null, null, "RDD", null, null, null, null);
+        query2 = new Query(null, null, null, "TP53", "R248", null, null, "RDD", MISSENSE_VARIANT, null, null, null);
+        resp1 = IndicatorUtils.processQuery(query1, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, true, null);
+        pairComparison(resp1, resp2);
+
     }
 
     private void pairComparison(IndicatorQueryResp resp1, IndicatorQueryResp resp2) {


### PR DESCRIPTION
When user specifies the positional variant as missense variant, the downstream would be confused. Adding checks to bypass that

This fixes https://github.com/cBioPortal/cbioportal/issues/7499