### PR TITLE
Support nonstop/stop lost mutation format

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -281,6 +281,23 @@ public final class AlterationUtils {
                                         consequence = "inframe_deletion";
                                         break;
                                 }
+                            } else {
+                                /**
+                                 * support extension variant (https://varnomen.hgvs.org/recommendations/protein/variant/extension/)
+                                 * the following examples are supported
+                                 * *959Qext*14
+                                 * *110Gext*17
+                                 * *315TextALGT*
+                                 * *327Aext*?
+                                 */
+                                p = Pattern.compile("(\\*)([0-9]+)[A-Z]ext([A-Z]+)?\\*([0-9]+)?(\\?)?");
+                                m = p.matcher(proteinChange);
+                                if (m.matches()) {
+                                    ref = m.group(1);
+                                    start = Integer.valueOf(m.group(2));
+                                    end = start;
+                                    consequence = "stop_lost";
+                                }
                             }
                         }
                     }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AnnotateAlterationTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AnnotateAlterationTest.java
@@ -9,6 +9,7 @@ import org.mskcc.cbio.oncokb.model.AlterationPositionBoundary;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mskcc.cbio.oncokb.Constants.MISSENSE_VARIANT;
 
@@ -91,6 +92,13 @@ public class AnnotateAlterationTest {
 
                 // Stop gained
                 {"R2109*", "2109", "2109", "2109", "2109", "R", "*", "stop_gained"},
+
+                // Stop lost, tests are from https://varnomen.hgvs.org/recommendations/protein/variant/extension/
+                {"*959Qext*14", "959", "959", "959", "959", "*", null, "stop_lost"},
+                {"*110Gext*17", "110", "110", "110", "110", "*", null, "stop_lost"},
+                {"*315TextALGT*", "315", "315", "315", "315", "*", null, "stop_lost"},
+                {"*327Aext*?", "327", "327", "327", "327", "*", null, "stop_lost"},
+                {"327Aext*?", "327", "327", "327", "327", null, null, "NA"},
 
                 // Synonymous Variant
                 {"G500G", "500", "500", "500", "500", "G", "G", "synonymous_variant"},


### PR DESCRIPTION
We are following the format described in https://varnomen.hgvs.org/recommendations/protein/variant/extension/
This fixes #2724