### PR TITLE
Do not get the relevant tumor type separately

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/EvidenceBo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/EvidenceBo.java
@@ -47,7 +47,7 @@ public interface EvidenceBo extends GenericBo<Evidence> {
      * @param tumorTypes
      * @return
      */
-    List<Evidence> findEvidencesByAlteration(Collection<Alteration> alterations, Collection<EvidenceType> evidenceTypes, TumorType tumorType, Collection<TumorType> tumorTypes);
+    List<Evidence> findEvidencesByAlteration(Collection<Alteration> alterations, Collection<EvidenceType> evidenceTypes, TumorType tumorType, List<TumorType> tumorTypes);
 
 
     /**
@@ -58,7 +58,7 @@ public interface EvidenceBo extends GenericBo<Evidence> {
      * @param levelOfEvidences
      * @return
      */
-    List<Evidence> findEvidencesByAlteration(Collection<Alteration> alterations, Collection<EvidenceType> evidenceTypes, TumorType tumorType, Collection<TumorType> tumorTypes, Collection<LevelOfEvidence> levelOfEvidences);
+    List<Evidence> findEvidencesByAlteration(Collection<Alteration> alterations, Collection<EvidenceType> evidenceTypes, TumorType tumorType, List<TumorType> tumorTypes, Collection<LevelOfEvidence> levelOfEvidences);
 
     /**
      * Find Evidences by Entrez Gene ID

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -147,7 +147,7 @@ public class EvidenceUtils {
         return result;
     }
 
-    public static List<Evidence> getEvidence(List<Alteration> alterations, Set<EvidenceType> evidenceTypes, TumorType matchedTumorType, Set<TumorType> tumorTypes, Set<LevelOfEvidence> levelOfEvidences) {
+    public static List<Evidence> getEvidence(List<Alteration> alterations, Set<EvidenceType> evidenceTypes, TumorType matchedTumorType, List<TumorType> tumorTypes, Set<LevelOfEvidence> levelOfEvidences) {
         if (alterations == null || alterations.size() == 0) {
             return new ArrayList<>();
         }
@@ -170,8 +170,8 @@ public class EvidenceUtils {
         Set<Gene> genes = new HashSet<>(); //Get gene evidences
         TumorType matchedTumorType = TumorTypeUtils.getByName(query.getQuery().getTumorType());
         Set<Alteration> alterations = new HashSet<>();
-        Set<TumorType> upwardTumorTypes = new HashSet<>();
-        Set<TumorType> downwardTumorTypes = new HashSet<>();
+        List<TumorType> upwardTumorTypes = new ArrayList<>();
+        List<TumorType> downwardTumorTypes = new ArrayList<>();
 
         if (query.getOncoTreeTypes() != null) {
             upwardTumorTypes.addAll(query.getOncoTreeTypes());

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -301,13 +301,13 @@ public class IndicatorUtils {
 
                 if (hasDiagnosticImplicationEvidence) {
                     List<Implication> implications = new ArrayList<>();
-                    implications.addAll(getImplications(matchedAlt, alleles, relevantAlterationsWithoutAlternativeAlleles, EvidenceType.DIAGNOSTIC_IMPLICATION, matchedTumorType, StringUtils.isEmpty(query.getTumorType()) ? null : new HashSet<>(relevantDownwardTumorTypes), query.getHugoSymbol(), Collections.singleton(LevelOfEvidence.LEVEL_Dx1)));
+                    implications.addAll(getImplications(matchedAlt, alleles, relevantAlterationsWithoutAlternativeAlleles, EvidenceType.DIAGNOSTIC_IMPLICATION, matchedTumorType, StringUtils.isEmpty(query.getTumorType()) ? null : relevantDownwardTumorTypes, query.getHugoSymbol(), Collections.singleton(LevelOfEvidence.LEVEL_Dx1)));
 
                     // For Dx2 and Dx3, the logic is the same as Tx/Px
                     Set<LevelOfEvidence> levelOfEvidences = new HashSet<>();
                     levelOfEvidences.add(LevelOfEvidence.LEVEL_Dx2);
                     levelOfEvidences.add(LevelOfEvidence.LEVEL_Dx3);
-                    implications.addAll(getImplications(matchedAlt, alleles, relevantAlterationsWithoutAlternativeAlleles, EvidenceType.DIAGNOSTIC_IMPLICATION, matchedTumorType, StringUtils.isEmpty(query.getTumorType()) ? null : new HashSet<>(relevantUpwardTumorTypes), query.getHugoSymbol(), levelOfEvidences));
+                    implications.addAll(getImplications(matchedAlt, alleles, relevantAlterationsWithoutAlternativeAlleles, EvidenceType.DIAGNOSTIC_IMPLICATION, matchedTumorType, StringUtils.isEmpty(query.getTumorType()) ? null : relevantUpwardTumorTypes, query.getHugoSymbol(), levelOfEvidences));
                     indicatorQuery.setDiagnosticImplications(implications);
                     if (indicatorQuery.getDiagnosticImplications().size() > 0) {
                         indicatorQuery.setHighestDiagnosticImplicationLevel(LevelUtils.getHighestDiagnosticImplicationLevel(indicatorQuery.getDiagnosticImplications().stream().map(implication -> implication.getLevelOfEvidence()).collect(Collectors.toSet())));
@@ -315,7 +315,7 @@ public class IndicatorUtils {
                 }
 
                 if (hasPrognosticImplicationEvidence) {
-                    indicatorQuery.setPrognosticImplications(getImplications(matchedAlt, alleles, relevantAlterationsWithoutAlternativeAlleles, EvidenceType.PROGNOSTIC_IMPLICATION, matchedTumorType, StringUtils.isEmpty(query.getTumorType()) ? null : new HashSet<>(relevantUpwardTumorTypes), query.getHugoSymbol(), null));
+                    indicatorQuery.setPrognosticImplications(getImplications(matchedAlt, alleles, relevantAlterationsWithoutAlternativeAlleles, EvidenceType.PROGNOSTIC_IMPLICATION, matchedTumorType, StringUtils.isEmpty(query.getTumorType()) ? null : relevantUpwardTumorTypes, query.getHugoSymbol(), null));
                     if (indicatorQuery.getPrognosticImplications().size() > 0) {
                         indicatorQuery.setHighestPrognosticImplicationLevel(LevelUtils.getHighestPrognosticImplicationLevel(indicatorQuery.getPrognosticImplications().stream().map(implication -> implication.getLevelOfEvidence()).collect(Collectors.toSet())));
                     }
@@ -549,7 +549,7 @@ public class IndicatorUtils {
         return implications;
     }
 
-    private static List<Implication> getImplications(Alteration matchedAlt, List<Alteration> alternativeAlleles, List<Alteration> relevantAlterations, EvidenceType evidenceType, TumorType matchedTumorType, Set<TumorType> tumorTypes, String queryHugoSymbol, Set<LevelOfEvidence> levelOfEvidences) {
+    private static List<Implication> getImplications(Alteration matchedAlt, List<Alteration> alternativeAlleles, List<Alteration> relevantAlterations, EvidenceType evidenceType, TumorType matchedTumorType, List<TumorType> tumorTypes, String queryHugoSymbol, Set<LevelOfEvidence> levelOfEvidences) {
         List<Implication> implications = new ArrayList<>();
 
         // Find alteration specific evidence

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
@@ -69,13 +69,8 @@ public class SummaryUtils {
         // Get all tumor type summary evidences for the exact alteration + alternative alleles
         // Tumor type has high priority. Get relevant tumor type summary across all alternative alleles, then look for other tumor types summary
         if (tumorTypeSummary == null) {
-            for (TumorType tumorType : relevantTumorTypes) {
-                for (Alteration allele : alternativeAlleles) {
-                    tumorTypeSummary = getRelevantTumorTypeSummaryByAlt(evidenceType, allele, tumorType, Collections.singleton(tumorType));
-                    if (tumorTypeSummary != null) {
-                        break;
-                    }
-                }
+            for (Alteration allele : alternativeAlleles) {
+                tumorTypeSummary = getRelevantTumorTypeSummaryByAlt(evidenceType, allele, matchedTumorType, relevantTumorTypes);
                 if (tumorTypeSummary != null) {
                     break;
                 }
@@ -125,11 +120,9 @@ public class SummaryUtils {
 
             // Base on the priority of relevant alterations
             for (Alteration alt : relevantAlterations) {
-                for (TumorType tumorType : relevantTumorTypes) {
-                    tumorTypeSummary = getRelevantTumorTypeSummaryByAlt(evidenceType, alt, tumorType, Collections.singleton(tumorType));
-                    if (tumorTypeSummary != null) {
-                        break;
-                    }
+                tumorTypeSummary = getRelevantTumorTypeSummaryByAlt(evidenceType, alt, matchedTumorType, relevantTumorTypes);
+                if (tumorTypeSummary != null) {
+                    break;
                 }
                 if (tumorTypeSummary != null) {
                     break;
@@ -170,7 +163,7 @@ public class SummaryUtils {
         return tumorTypeSummary;
     }
 
-    private static Map<String, Object> getRelevantTumorTypeSummaryByAlt(EvidenceType evidenceType, Alteration alteration, TumorType matchedTumorType, Set<TumorType> relevantTumorTypes) {
+    private static Map<String, Object> getRelevantTumorTypeSummaryByAlt(EvidenceType evidenceType, Alteration alteration, TumorType matchedTumorType, List<TumorType> relevantTumorTypes) {
         return getTumorTypeSummaryFromEvidences(EvidenceUtils.getEvidence(Collections.singletonList(alteration), Collections.singleton(evidenceType), matchedTumorType, relevantTumorTypes, null));
     }
 
@@ -191,7 +184,7 @@ public class SummaryUtils {
                 Collections.singletonList(alteration),
                 Collections.singleton(evidenceType),
                 TumorTypeUtils.getBySpecialTumor(specialTumorType),
-                Collections.singleton(TumorTypeUtils.getBySpecialTumor(specialTumorType)), null);
+                Collections.singletonList(TumorTypeUtils.getBySpecialTumor(specialTumorType)), null);
             if (evidences.size() > 0) {
                 return getTumorTypeSummaryFromEvidences(evidences);
             }


### PR DESCRIPTION
The evidence now includes relevant cancer type. It cannot be used directly with relevant cancer type of the query