### PR TITLE
Remove JsonIdentityInfo for Evidence model

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Evidence.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Evidence.java
@@ -1,8 +1,6 @@
 package org.mskcc.cbio.oncokb.model;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
@@ -84,7 +82,6 @@ import java.util.*;
 
 @Entity
 @Table(name = "evidence")
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Evidence implements java.io.Serializable {
 
     @Id


### PR DESCRIPTION
The annotation removes the duplicate model and keeps the id instead https://stackoverflow.com/questions/27109953/jackson-with-spring-mvc-duplicate-nested-objects-not-deserializing
The original design is for drug model. The evidence should not be included.
This fixes https://github.com/oncokb/oncokb/issues/2418