### PR TITLE
Support exclusion in the mutation name

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -12,8 +12,13 @@ import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.util.*;
 
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.mskcc.cbio.oncokb.Constants.*;
+import static org.mskcc.cbio.oncokb.util.AlterationUtils.findFusions;
+import static org.mskcc.cbio.oncokb.util.AlterationUtils.findOncogenicMutations;
 
 /**
  * @author jgao
@@ -265,9 +270,9 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             // TODO: match fusion partner
 
             //the alteration 'fusions' should be injected into alteration list
-            Alteration alt = findAlteration(referenceGenome, "fusions", fullAlterations);
-            if (alt != null) {
-                alterations.add(alt);
+            List<Alteration> alts = findFusions(fullAlterations);
+            if (!alts.isEmpty()) {
+                alterations.addAll(alts);
             } else {
                 // If no fusions curated, check the Truncating Mutations.
                 addTruncatingMutations = true;
@@ -349,9 +354,9 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         if (addOncogenicMutations(alteration, alterations)) {
-            Alteration oncogenicMutations = findAlteration(referenceGenome, "oncogenic mutations", fullAlterations);
-            if (oncogenicMutations != null) {
-                alterations.add(oncogenicMutations);
+            List<Alteration> oncogenicMutations = findOncogenicMutations(fullAlterations);
+            if (!oncogenicMutations.isEmpty()) {
+                alterations.addAll(oncogenicMutations);
             }
         }
 
@@ -395,6 +400,20 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             }
         }
 
+        // Remove all relevant alterations that potentially excluding the current alteration
+        Set<Alteration> exclusionAlts = new HashSet<>();
+        Set<Alteration> relevantAlterationsWithoutAlternativeAlleles = alterations.stream().collect(Collectors.toSet());
+        relevantAlterationsWithoutAlternativeAlleles.removeAll(AlterationUtils.getAlleleAlterations(referenceGenome, alteration, fullAlterations));
+        Set<String> alterationsName = relevantAlterationsWithoutAlternativeAlleles.stream().map(Alteration::getAlteration).collect(Collectors.toSet());
+        alterations.stream().filter(alt -> AlterationUtils.hasExclusionCriteria(alt.getAlteration()))
+            .forEach(alt -> {
+                Set<String> altsShouldBeExcluded = AlterationUtils.getExclusionAlterations(alt.getAlteration()).stream().map(alteration1->alteration1.getAlteration()).collect(Collectors.toSet());
+                boolean altShouldBeExcluded = !Collections.disjoint(alterationsName, altsShouldBeExcluded);
+                if (altShouldBeExcluded) {
+                    exclusionAlts.add(alt);
+                }
+            });
+        alterations.removeAll(exclusionAlts);
         return alterations;
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -29,6 +29,7 @@ public final class AlterationUtils {
         Oncogenicity.LIKELY.getOncogenic(), Oncogenicity.YES.getOncogenic()});
 
     private static AlterationBo alterationBo = ApplicationContextSingleton.getAlterationBo();
+    private static final String PROTEIN_CHANGE_EXCLUSION_REGEX = "(.*),\\s*(exclude|excluding)(.*)";
 
 
     private AlterationUtils() {
@@ -66,12 +67,33 @@ public final class AlterationUtils {
         return overlaps;
     }
 
-    public static List<Alteration> parseMutationString(String mutationStr) {
+    private static Matcher getExclusionCriteriaMatcher(String proteinChange) {
+        Pattern exclusionPatter = Pattern.compile("(.*)\\{\\s*(exclude|excluding)(.*)\\}", Pattern.CASE_INSENSITIVE);
+        Matcher exclusionMatch = exclusionPatter.matcher(proteinChange);
+        return exclusionMatch;
+    }
+
+    public static Set<Alteration> getExclusionAlterations(String proteinChange) {
+        Set<Alteration> exclusionAlterations = new HashSet<>();
+        Matcher exclusionMatcher = getExclusionCriteriaMatcher(proteinChange);
+        if (exclusionMatcher.matches()) {
+            String excludedStr = exclusionMatcher.group(3).trim();
+            exclusionAlterations.addAll(parseMutationString(excludedStr, ";"));
+        }
+        return exclusionAlterations;
+    }
+
+    public static boolean hasExclusionCriteria(String proteinChange) {
+        Matcher exclusionMatch = getExclusionCriteriaMatcher(proteinChange);
+        return exclusionMatch.matches();
+    }
+
+    public static List<Alteration> parseMutationString(String mutationStr, String mutationSeparator) {
         List<Alteration> ret = new ArrayList<>();
 
         mutationStr = mutationStr.replaceAll("\\([^\\)]+\\)", ""); // remove comments first
 
-        String[] parts = mutationStr.split(", *");
+        String[] parts = mutationStr.split(mutationSeparator);
 
         Pattern p = Pattern.compile("([A-Z][0-9]+)([^0-9/]+/.+)", Pattern.CASE_INSENSITIVE);
         Pattern rgp = Pattern.compile("(((grch37)|(grch38)):\\s*).*", Pattern.CASE_INSENSITIVE);
@@ -101,6 +123,18 @@ public final class AlterationUtils {
             } else {
                 proteinChange = part;
                 displayName = part;
+                if (displayName.contains("{")) {
+                    int left = displayName.indexOf("{");
+                    int right = displayName.indexOf("}");
+                    if(left > 0 && right > 0) {
+                        String exclusion = displayName.substring(left + 1, right);
+                        String separatorRegex = "\\s*;\\s*";
+                        exclusion = MainUtils.replaceLast(exclusion, separatorRegex, " and ");
+                        exclusion.replaceAll(separatorRegex, ", ");
+
+                        displayName = displayName.substring(0, left) + "(" + exclusion + ")" + displayName.substring(right + 1);
+                    }
+                }
             }
 
             Matcher m = p.matcher(proteinChange);
@@ -145,6 +179,14 @@ public final class AlterationUtils {
 
         if (proteinChange.indexOf("[") != -1) {
             proteinChange = proteinChange.substring(0, proteinChange.indexOf("["));
+        }
+
+        // we need to deal with the exclusion format so the protein change can properly be interpreted.
+        String excludedStr = "";
+        Matcher exclusionMatch = getExclusionCriteriaMatcher(proteinChange);
+        if (exclusionMatch.matches()) {
+            proteinChange = exclusionMatch.group(1);
+            excludedStr = exclusionMatch.group(3).trim();
         }
 
         proteinChange = proteinChange.trim();
@@ -370,7 +412,11 @@ public final class AlterationUtils {
         if (com.mysql.jdbc.StringUtils.isNullOrEmpty(alteration.getName()) && alteration.getAlteration() != null) {
             // Change the positional name
             if (isPositionedAlteration(alteration)) {
-                alteration.setName(alteration.getAlteration() + " Missense Mutations");
+                if (StringUtils.isEmpty(excludedStr)) {
+                    alteration.setName(alteration.getAlteration() + " Missense Mutations");
+                } else {
+                    alteration.setName(proteinChange + " Missense Mutations, excluding " + excludedStr);
+                }
             } else {
                 alteration.setName(alteration.getAlteration());
             }
@@ -967,6 +1013,11 @@ public final class AlterationUtils {
     }
 
     public static List<Alteration> getRelevantAlterations(ReferenceGenome referenceGenome, Alteration alteration) {
+        Gene gene = alteration.getGene();
+        return getRelevantAlterations(referenceGenome, alteration, getAllAlterations(referenceGenome, gene));
+    }
+
+    public static List<Alteration> getRelevantAlterations(ReferenceGenome referenceGenome, Alteration alteration, Set<Alteration> fullAlterations) {
         if (alteration == null || alteration.getGene() == null) {
             return new ArrayList<>();
         }
@@ -979,7 +1030,7 @@ public final class AlterationUtils {
         return getAlterations(
             gene, referenceGenome, alteration.getAlteration(), alteration.getAlterationType(), term,
             proteinStart, proteinEnd,
-            getAllAlterations(referenceGenome, gene));
+            fullAlterations);
     }
 
     public static List<Alteration> removeAlterationsFromList(List<Alteration> list, List<Alteration> alterationsToBeRemoved) {
@@ -1001,6 +1052,26 @@ public final class AlterationUtils {
         } else {
             return alterationBo.findAlteration(gene, AlterationType.MUTATION, referenceGenome, alteration);
         }
+    }
+
+    public static List<Alteration> findOncogenicMutations(Set<Alteration> fullAlterations) {
+        return findAlterationsByRegex(InferredMutation.ONCOGENIC_MUTATIONS.getVariant() + ".*", fullAlterations);
+    }
+
+    public static List<Alteration> findFusions(Set<Alteration> fullAlterations) {
+        return findAlterationsByRegex(StructuralAlteration.FUSIONS.getVariant() + ".*", fullAlterations);
+    }
+
+    private static List<Alteration> findAlterationsByRegex(String regex, Set<Alteration> fullAlterations) {
+        Comparator<Alteration> byAlt = Comparator.comparing(Alteration::getAlteration).reversed();
+        TreeSet<Alteration> matchedAlterations = new TreeSet<>(byAlt);
+        // Implement the data access logic
+        for (Alteration alt : fullAlterations) {
+            if (alt.getAlteration() != null && alt.getAlteration().matches(regex)) {
+                matchedAlterations.add(alt);
+            }
+        }
+        return matchedAlterations.stream().collect(Collectors.toList());
     }
 
     /**

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -890,9 +890,9 @@ public class EvidenceUtils {
                         // Look for Oncogenic Mutations if no relevantAlt found for alt and alt is hotspot
                         if (relevantAlts.isEmpty()
                             && HotspotUtils.isHotspot(alt)) {
-                            Alteration oncogenicMutations = AlterationUtils.findAlteration(alt.getGene(),requestQuery.getReferenceGenome(), "Oncogenic Mutations");
-                            if (oncogenicMutations != null) {
-                                relevantAlts.add(oncogenicMutations);
+                            List<Alteration> oncogenicMutations = AlterationUtils.findOncogenicMutations(AlterationUtils.getAllAlterations(requestQuery.getReferenceGenome(), alt.getGene()));
+                            if (!oncogenicMutations.isEmpty()) {
+                                relevantAlts.addAll(oncogenicMutations);
                             }
                         }
 
@@ -1004,7 +1004,7 @@ public class EvidenceUtils {
             AlterationType type = AlterationType.MUTATION;
             Set<Alteration> alterations = new HashSet<Alteration>();
             AlterationBo alterationBo = ApplicationContextSingleton.getAlterationBo();
-            evidence.getAlterations().stream().forEach(alteration -> parsedAlterations.addAll(AlterationUtils.parseMutationString(alteration.getAlteration())));
+            evidence.getAlterations().stream().forEach(alteration -> parsedAlterations.addAll(AlterationUtils.parseMutationString(alteration.getAlteration(), ",")));
             for (Alteration alt : parsedAlterations) {
                 String proteinChange = alt.getAlteration();
                 String displayName = alt.getName();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -327,16 +327,16 @@ public class IndicatorUtils {
                 indicatorQuery.setOncogenic(Oncogenicity.PREDICTED.getOncogenic());
 
                 // Check whether the gene has Oncogenic Mutations annotated
-                Alteration oncogenicMutation = AlterationUtils.findAlteration(gene, query.getReferenceGenome(), "Oncogenic Mutations");
-                if (oncogenicMutation != null) {
-                    relevantAlterations.add(oncogenicMutation);
+                List<Alteration> oncogenicMutations = new ArrayList<>(AlterationUtils.findOncogenicMutations(AlterationUtils.getAllAlterations(query.getReferenceGenome(), gene)));
+                if (!oncogenicMutations.isEmpty()) {
+                    relevantAlterations.addAll(oncogenicMutations);
                     if (hasTreatmentEvidence) {
                         if (StringUtils.isEmpty(query.getTumorType())) {
-                            treatmentEvidences.addAll(EvidenceUtils.getEvidence(Collections.singletonList(oncogenicMutation), selectedTreatmentEvidence, levels));
+                            treatmentEvidences.addAll(EvidenceUtils.getEvidence(oncogenicMutations, selectedTreatmentEvidence, levels));
                         } else {
                             treatmentEvidences.addAll(EvidenceUtils.keepHighestLevelForSameTreatments(
                                 EvidenceUtils.convertEvidenceLevel(
-                                    EvidenceUtils.getEvidence(Collections.singletonList(oncogenicMutation),
+                                    EvidenceUtils.getEvidence(oncogenicMutations,
                                         selectedTreatmentEvidence, levels), new HashSet<>(relevantUpwardTumorTypes)), query.getReferenceGenome(), matchedAlt));
                         }
                     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -654,4 +654,9 @@ public class MainUtils {
             }
         });
     }
+
+    public static String replaceLast(String text, String regex, String replacement) {
+        // the code is from https://stackoverflow.com/a/2282998
+        return text.replaceFirst("(?s)"+regex+"(?!.*?"+regex+")", replacement);
+    }
 }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
@@ -99,6 +99,70 @@ public class AlterationUtilsTest extends TestCase
         assertEquals("The relevant alterations do not match", "W583del", relevantAltsName);
     }
 
+    public void testGetRelevantAlterationsForExclusion() throws Exception {
+        // Test alteration with exclusion
+        Gene gene = GeneUtils.getGeneByHugoSymbol("BRAF");
+        Alteration v600e = generateAlteration(gene, "V600E");
+        Alteration v600k = generateAlteration(gene, "V600K");
+        Alteration v600 = generateAlteration(gene, "V600");
+        Alteration v600eExcluded = generateAlteration(gene, "V600 {excluding V600E}");
+        Alteration rangeMissense = generateAlteration(gene, "V600_V601delinsEB");
+        Alteration rangeMissenseExcluded = generateAlteration(gene, "V600_V601delinsEB {excluding V600E}");
+        Alteration rangeMissenseExcludesPosition = generateAlteration(gene, "V600_V601delinsEB {excluding V600}");
+
+        Set<Alteration> fullAlteration = new HashSet<>();
+        fullAlteration.add(v600e);
+        fullAlteration.add(v600k);
+        fullAlteration.add(v600);
+        fullAlteration.add(v600eExcluded);
+        fullAlteration.add(rangeMissense);
+        fullAlteration.add(rangeMissenseExcluded);
+        fullAlteration.add(rangeMissenseExcludesPosition);
+
+        List<Alteration> alterations = AlterationUtils.getRelevantAlterations(DEFAULT_REFERENCE_GENOME, v600e, fullAlteration);
+        String relevantAltsName = AlterationUtils.toString(alterations);
+        assertEquals("The relevant alterations do not match", "V600E, V600K, V600_V601delinsEB, V600", relevantAltsName);
+
+        alterations = AlterationUtils.getRelevantAlterations(DEFAULT_REFERENCE_GENOME, v600k, fullAlteration);
+        relevantAltsName = AlterationUtils.toString(alterations);
+        assertEquals("The relevant alterations do not match", "V600K, V600E, V600_V601delinsEB, V600_V601delinsEB {excluding V600E}, V600 {excluding V600E}, V600", relevantAltsName);
+
+        // Test alteration with exclusion
+        Alteration fusionA = generateAlteration(gene, "AKAP9-BRAF Fusion");
+        Alteration fusionB = generateAlteration(gene, "AGAP3-BRAF Fusion");
+        Alteration fusionC = generateAlteration(gene, "FAM131B-BRAF Fusion");
+        Alteration fusions = generateAlteration(gene, "Fusions");
+        Alteration oncogenicMutationsExcludesFusion = generateAlteration(gene, "Fusions {excluding AKAP9-BRAF Fusion; FAM131B-BRAF Fusion}");
+
+        fullAlteration = new HashSet<>();
+        fullAlteration.add(fusionA);
+        fullAlteration.add(fusionB);
+        fullAlteration.add(fusionC);
+        fullAlteration.add(fusions);
+        fullAlteration.add(oncogenicMutationsExcludesFusion);
+
+        alterations = AlterationUtils.getRelevantAlterations(DEFAULT_REFERENCE_GENOME, fusionA, fullAlteration);
+        relevantAltsName = AlterationUtils.toString(alterations);
+        assertEquals("The relevant alterations do not match", "AKAP9-BRAF Fusion, Fusions", relevantAltsName);
+
+        alterations = AlterationUtils.getRelevantAlterations(DEFAULT_REFERENCE_GENOME, fusionB, fullAlteration);
+        relevantAltsName = AlterationUtils.toString(alterations);
+        assertEquals("The relevant alterations do not match", "AGAP3-BRAF Fusion, Fusions {excluding AKAP9-BRAF Fusion; FAM131B-BRAF Fusion}, Fusions", relevantAltsName);
+
+        alterations = AlterationUtils.getRelevantAlterations(DEFAULT_REFERENCE_GENOME, fusionC, fullAlteration);
+        relevantAltsName = AlterationUtils.toString(alterations);
+        assertEquals("The relevant alterations do not match", "FAM131B-BRAF Fusion, Fusions", relevantAltsName);
+
+    }
+
+    private Alteration generateAlteration(Gene gene, String proteinChange) {
+        Alteration alteration = new Alteration();
+        alteration.setAlteration(proteinChange);
+        alteration.setGene(gene);
+        AlterationUtils.annotateAlteration(alteration, alteration.getAlteration());
+        return alteration;
+    }
+
     public void testSortAlterationsByTheRange() throws Exception {
         int start = 8;
         int end = 8;

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/MainUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/MainUtilsTest.java
@@ -3,6 +3,8 @@ package org.mskcc.cbio.oncokb.util;
 import junit.framework.TestCase;
 import org.mskcc.cbio.oncokb.model.MutationEffect;
 
+import static org.mskcc.cbio.oncokb.util.MainUtils.replaceLast;
+
 /**
  * Created by Hongxin Zhang on 3/1/18.
  */
