### PR TITLE
Use HGNC fusion format to avoid naming conflicts

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -232,7 +232,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         // Find exact match
         Alteration matchedAlt = findExactlyMatchedAlteration(referenceGenome, alteration, fullAlterations);
 
-        if(matchedAlt == null && AlterationUtils.isFusion(alteration.getAlteration())) {
+        if(matchedAlt == null && FusionUtils.isFusion(alteration.getAlteration())) {
             matchedAlt = AlterationUtils.getRevertFusions(referenceGenome, alteration, fullAlterations);
         }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mskcc.cbio.oncokb.Constants.DEFAULT_REFERENCE_GENOME;
+import static org.mskcc.cbio.oncokb.util.FusionUtils.FUSION_ALTERNATIVE_SEPARATOR;
+import static org.mskcc.cbio.oncokb.util.FusionUtils.FUSION_SEPARATOR;
 
 
 /**
@@ -243,7 +245,11 @@ public class Query implements java.io.Serializable {
                 Gene entrezGeneIdGene = GeneUtils.getGeneByEntrezId(this.getEntrezGeneId());
                 this.setHugoSymbol(entrezGeneIdGene.getHugoSymbol());
             }
-            if (this.getAlteration() != null && !this.getAlteration().toLowerCase().contains("fusion") && this.getAlteration().toLowerCase().contains("-") && (alterationType.equals(AlterationType.FUSION) || (this.consequence != null && this.consequence.toLowerCase().equals("fusion")))) {
+            if (this.getAlteration() != null &&
+                !this.getAlteration().toLowerCase().contains("fusion") &&
+                (!this.getAlteration().toLowerCase().contains(FUSION_SEPARATOR) && this.getAlteration().toLowerCase().contains(FUSION_ALTERNATIVE_SEPARATOR)) &&
+                (alterationType.equals(AlterationType.FUSION) || (this.consequence != null && this.consequence.toLowerCase().equals("fusion")))
+            ) {
                 this.setAlteration(this.getAlteration() + " Fusion");
             }
         }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -30,7 +30,6 @@ public final class AlterationUtils {
 
     private static AlterationBo alterationBo = ApplicationContextSingleton.getAlterationBo();
 
-    private final static String fusionRegex = "((\\w*)-(\\w*))\\s+(?i)fusion";
 
     private AlterationUtils() {
         throw new AssertionError();
@@ -365,14 +364,6 @@ public final class AlterationUtils {
         }
     }
 
-    public static Boolean isFusion(String variant) {
-        Boolean flag = false;
-        if (variant != null && Pattern.matches(fusionRegex, variant)) {
-            flag = true;
-        }
-        return flag;
-    }
-
     public static Alteration getRevertFusions(ReferenceGenome referenceGenome, Alteration alteration, Set<Alteration> fullAlterations) {
         if (fullAlterations == null) {
             return getRevertFusions(referenceGenome, alteration);
@@ -395,21 +386,8 @@ public final class AlterationUtils {
     public static String getRevertFusionName(Alteration alteration) {
         String revertFusionAltStr = null;
         if (alteration != null && alteration.getAlteration() != null
-            && isFusion(alteration.getAlteration())) {
-            revertFusionAltStr = getRevertFusionName(alteration.getAlteration());
-        }
-        return revertFusionAltStr;
-    }
-
-    public static String getRevertFusionName(String fusionName) {
-        String revertFusionAltStr = "";
-        Pattern pattern = Pattern.compile(fusionRegex);
-        Matcher matcher = pattern.matcher(fusionName);
-        if (matcher.matches() && matcher.groupCount() == 3) {
-            // Revert fusion
-            String geneA = matcher.group(2);
-            String geneB = matcher.group(3);
-            revertFusionAltStr = geneB + "-" + geneA + " fusion";
+            && FusionUtils.isFusion(alteration.getAlteration())) {
+            revertFusionAltStr = FusionUtils.getRevertFusionName(alteration.getAlteration());
         }
         return revertFusionAltStr;
     }
@@ -739,7 +717,7 @@ public final class AlterationUtils {
             }
         }
 
-        if (isFusion(alteration)) {
+        if (FusionUtils.isFusion(alteration)) {
             Alteration alt = new Alteration();
             alt.setAlteration(alteration);
             alt.setAlterationType(alterationType == null ? AlterationType.MUTATION : alterationType);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/FusionUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/FusionUtils.java
@@ -6,23 +6,28 @@ import org.mskcc.cbio.oncokb.model.Gene;
 import org.mskcc.cbio.oncokb.model.ReferenceGenome;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-/**
- * Created by Hongxin Zhang on 8/23/17.
- */
 public class FusionUtils {
+    public final static String FUSION_SEPARATOR = "::";
+    public final static String FUSION_ALTERNATIVE_SEPARATOR = "-";
+    private final static String FUSION_REGEX = "\\s*(\\w*)" + FUSION_SEPARATOR + "(\\w*)\\s*(?i)(fusion)?\\s*";
+    private final static String FUSION_ALT_REGEX = "\\s*((\\w*)" + FUSION_ALTERNATIVE_SEPARATOR + "(\\w*))\\s+(?i)fusion\\s*";
+
     public static List<String> getGenesStrs(String query) {
         Set<String> geneStrsList = new LinkedHashSet<>();
         if (!StringUtils.isNullOrEmpty(query)) {
-            List<String> geneFragments = Arrays.asList(query.split("-"));
+            String fusionSeparator = query.contains(FUSION_SEPARATOR) ? FUSION_SEPARATOR : FUSION_ALTERNATIVE_SEPARATOR;
+            List<String> geneFragments = Arrays.asList(query.split(fusionSeparator));
             if (geneFragments.size() > 2) {
-                String rightHandGene = org.apache.commons.lang3.StringUtils.join(geneFragments.subList(1, geneFragments.size()), "-");
+                String rightHandGene = org.apache.commons.lang3.StringUtils.join(geneFragments.subList(1, geneFragments.size()), fusionSeparator);
                 if (GeneUtils.getGeneByHugoSymbol(rightHandGene) != null) {
                     geneStrsList.add(rightHandGene);
                     geneStrsList.add(geneFragments.get(0));
                 }
-                String leftHandGene = org.apache.commons.lang3.StringUtils.join(geneFragments.subList(0, geneFragments.size() - 1), "-");
+                String leftHandGene = org.apache.commons.lang3.StringUtils.join(geneFragments.subList(0, geneFragments.size() - 1), fusionSeparator);
                 if (GeneUtils.getGeneByHugoSymbol(leftHandGene) != null) {
                     geneStrsList.add(leftHandGene);
                     geneStrsList.add(geneFragments.get(geneFragments.size() - 1));
@@ -51,17 +56,6 @@ public class FusionUtils {
         return new ArrayList<>(geneStrsList);
     }
 
-    public static List<Gene> getGenes(String query) {
-        List<Gene> genes = new ArrayList<>();
-        for (String geneStr : getGenesStrs(query)) {
-            Gene tmpGene = GeneUtils.getGeneByHugoSymbol(geneStr);
-            if (tmpGene != null && !genes.contains(tmpGene)) {
-                genes.add(tmpGene);
-            }
-        }
-        return genes;
-    }
-
     public static String getFusionName(Gene geneA, Gene geneB) {
         if (geneA == null || geneB == null) {
             return "";
@@ -78,25 +72,24 @@ public class FusionUtils {
 
         for (String hugoA : geneANames) {
             for (String hugoB : geneBNames) {
+                fusionName = getFusionAlterationName(hugoA, hugoB);
+                matchedAlteration = findAltByFusionName(fusionName, geneA, geneB);
+                if (matchedAlteration != null) {
+                    return fusionName;
+                }
                 fusionName = getFusionName(hugoA, hugoB);
-                matchedAlteration = AlterationUtils.findAlteration(geneA, ReferenceGenome.GRCh37, fusionName);
+                matchedAlteration = findAltByFusionName(fusionName, geneA, geneB);
                 if (matchedAlteration != null) {
                     return fusionName;
                 }
 
-                fusionName = getFusionName(hugoA, hugoB);
-                matchedAlteration = AlterationUtils.findAlteration(geneB, ReferenceGenome.GRCh37, fusionName);
-                if (matchedAlteration != null) {
-                    return fusionName;
-                }
-
-                fusionName = getFusionName(hugoB, hugoA);
-                matchedAlteration = AlterationUtils.findAlteration(geneA, ReferenceGenome.GRCh37, fusionName);
+                fusionName = getFusionAlterationName(hugoB, hugoA);
+                matchedAlteration = findAltByFusionName(fusionName, geneA, geneB);
                 if (matchedAlteration != null) {
                     return fusionName;
                 }
                 fusionName = getFusionName(hugoB, hugoA);
-                matchedAlteration = AlterationUtils.findAlteration(geneB, ReferenceGenome.GRCh37, fusionName);
+                matchedAlteration = findAltByFusionName(fusionName, geneA, geneB);
                 if (matchedAlteration != null) {
                     return fusionName;
                 }
@@ -108,7 +101,51 @@ public class FusionUtils {
         return fusionName;
     }
 
+    private static Alteration findAltByFusionName(String fusionName, Gene geneA, Gene geneB) {
+        Alteration matchedAlteration = null;
+        matchedAlteration = AlterationUtils.findAlteration(geneA, ReferenceGenome.GRCh37, fusionName);
+        if (matchedAlteration == null) {
+            matchedAlteration = AlterationUtils.findAlteration(geneB, ReferenceGenome.GRCh37, fusionName);
+        }
+        return matchedAlteration;
+    }
+
     private static String getFusionName(String hugoA, String hugoB) {
-        return hugoA + "-" + hugoB + " Fusion";
+        return hugoA + FUSION_SEPARATOR + hugoB;
+    }
+
+    // This is used to find fusion in the alteration table
+    private static String getFusionAlterationName(String hugoA, String hugoB) {
+        return hugoA + FUSION_ALTERNATIVE_SEPARATOR + hugoB + " Fusion";
+    }
+
+    public static Boolean isFusion(String variant) {
+        Boolean flag = false;
+        if (variant != null && (Pattern.matches(FUSION_REGEX, variant) || Pattern.matches(FUSION_ALT_REGEX, variant))) {
+            flag = true;
+        }
+        return flag;
+    }
+
+    public static String getRevertFusionName(String fusionName) {
+        String revertFusionAltStr = "";
+        Pattern pattern = Pattern.compile(FUSION_REGEX);
+        Matcher matcher = pattern.matcher(fusionName);
+        if (matcher.matches() && matcher.groupCount() == 3) {
+            // Revert fusion
+            String geneA = matcher.group(1);
+            String geneB = matcher.group(2);
+            revertFusionAltStr = getFusionName(geneB, geneA);
+        } else {
+            pattern = Pattern.compile(FUSION_ALT_REGEX);
+            matcher = pattern.matcher(fusionName);
+            if (matcher.matches() && matcher.groupCount() == 3) {
+                // Revert fusion
+                String geneA = matcher.group(2);
+                String geneB = matcher.group(3);
+                revertFusionAltStr = getFusionAlterationName(geneB, geneA);
+            }
+        }
+        return revertFusionAltStr;
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/QueryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/QueryUtils.java
@@ -6,6 +6,8 @@ import org.mskcc.cbio.oncokb.model.*;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 
+import static org.mskcc.cbio.oncokb.util.FusionUtils.FUSION_SEPARATOR;
+
 /**
  * Created by Hongxin Zhang on 8/23/17.
  */
@@ -25,7 +27,7 @@ public class QueryUtils {
                             Gene entrezGeneIdGene = GeneUtils.getGeneByEntrezId(query.getEntrezGeneId());
                             name = entrezGeneIdGene.getHugoSymbol();
                         } else {
-                            LinkedHashSet<String> genes = StringUtils.isNullOrEmpty(query.getHugoSymbol()) ? new LinkedHashSet<>() : new LinkedHashSet<>(Arrays.asList(query.getHugoSymbol().split("-")));
+                            LinkedHashSet<String> genes = StringUtils.isNullOrEmpty(query.getHugoSymbol()) ? new LinkedHashSet<>() : new LinkedHashSet<>(FusionUtils.getGenesStrs(query.getHugoSymbol()));
                             if (genes.size() > 1) {
                                 name = org.apache.commons.lang3.StringUtils.join(genes, "-") + " Fusion";
                             } else if (genes.size() == 1) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/ValidationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/ValidationUtils.java
@@ -16,6 +16,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.mskcc.cbio.oncokb.util.FusionUtils.FUSION_ALTERNATIVE_SEPARATOR;
+import static org.mskcc.cbio.oncokb.util.FusionUtils.FUSION_SEPARATOR;
+
 public class ValidationUtils {
 
     public static JSONArray getMissingTreatmentInfoData() {
@@ -185,7 +188,7 @@ public class ValidationUtils {
                     if (alteration.getName().toLowerCase().contains("exon") && (alteration.getProteinStart() == null || alteration.getProteinEnd() == null || alteration.getProteinStart().equals(alteration.getProteinEnd()) || alteration.getProteinStart().equals(-1))) {
                         data.put(getErrorMessage(getTarget(alteration.getGene().getHugoSymbol(), getAlterationName(alteration)), EXON_RANGE_NEEDED));
                     }
-                    if (alteration.getAlteration().contains("-") && !alteration.getAlteration().toLowerCase().contains("fusion") && !specialAlterationNames().contains(alteration.getName())) {
+                    if (alteration.getAlteration().contains(FUSION_ALTERNATIVE_SEPARATOR) && !alteration.getAlteration().toLowerCase().contains("fusion") && !specialAlterationNames().contains(alteration.getName())) {
                         data.put(getErrorMessage(getTarget(alteration.getGene().getHugoSymbol(), getAlterationName(alteration)), FUSION_NAME_IS_INCORRECT));
                     }
                     if (alteration.getConsequence() == null) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FusionUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FusionUtilsTest.java
@@ -36,25 +36,24 @@ public class FusionUtilsTest extends TestCase {
 
     }
 
-    public void testGetGenes() {
-        List<Gene> genes = getGenes("H1-4");
-        assertEquals(1, genes.size());
-        assertEquals("H1-4", genes.get(0).getHugoSymbol());
+    public void testIsFusion() {
+        assertTrue(isFusion("A-B fusion"));
+        assertTrue(isFusion("A-B fusion "));
+        assertTrue(isFusion("A-B  fusion "));
+        assertTrue(isFusion(" A-B  fusion "));
+        assertTrue(isFusion("A::B"));
+        assertTrue(isFusion("A::B fusion"));
 
-        genes = getGenes("HIST1H2BD-HIST1H1E");
-        assertEquals(2, genes.size());
-        assertTrue(genes.stream().filter(gene -> gene.getHugoSymbol().equals("H1-4")).findAny().isPresent());
-        assertTrue(genes.stream().filter(gene -> gene.getHugoSymbol().equals("H2BC5")).findAny().isPresent());
+        assertFalse(isFusion("A-B"));
+    }
 
-        genes = getGenes("H2BC5-H1-4");
-        assertEquals(2, genes.size());
-        assertTrue(genes.stream().filter(gene -> gene.getHugoSymbol().equals("H2BC5")).findAny().isPresent());
-        assertTrue(genes.stream().filter(gene -> gene.getHugoSymbol().equals("H1-4")).findAny().isPresent());
-
-        genes = getGenes("H1-4-H2BC5");
-        assertEquals(2, genes.size());
-        assertTrue(genes.stream().filter(gene -> gene.getHugoSymbol().equals("H2BC5")).findAny().isPresent());
-        assertTrue(genes.stream().filter(gene -> gene.getHugoSymbol().equals("H1-4")).findAny().isPresent());
+    public void testRevertFusionName() {
+        assertEquals("B-A Fusion", getRevertFusionName("A-B fusion"));
+        assertEquals("B-A Fusion", getRevertFusionName("A-B fusion "));
+        assertEquals("B-A Fusion", getRevertFusionName("A-B  fusion "));
+        assertEquals("B-A Fusion", getRevertFusionName(" A-B  fusion "));
+        assertEquals("B::A", getRevertFusionName("A::B"));
+        assertEquals("B::A", getRevertFusionName("A::B fusion"));
     }
 
     public void testGetFusionName() {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -522,6 +522,17 @@ public class IndicatorUtilsTest {
         assertTrue("Highest sensitive levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestSensitiveLevel(), resp2.getHighestSensitiveLevel()));
         assertTrue("Highest resistance levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestResistanceLevel(), resp2.getHighestResistanceLevel()));
 
+        //Check both fusion name formats are supproted(GeneA-GeneB Fusion, GeneA::GeneB)
+        query1 = new Query(null, DEFAULT_REFERENCE_GENOME, null, 673, "AGK-BRAF", null, null, null, "Melanoma", null, null, null, null);
+        query2 = new Query(null, DEFAULT_REFERENCE_GENOME, null, null, "AGK::BRAF", null, null, null, "Melanoma", null, null, null, null);
+        resp1 = IndicatorUtils.processQuery(query1, null, true, null);
+        resp2 = IndicatorUtils.processQuery(query2, null, true, null);
+        assertTrue("Genes are not the same, but they should.", resp1.getGeneSummary().equals(resp2.getGeneSummary()));
+        assertTrue("Oncogenicities are not the same, but they should.", resp1.getOncogenic().equals(resp2.getOncogenic()));
+        assertTrue("Treatments are not the same, but they should.", resp1.getTreatments().equals(resp2.getTreatments()));
+        assertTrue("Highest sensitive levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestSensitiveLevel(), resp2.getHighestSensitiveLevel()));
+        assertTrue("Highest resistance levels are not the same, but they should.", LevelUtils.areSameLevels(resp1.getHighestResistanceLevel(), resp2.getHighestResistanceLevel()));
+
         // Compare EGFR CTD AND EGFR, EGFR CTD
         // Check EGFR CTD
         query1 = new Query(null, DEFAULT_REFERENCE_GENOME, null, null, "EGFR", "EGFR CTD", null, null, "Gastrointestinal Stromal Tumor", null, null, null, null);

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
@@ -420,7 +420,7 @@ public class AnnotationsApiController {
                 }
                 String fusionName = FusionUtils.getFusionName(geneA, geneB);
                 indicatorQueryResp = this.cacheFetcher.processQuery(
-                    matchedRG, null, fusionName.replace(" Fusion", ""), null, AlterationType.STRUCTURAL_VARIANT.name(), tumorType, isFunctionalFusion ? "fusion" : null, null, null, structuralVariantType, null,
+                    matchedRG, null, fusionName, null, AlterationType.STRUCTURAL_VARIANT.name(), tumorType, isFunctionalFusion ? "fusion" : null, null, null, structuralVariantType, null,
                     null, false, new HashSet<>(MainUtils.stringToEvidenceTypes(evidenceTypes, ",")));
             }
         }
@@ -478,7 +478,7 @@ public class AnnotationsApiController {
                 String fusionName = FusionUtils.getFusionName(geneA, geneB);
 
                 IndicatorQueryResp resp = this.cacheFetcher.processQuery(
-                    query.getReferenceGenome(),  null, fusionName.replace(" Fusion", ""), null, AlterationType.STRUCTURAL_VARIANT.name(), query.getTumorType(), query.getFunctionalFusion() ? "fusion" : "", null, null, query.getStructuralVariantType(), null,
+                    query.getReferenceGenome(),  null, fusionName, null, AlterationType.STRUCTURAL_VARIANT.name(), query.getTumorType(), query.getFunctionalFusion() ? "fusion" : "", null, null, query.getStructuralVariantType(), null,
                     null, false, query.getEvidenceTypes());
                 resp.getQuery().setId(query.getId());
                 result.add(resp);


### PR DESCRIPTION
The dash is used in the fusion name also in the gene alias which brings the issue when trying to parse the name. We now follow the HGNC fusion format definition. The format is defined in https://www.nature.com/articles/s41375-021-01436-6

This fixes https://github.com/oncokb/oncokb/issues/2720
This is related to https://github.com/oncokb/oncokb/issues/2725