### PR TITLE
Cache annotation endpoints/ findGeneBySymbol/GN hgvsg/genomic change

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/Citations.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/Citations.java
@@ -2,13 +2,14 @@ package org.mskcc.cbio.oncokb.apiModels;
 
 import org.mskcc.cbio.oncokb.model.ArticleAbstract;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Created by Hongxin Zhang on 2/21/18.
  */
-public class Citations {
+public class Citations implements Serializable {
     Set<String> pmids = new HashSet<String>(0);
     Set<ArticleAbstract> abstracts = new HashSet<ArticleAbstract>(0);
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/Implication.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/Implication.java
@@ -4,13 +4,14 @@ import org.mskcc.cbio.oncokb.model.ArticleAbstract;
 import org.mskcc.cbio.oncokb.model.LevelOfEvidence;
 import org.mskcc.cbio.oncokb.apiModels.TumorType;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Created by Hongxin Zhang on 2019-05-29.
  */
-public class Implication {
+public class Implication implements Serializable {
     LevelOfEvidence levelOfEvidence;
     Set<String> alterations = new HashSet<>();
     TumorType tumorType;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/MainType.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/MainType.java
@@ -3,6 +3,7 @@ package org.mskcc.cbio.oncokb.apiModels;
 import io.swagger.annotations.ApiModel;
 import org.mskcc.cbio.oncokb.model.TumorForm;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 
@@ -10,7 +11,7 @@ import java.util.Objects;
  * General tumor type category.
  **/
 @ApiModel(description = "OncoTree Cancer Type")
-public class MainType {
+public class MainType implements Serializable {
 
   private Integer id = null;
   private String name = null;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/MutationEffectResp.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/MutationEffectResp.java
@@ -1,9 +1,11 @@
 package org.mskcc.cbio.oncokb.apiModels;
 
+import java.io.Serializable;
+
 /**
  * Created by Hongxin Zhang on 2/21/18.
  */
-public class MutationEffectResp {
+public class MutationEffectResp implements Serializable {
     String knownEffect = "";
     String description = "";
     Citations citations = new Citations();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/TumorType.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/TumorType.java
@@ -5,13 +5,14 @@ import org.mskcc.cbio.oncokb.model.TumorForm;
 import org.mskcc.cbio.oncokb.util.MainUtils;
 import org.mskcc.cbio.oncokb.util.TumorTypeUtils;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 
 @ApiModel(description = "OncoTree Detailed Cancer Type")
-public class TumorType {
+public class TumorType implements Serializable {
 
     private Integer id = null;
     private String code = null;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/OncokbTranscriptService.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/OncokbTranscriptService.java
@@ -173,6 +173,6 @@ public class OncokbTranscriptService {
             gene.setGeneAliases(transcriptGene.getGeneAliases().stream().map(geneAlias -> geneAlias.getName()).collect(Collectors.toSet()));
             return gene;
         }
-        return null;
+        return new Gene();
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -1,5 +1,6 @@
 package org.mskcc.cbio.oncokb.cache;
 
+import org.mskcc.cbio.oncokb.cache.keygenerator.ConcatGenerator;
 import org.mskcc.cbio.oncokb.util.PropertiesUtils;
 import org.mskcc.oncokb.meta.enumeration.RedisType;
 import org.redisson.Redisson;
@@ -8,6 +9,7 @@ import org.redisson.config.Config;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.CacheResolver;
+import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.*;
 
 @Configuration
@@ -66,5 +68,10 @@ public class CacheConfiguration {
         CacheManager cm
     ) {
         return new GeneralCacheResolver(cm);
+    }
+
+    @Bean
+    public KeyGenerator concatKeyGenerator(){
+        return new ConcatGenerator();
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -30,12 +30,14 @@ public class CacheConfiguration {
                 .setAddress(redisAddress)
                 .setConnectionMinimumIdleSize(1)
                 .setConnectionPoolSize(2)
+                .setDnsMonitoringInterval(-1)
                 .setPassword(redisPassword);
         } else if (redisType.equals(RedisType.SENTINEL.getType())) {
             config
                 .useSentinelServers()
                 .setMasterName(redisMasterName)
                 .setCheckSentinelsList(false)
+                .setDnsMonitoringInterval(-1)
                 .addSentinelAddress(redisAddress)
                 .setPassword(redisPassword);
         } else {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -4,9 +4,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
 import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
 import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotationQueryType;
+import org.mskcc.cbio.oncokb.bo.OncokbTranscriptService;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.util.*;
+import org.oncokb.oncokb_transcript.ApiException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +22,8 @@ import static org.mskcc.cbio.oncokb.Constants.DEFAULT_REFERENCE_GENOME;
 
 @Component
 public class CacheFetcher {
+    OncokbTranscriptService oncokbTranscriptService = new OncokbTranscriptService();
+
     @Cacheable(cacheResolver = "generalCacheResolver", key = "'all'")
     public OncoKBInfo getOncoKBInfo() {
         return new OncoKBInfo();
@@ -164,6 +169,11 @@ public class CacheFetcher {
 
     private String getStringByBoolean(Boolean val) {
         return val ? "Yes" : "No";
+    }
+
+    @Cacheable(cacheResolver = "generalCacheResolver")
+    public Gene findGeneBySymbol(String symbol) throws ApiException {
+        return this.oncokbTranscriptService.findGeneBySymbol(symbol);
     }
 
     @Cacheable(

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -1,6 +1,8 @@
 package org.mskcc.cbio.oncokb.cache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
 import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotationQueryType;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.*;
@@ -188,18 +190,13 @@ public class CacheFetcher {
         Query query = new Query(null, referenceGenome, AnnotationQueryType.REGULAR.getName(), entrezGeneId, hugoSymbol, alteration, alterationType, svType, tumorType, consequence, proteinStart, proteinEnd, hgvs);
         return IndicatorUtils.processQuery(
             query, levels, highestLevelOnly,
-            new HashSet<>(evidenceTypes)
+            evidenceTypes
         );
     }
 
     @Cacheable(cacheResolver = "generalCacheResolver",
         keyGenerator = "concatKeyGenerator")
-    public IndicatorQueryResp getIndicatorQueryFromGenomicLocation(ReferenceGenome referenceGenome, String genomicLocation, String tumorType, Set<EvidenceType> evidenceTypes) {
-        Alteration alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.GENOMIC_LOCATION, genomicLocation, referenceGenome);
-        Query query = new Query();
-        if (alteration != null) {
-            query = new Query(null, referenceGenome, AnnotationQueryType.REGULAR.getName(), null, alteration.getGene().getHugoSymbol(), alteration.getAlteration(), null, null, tumorType, alteration.getConsequence() == null ? null : alteration.getConsequence().getTerm(), alteration.getProteinStart(), alteration.getProteinEnd(), null);
-        }
-        return IndicatorUtils.processQuery(query, null, false, evidenceTypes);
+    public Alteration getAlterationFromGenomeNexus(GNVariantAnnotationType gnVariantAnnotationType, ReferenceGenome referenceGenome, String genomicLocation) {
+        return AlterationUtils.getAlterationFromGenomeNexus(gnVariantAnnotationType, genomicLocation, referenceGenome);
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -164,7 +164,10 @@ public class CacheFetcher {
         return val ? "Yes" : "No";
     }
 
-    @Cacheable(cacheResolver = "generalCacheResolver")
+    @Cacheable(
+        cacheResolver = "generalCacheResolver",
+        keyGenerator = "concatKeyGenerator"
+    )
     public IndicatorQueryResp processQuery(ReferenceGenome referenceGenome,
                                            Integer entrezGeneId,
                                            String hugoSymbol,
@@ -179,7 +182,7 @@ public class CacheFetcher {
                                            Set<LevelOfEvidence> levels,
                                            Boolean highestLevelOnly,
                                            Set<EvidenceType> evidenceTypes) {
-        if(referenceGenome==null){
+        if (referenceGenome == null) {
             referenceGenome = DEFAULT_REFERENCE_GENOME;
         }
         Query query = new Query(null, referenceGenome, AnnotationQueryType.REGULAR.getName(), entrezGeneId, hugoSymbol, alteration, alterationType, svType, tumorType, consequence, proteinStart, proteinEnd, hgvs);
@@ -189,7 +192,8 @@ public class CacheFetcher {
         );
     }
 
-    @Cacheable(cacheResolver = "generalCacheResolver")
+    @Cacheable(cacheResolver = "generalCacheResolver",
+        keyGenerator = "concatKeyGenerator")
     public IndicatorQueryResp getIndicatorQueryFromGenomicLocation(ReferenceGenome referenceGenome, String genomicLocation, String tumorType, Set<EvidenceType> evidenceTypes) {
         Alteration alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.GENOMIC_LOCATION, genomicLocation, referenceGenome);
         Query query = new Query();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheKey.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheKey.java
@@ -6,6 +6,7 @@ public enum CacheKey {
     CANCER_GENE_LIST_TXT("getCancerGenesTxt"),
     CURATED_GENE_LIST("getCuratedGenes"),
     CURATED_GENE_LIST_TXT("getCuratedGenesTxt"),
+    FIND_GENE_BY_SYMBOL("findGeneBySymbol"),
     PROCESS_QUERY("processQuery"),
     GET_ALTERATION_FROM_GN("getAlterationFromGenomeNexus"),
     ONCOKB_INFO("getOncoKBInfo");

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheKey.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheKey.java
@@ -7,7 +7,7 @@ public enum CacheKey {
     CURATED_GENE_LIST("getCuratedGenes"),
     CURATED_GENE_LIST_TXT("getCuratedGenesTxt"),
     PROCESS_QUERY("processQuery"),
-    GENOMIC_LOCATION_QUERY("getIndicatorQueryFromGenomicLocation"),
+    GET_ALTERATION_FROM_GN("getAlterationFromGenomeNexus"),
     ONCOKB_INFO("getOncoKBInfo");
 
     String key;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheKey.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheKey.java
@@ -6,6 +6,8 @@ public enum CacheKey {
     CANCER_GENE_LIST_TXT("getCancerGenesTxt"),
     CURATED_GENE_LIST("getCuratedGenes"),
     CURATED_GENE_LIST_TXT("getCuratedGenesTxt"),
+    PROCESS_QUERY("processQuery"),
+    GENOMIC_LOCATION_QUERY("getIndicatorQueryFromGenomicLocation"),
     ONCOKB_INFO("getOncoKBInfo");
 
     String key;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
@@ -52,11 +52,8 @@ public class CustomRedisCacheManager implements CacheManager {
             CacheKey nameKey = CacheKey.getByKey(name);
             if (nameKey != null) {
                 switch (nameKey) {
-                    case ONCOKB_INFO:
-                    case CANCER_GENE_LIST:
-                    case CANCER_GENE_LIST_TXT:
-                    case CURATED_GENE_LIST:
-                    case CURATED_GENE_LIST_TXT:
+                    case PROCESS_QUERY:
+                        return new CustomMapRedisCache(cacheName, client, clientTTLInMinutes);
                     default:
                         return new CustomBucketRedisCache(cacheName, client, clientTTLInMinutes);
                 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
@@ -54,6 +54,7 @@ public class CustomRedisCacheManager implements CacheManager {
                 switch (nameKey) {
                     case PROCESS_QUERY:
                     case GET_ALTERATION_FROM_GN:
+                    case FIND_GENE_BY_SYMBOL:
                         return new CustomMapRedisCache(cacheName, client, clientTTLInMinutes);
                     default:
                         return new CustomBucketRedisCache(cacheName, client, clientTTLInMinutes);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
@@ -53,6 +53,7 @@ public class CustomRedisCacheManager implements CacheManager {
             if (nameKey != null) {
                 switch (nameKey) {
                     case PROCESS_QUERY:
+                    case GET_ALTERATION_FROM_GN:
                         return new CustomMapRedisCache(cacheName, client, clientTTLInMinutes);
                     default:
                         return new CustomBucketRedisCache(cacheName, client, clientTTLInMinutes);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/keygenerator/ConcatGenerator.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/keygenerator/ConcatGenerator.java
@@ -1,0 +1,13 @@
+package org.mskcc.cbio.oncokb.cache.keygenerator;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+
+public class ConcatGenerator implements KeyGenerator {
+
+    public Object generate(Object target, Method method, Object... params) {
+        return StringUtils.arrayToDelimitedString(params, "_");
+    }
+}

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
@@ -50,7 +50,7 @@ public class Query implements java.io.Serializable {
         newQuery.setConsequence(this.consequence);
         newQuery.setProteinStart(this.proteinStart);
         newQuery.setProteinEnd(this.proteinEnd);
-        newQuery.setHgvs(this.hgvs, this.referenceGenome);
+        newQuery.setHgvs(this.hgvs);
         return newQuery;
     }
 
@@ -68,18 +68,6 @@ public class Query implements java.io.Serializable {
         this.consequence = mutationQuery.getConsequence();
         this.proteinStart = mutationQuery.getProteinStart();
         this.proteinEnd = mutationQuery.getProteinEnd();
-        this.referenceGenome = mutationQuery.getReferenceGenome();
-        if (this.referenceGenome == null) {
-            this.referenceGenome = DEFAULT_REFERENCE_GENOME;
-        }
-    }
-
-    public Query(AnnotateMutationByHGVSgQuery mutationQuery) {
-        this.id = mutationQuery.getId();
-        this.type = AnnotationQueryType.REGULAR.getName();
-        this.setTumorType(mutationQuery.getTumorType());
-
-        this.setHgvs(mutationQuery.getHgvsg(), referenceGenome);
         this.referenceGenome = mutationQuery.getReferenceGenome();
         if (this.referenceGenome == null) {
             this.referenceGenome = DEFAULT_REFERENCE_GENOME;
@@ -127,7 +115,7 @@ public class Query implements java.io.Serializable {
         this.consequence = consequence;
         this.proteinStart = proteinStart;
         this.proteinEnd = proteinEnd;
-        this.setHgvs(hgvs, referenceGenome);
+        this.setHgvs(hgvs);
     }
 
     public String getId() {
@@ -236,23 +224,8 @@ public class Query implements java.io.Serializable {
         return hgvs;
     }
 
-    public void setHgvs(String hgvs, ReferenceGenome referenceGenome) {
+    public void setHgvs(String hgvs) {
         this.hgvs = hgvs;
-        if (hgvs != null && !hgvs.trim().isEmpty()) {
-            Alteration alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, hgvs, referenceGenome);
-            if (alteration != null) {
-                if (alteration.getGene() != null) {
-                    this.hugoSymbol = alteration.getGene().getHugoSymbol();
-                    this.entrezGeneId = alteration.getGene().getEntrezGeneId();
-                }
-                this.alterationType = null;
-                this.setAlteration(alteration.getAlteration());
-                this.proteinStart = alteration.getProteinStart();
-                this.proteinEnd = alteration.getProteinEnd();
-                if (alteration.getConsequence() != null)
-                    this.consequence = alteration.getConsequence().getTerm();
-            }
-        }
     }
 
     public void enrich() {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -473,7 +473,7 @@ public final class AlterationUtils {
     }
 
     public static Alteration getAlterationFromGenomeNexus(GNVariantAnnotationType type, String query, ReferenceGenome referenceGenome) {
-        Alteration alteration = null;
+        Alteration alteration = new Alteration();
         if (query != null && !query.trim().isEmpty()) {
             TranscriptConsequence transcriptConsequence = GenomeNexusUtils.getTranscriptConsequence(type, query, referenceGenome);
             if (transcriptConsequence != null) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/QueryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/QueryUtils.java
@@ -1,9 +1,8 @@
 package org.mskcc.cbio.oncokb.util;
 
 import com.mysql.jdbc.StringUtils;
-import org.mskcc.cbio.oncokb.model.AlterationType;
-import org.mskcc.cbio.oncokb.model.Gene;
-import org.mskcc.cbio.oncokb.model.Query;
+import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
+import org.mskcc.cbio.oncokb.model.*;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -43,5 +42,23 @@ public class QueryUtils {
             name = query.getAlteration().trim();
         }
         return name;
+    }
+
+    public static Query getQueryForHgvsg(ReferenceGenome referenceGenome, String hgvsg, String tumorType, Alteration alteration) {
+        Query query = new Query();
+        query.setReferenceGenome(referenceGenome);
+        query.setHgvs(hgvsg);
+        query.setTumorType(tumorType);
+        if (alteration.getGene() != null) {
+            query.setHugoSymbol(alteration.getGene().getHugoSymbol());
+            query.setEntrezGeneId(alteration.getGene().getEntrezGeneId());
+        }
+        query.setAlteration(alteration.getAlteration());
+        query.setProteinStart(alteration.getProteinStart());
+        query.setProteinEnd(alteration.getProteinEnd());
+        if (alteration.getConsequence() != null) {
+            query.setConsequence(alteration.getConsequence().getTerm());
+        }
+        return query;
     }
 }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -4,8 +4,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.mskcc.cbio.oncokb.apiModels.Implication;
 import org.mskcc.cbio.oncokb.apiModels.MainType;
+import org.mskcc.cbio.oncokb.cache.CacheFetcher;
+import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.apiModels.TumorType;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -568,29 +571,27 @@ public class IndicatorUtilsTest {
         assertTrue("The highest diagnostic level should be empty, but it's not", indicatorQueryResp.getHighestDiagnosticImplicationLevel() == null);
 
         // Test indicator endpoint supports HGVS
-        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, null, null, null, null, null, "Melanoma", null, null, null, "7:g.140453136A>T");
+        String hgvsg = "7:g.140453136A>T";
+        Alteration alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, hgvsg, DEFAULT_REFERENCE_GENOME);
+        query = QueryUtils.getQueryForHgvsg(DEFAULT_REFERENCE_GENOME, hgvsg, "Melanoma", alteration);
         indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
         assertTrue("The geneExist is not true, but it should be.", indicatorQueryResp.getGeneExist() == true);
         assertEquals("The oncogenicity is not Oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level is not 1, but it should be.", LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
 
-        query1 = new Query(null, DEFAULT_REFERENCE_GENOME, null, null, null, null, null, null, "Melanoma", null, null, null, "7:g.140453136A>T");
+        hgvsg = "7:g.140453136A>T";
+        alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, hgvsg, DEFAULT_REFERENCE_GENOME);
+        query1 = QueryUtils.getQueryForHgvsg(DEFAULT_REFERENCE_GENOME, hgvsg, "Melanoma", alteration);
         query2 = new Query(null, DEFAULT_REFERENCE_GENOME, null, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
-        resp1 = IndicatorUtils.processQuery(query1, null, true, null);
-        resp2 = IndicatorUtils.processQuery(query2, null, true, null);
+
+        resp1 = IndicatorUtils.processQuery(query1, null, false, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, false, null);
+
         assertTrue("Genes are not the same, but they should.", resp1.getGeneSummary().equals(resp2.getGeneSummary()));
         assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
         assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
         assertTrue("Highest sensitive levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestSensitiveLevel(), resp2.getHighestSensitiveLevel()));
         assertTrue("Highest resistance levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestResistanceLevel(), resp2.getHighestResistanceLevel()));
-
-        // Test HGVS has higher priority than gene/variant pair
-        // 7:g.140453136A>T is BRAF V600E
-        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, null, "ALK", "R401Q", null, null, "Melanoma", null, null, null, "7:g.140453136A>T");
-        indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
-        assertTrue("The geneExist is not true, but it should be.", indicatorQueryResp.getGeneExist() == true);
-        assertEquals("The oncogenicity is not Oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
-        assertEquals("The highest sensitive level is not 1, but it should be.", LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
 
         // Check structural variant fusion
         // a) BRAF is oncogenic gene. No Truncating Mutations is curated.


### PR DESCRIPTION
Utilize redis to cache the following content:

- api /annotate/mutations/byProteinChange GET/POST
- api /annotate/mutations/byGenomicChange GET/POST
- api /annotate/mutations/byHGVSg GET/POST
- api /annotate/copyNumberAlterations GET/POST
- api /annotate/structuralVariants GET/POST
- findGeneBySymbol
- Cache HGVSg and Genomic Change from GN

This is related to https://github.com/oncokb/oncokb/issues/2589