### PR TITLE
Splice consequences should be treated equally

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
@@ -1,6 +1,13 @@
 package org.mskcc.cbio.oncokb;
 
 import org.mskcc.cbio.oncokb.model.ReferenceGenome;
+import org.mskcc.cbio.oncokb.model.VariantConsequence;
+import org.mskcc.cbio.oncokb.util.VariantConsequenceUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Application constants.
@@ -22,6 +29,8 @@ public final class Constants {
     public static final String SWAGGER_DESCRIPTION = "swagger_description";
 
     public static final ReferenceGenome DEFAULT_REFERENCE_GENOME = ReferenceGenome.GRCh37;
+
+    public static final Set<VariantConsequence> SPLICE_SITE_VARIANTS = Arrays.asList("splice_acceptor_variant", "splice_donor_variant", "splice_region_variant").stream().map(term -> VariantConsequenceUtils.findVariantConsequenceByTerm(term)).collect(Collectors.toSet());
 
     private Constants() {
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -144,7 +144,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         if (alterations != null && alterations.size() > 0) {
             for (Alteration alteration : alterations) {
                 if (alteration.getGene().equals(gene) && alteration.getConsequence() != null
-                    && alteration.getConsequence().equals(consequence)
+                    && AlterationUtils.consequenceRelated(alteration.getConsequence(), consequence)
                     && alteration.getProteinStart() != null
                     && alteration.getProteinEnd() != null
                     && (referenceGenome == null || alteration.getReferenceGenomes().contains(referenceGenome))

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -18,9 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.mskcc.cbio.oncokb.Constants.DEFAULT_REFERENCE_GENOME;
-import static org.mskcc.cbio.oncokb.Constants.MISSENSE_VARIANT;
-import static org.mskcc.cbio.oncokb.Constants.UPSTREAM_GENE;
+import static org.mskcc.cbio.oncokb.Constants.*;
 
 /**
  * @author jgao
@@ -38,10 +36,21 @@ public final class AlterationUtils {
         throw new AssertionError();
     }
 
+    public static boolean consequenceRelated(VariantConsequence consequence, VariantConsequence compareTo) {
+        if (consequence == null || compareTo == null) {
+            return consequence == compareTo;
+        }
+        if (SPLICE_SITE_VARIANTS.contains(consequence)) {
+            return SPLICE_SITE_VARIANTS.contains(compareTo);
+        } else {
+            return consequence.equals(compareTo);
+        }
+    }
+
     public static Set<Alteration> findOverlapAlteration(Set<Alteration> alterations, Gene gene, ReferenceGenome referenceGenome, VariantConsequence consequence, int start, int end) {
         Set<Alteration> overlaps = new HashSet<>();
         for (Alteration alteration : alterations) {
-            if (alteration.getGene().equals(gene) && alteration.getConsequence() != null && alteration.getConsequence().equals(consequence) && (referenceGenome == null || alteration.getReferenceGenomes().contains(referenceGenome))) {
+            if (alteration.getGene().equals(gene) && alteration.getConsequence() != null && consequenceRelated(consequence, alteration.getConsequence()) && (referenceGenome == null || alteration.getReferenceGenomes().contains(referenceGenome))) {
                 //For alteration without specific position, do not do intersection
                 if (start <= AlterationPositionBoundary.START.getValue() || end >= AlterationPositionBoundary.END.getValue()) {
                     if (start >= alteration.getProteinStart()
@@ -309,7 +318,7 @@ public final class AlterationUtils {
         if (alteration.getConsequence() == null && variantConsequence != null) {
             alteration.setConsequence(variantConsequence);
         } else if (alteration.getConsequence() != null && variantConsequence != null &&
-            !alteration.getConsequence().equals(variantConsequence)) {
+            !AlterationUtils.consequenceRelated(alteration.getConsequence(), variantConsequence)) {
             // For the query which already contains consequence but different with OncoKB algorithm,
             // we should keep query consequence unless it is `any`
             if (alteration.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm("any"))) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
@@ -345,7 +345,7 @@ public class CacheUtils {
     public static Set<Alteration> findMutationsByConsequenceAndPositionOnSamePosition(Gene gene, ReferenceGenome referenceGenome, VariantConsequence consequence, int start, int end) {
         Set<Alteration> alterations = new HashSet<>();
         for (Alteration alteration : getAlterations(gene.getEntrezGeneId())) {
-            if (alteration.getConsequence().equals(consequence)
+            if (AlterationUtils.consequenceRelated(alteration.getConsequence(), consequence)
                 && (referenceGenome == null || alteration.getReferenceGenomes().contains(referenceGenome))
                 && alteration.getProteinStart().equals(alteration.getProteinEnd())
                 && alteration.getProteinStart() >= start

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -602,7 +602,7 @@ public class EvidenceUtils {
                 Iterator<Alteration> i = relevantAlterations.iterator();
                 while (i.hasNext()) {
                     Alteration relAlt = i.next();
-                    if (relAlt.getConsequence().equals(alteration.getConsequence())) {
+                    if (AlterationUtils.consequenceRelated(relAlt.getConsequence(), alteration.getConsequence())) {
                         if (relAlt.getProteinStart() > alteration.getProteinStart() || relAlt.getProteinEnd() < alteration.getProteinEnd()) {
                             i.remove();
                         }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsIndependentTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsIndependentTest.java
@@ -66,4 +66,60 @@ public class FindRelevantAlterationsIndependentTest extends TestCase {
         assertEquals(1, relevantAlterations.size());
     }
 
+    public void testFindRelevantAlterationsWithConsequence() {
+        Gene gene = new Gene();
+        gene.setHugoSymbol("MET");
+        gene.setEntrezGeneId(4233);
+
+        Alteration alt1 = new Alteration();
+        alt1.setGene(gene);
+        alt1.setAlteration("X1010_splice");
+        alt1.setConsequence(VariantConsequenceUtils.findVariantConsequenceByTerm("splice_region_variant"));
+        alt1.setReferenceGenomes(Collections.singleton(ReferenceGenome.GRCh37));
+        AlterationUtils.annotateAlteration(alt1, alt1.getAlteration());
+
+
+        // alt should be matched when the consequence is the same
+        Alteration query = new Alteration();
+        query.setGene(gene);
+        query.setAlteration("X1010_splice");
+        query.setConsequence(VariantConsequenceUtils.findVariantConsequenceByTerm("splice_region_variant"));
+        AlterationUtils.annotateAlteration(query, query.getAlteration());
+
+        LinkedHashSet<Alteration> relevantAlterations =
+            ApplicationContextSingleton.getAlterationBo()
+                .findRelevantAlterations(ReferenceGenome.GRCh37, query, Collections.singleton(alt1), true);
+
+        assertEquals(1, relevantAlterations.size());
+
+
+        // alt should be matched when the consequence is relevant
+        query = new Alteration();
+        query.setGene(gene);
+        query.setAlteration("X1010_splice");
+        query.setConsequence(VariantConsequenceUtils.findVariantConsequenceByTerm("splice_donor_variant"));
+        AlterationUtils.annotateAlteration(query, query.getAlteration());
+
+        relevantAlterations =
+            ApplicationContextSingleton.getAlterationBo()
+                .findRelevantAlterations(ReferenceGenome.GRCh37, query, Collections.singleton(alt1), true);
+
+        assertEquals(1, relevantAlterations.size());
+
+
+        // alt should not be matched when the consequence is irrelevant
+        query = new Alteration();
+        query.setGene(gene);
+        query.setAlteration("X1010_splice");
+        query.setConsequence(VariantConsequenceUtils.findVariantConsequenceByTerm("missense_mutation"));
+        AlterationUtils.annotateAlteration(query, query.getAlteration());
+
+        relevantAlterations =
+            ApplicationContextSingleton.getAlterationBo()
+                .findRelevantAlterations(ReferenceGenome.GRCh37, query, Collections.singleton(alt1), true);
+
+        assertEquals(0, relevantAlterations.size());
+
+    }
+
 }


### PR DESCRIPTION
When variant is annotated as a splice mutation, no matter it's region/donor/acceptor, they should have the same impact.
This fixes https://github.com/oncokb/oncokb/issues/2541