### PR TITLE
Fix the tag name in the auto docker release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,4 +25,4 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           mvn -ntp package -DskipTests -P public,production
-          docker push oncokb/oncokb:${TAG_NAME}
+          docker push oncokb/oncokb:${TAG_NAME:1}


### PR DESCRIPTION
The tag name includes v but the docker does not use v.