### PR TITLE
Fix issue when querying unknown gene

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
@@ -91,7 +91,9 @@ public class Query implements java.io.Serializable {
         if (com.mysql.jdbc.StringUtils.isNullOrEmpty(geneHugoSymbol)) {
             if (queryGene.getEntrezGeneId() != null) {
                 gene = findGene(Integer.toString(queryGene.getEntrezGeneId()));
-                geneHugoSymbol = gene.getHugoSymbol();
+                if (gene != null) {
+                    geneHugoSymbol = gene.getHugoSymbol();
+                }
             }
             if (com.mysql.jdbc.StringUtils.isNullOrEmpty(geneHugoSymbol)) {
                 geneHugoSymbol = "";

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GeneAnnotator.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GeneAnnotator.java
@@ -26,6 +26,9 @@ public final class GeneAnnotator {
 
 
     public static Gene findGene(String symbol) {
+        if (StringUtils.isNumeric(symbol) && Integer.parseInt(symbol) <= 0) {
+            return null;
+        }
         Gene gene = findGeneFromCBioPortal(symbol);
         if (gene == null) {
             System.out.println("The gene does not exist in cBioPortal, looking in MyGeneInfo");
@@ -47,6 +50,9 @@ public final class GeneAnnotator {
     }
 
     private static Gene findGeneFromCBioPortal(String symbol) {
+        if (StringUtils.isNumeric(symbol) && Integer.parseInt(symbol) <= 0) {
+            return null;
+        }
         try {
             String response = HttpUtils.getRequest(CBIOPORTAL_GENES_ENDPOINT + symbol);
             JSONObject jsonObj = new JSONObject(response);
@@ -175,6 +181,9 @@ public final class GeneAnnotator {
     }
 
     private static void includeGeneAlias(Gene gene) throws IOException {
+        if (gene.getEntrezGeneId() == null || gene.getEntrezGeneId() <= 0) {
+            return;
+        }
         String url = URL_MY_GENE_INFO_3 + "gene/" + gene.getEntrezGeneId()
             + "?fields=alias";
         String json = FileUtils.readRemote(url);


### PR DESCRIPTION
- Do not send gene query to portal and mygeneinfo when entrez is not positive number
- Check whether gene exists after returning

This fixes https://github.com/oncokb/oncokb/issues/2412