@@ -56,4 +58,10 @@ public class MainUtilsTest extends TestCase {
         assertFalse(MainUtils.isEGFRTruncatingVariants("EGFRvIVa"));
     }
 
+    public void testReplaceLast() {
+        assertEquals("A", replaceLast("A", "and", ","));
+        assertEquals("A,B", replaceLast("AandB", "and", ","));
+        assertEquals("A,B,", replaceLast("A,Band", "and", ","));
+        assertEquals("A,B,D", replaceLast("A,BandD", "and", ","));
+    }
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
@@ -86,7 +86,7 @@ public class DriveAnnotationParser {
                 }
 //                JSONArray nameComments = variant.has("nameComments") ? variant.getJSONArray("nameComments") : null;
                 if (mutationStr != null) {
-                    List<Alteration> mutations = AlterationUtils.parseMutationString(mutationStr);
+                    List<Alteration> mutations = AlterationUtils.parseMutationString(mutationStr, ",");
                     Set<Alteration> alterations = new HashSet<>();
                     for (Alteration mutation : mutations) {
                         Alteration alteration = alterationBo.findAlteration(gene, type, mutation.getAlteration());
@@ -333,7 +333,7 @@ public class DriveAnnotationParser {
 //            addDateToLastReviewSetFromLong(lastReviewDatesEffect, mutationEffect, "effect");
             String effect_uuid = getUUID(mutationEffect, "effect");
 
-            List<Alteration> mutations = AlterationUtils.parseMutationString(mutationStr);
+            List<Alteration> mutations = AlterationUtils.parseMutationString(mutationStr, ",");
             for (Alteration mutation : mutations) {
                 Alteration alteration = alterationBo.findAlteration(gene, type, mutation.getAlteration());
                 if (alteration == null) {


### PR DESCRIPTION
Allow curators to exclude mutation in the mutation name.
Examples:
Oncogenic Mutations {excluding V600E;V600E}

This fixes https://github.com/oncokb/oncokb/issues/2710