### PR TITLE
Do not use mostSevereConsequence to choose the transcript

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -158,17 +158,16 @@ public class GenomeNexusUtils {
         return variantAnnotation;
     }
 
-    public static VariantConsequence getTranscriptConsequenceSummaryTerm(String consequenceTerms, String mostSevereConsequence) {
+    public static VariantConsequence getTranscriptConsequenceSummaryTerm(String consequenceTerms) {
         if (StringUtils.isEmpty(consequenceTerms)) {
             return null;
         }
         List<VariantConsequence> terms = Arrays.asList(consequenceTerms.split(",")).stream().map(consequence -> VariantConsequenceUtils.findVariantConsequenceByTerm(consequence.trim())).filter(Objects::nonNull).collect(Collectors.toList());
-        VariantConsequence mostSevereVariantConsequence = StringUtils.isNotEmpty(mostSevereConsequence) ? VariantConsequenceUtils.findVariantConsequenceByTerm(mostSevereConsequence.trim()) : null;
         // if we cannot find the matched variant consequence using the mostSevereConsequence, we should use the one from the consequence term list
-        if (mostSevereVariantConsequence == null && terms.size() > 0) {
+        if (terms.size() > 0) {
             return terms.iterator().next();
         } else {
-            return mostSevereVariantConsequence;
+            return null;
         }
     }
 
@@ -181,8 +180,8 @@ public class GenomeNexusUtils {
 
         if (variantAnnotation.getAnnotationSummary() != null && variantAnnotation.getAnnotationSummary().getTranscriptConsequenceSummaries() != null) {
             for (TranscriptConsequenceSummary consequenceSummary : variantAnnotation.getAnnotationSummary().getTranscriptConsequenceSummaries()) {
-                if (consequenceSummary.getHugoGeneSymbol() != null && consequenceSummary.getTranscriptId() != null) {
-                    Gene gene = GeneUtils.getGeneByHugoSymbol(consequenceSummary.getHugoGeneSymbol());
+                if (StringUtils.isNotEmpty(consequenceSummary.getEntrezGeneId()) && StringUtils.isNotEmpty(consequenceSummary.getTranscriptId())) {
+                    Gene gene = GeneUtils.getGeneByEntrezId(Integer.parseInt(consequenceSummary.getEntrezGeneId()));
                     String isoform = getIsoform(gene, referenceGenome);
                     if (gene != null && (StringUtils.isEmpty(isoform) || isoform.equals(consequenceSummary.getTranscriptId()))) {
                         summaries.add(consequenceSummary);
@@ -205,7 +204,7 @@ public class GenomeNexusUtils {
 
         // Only return one consequence term
         if (summary != null) {
-            VariantConsequence consequence = getTranscriptConsequenceSummaryTerm(summary.getConsequenceTerms(), variantAnnotation.getMostSevereConsequence());
+            VariantConsequence consequence = getTranscriptConsequenceSummaryTerm(summary.getConsequenceTerms());
             summary.setConsequenceTerms(consequence == null ? "" : consequence.getTerm());
         }
         return summary;

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
@@ -58,7 +58,7 @@ public class AlterationUtilsTest extends TestCase
         for (Alteration alt : positionedAlterations) {
             alterations.add(alt.getAlteration());
         }
-        assertEquals("V600, V600 {excluding V600E ; V600K}", MainUtils.listToString(alterations, ","));
+        assertEquals("V600,V600 {excluding V600E ; V600K}", MainUtils.listToString(alterations, ","));
 
         // non missense should not be annotated
         alteration = new Alteration();

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtilsTest.java
@@ -103,63 +103,58 @@ public class GenomeNexusUtilsTest extends TestCase {
         // No consequence can be found for the following
         consequence = GenomeNexusUtils.getTranscriptConsequence(GNVariantAnnotationType.GENOMIC_LOCATION, "9,136519547,136519547,C,C", ReferenceGenome.GRCh38);
         Assert.assertNull("No consequence should return for this genomic location", consequence);
+
+        // the picked transcript consequence terms might not include the most_severe_consequence
+        consequence = GenomeNexusUtils.getTranscriptConsequence(GNVariantAnnotationType.GENOMIC_LOCATION, "3, 38182641, 38182641,T,C", mskReferenceGenome);
+        gene = GeneUtils.getGeneByHugoSymbol("MYD88");
+        assertEquals("Picked transcript gene symbol is not MYD88, but it should.",
+            gene.getHugoSymbol(), consequence.getHugoGeneSymbol());
+        assertEquals("Picked transcript hgvs p short is not p.L265P, but it should.",
+            "p.L265P", consequence.getHgvspShort());
+        assertEquals("Picked transcript protein start is not 265, but it should.",
+            "265", Integer.toString(consequence.getProteinPosition().getStart()));
+        assertEquals("Picked transcript protein end is not 265, but it should.",
+            "265", Integer.toString(consequence.getProteinPosition().getEnd()));
+        assertEquals("Picked transcript RefSeq is not the same with MSKIMPACT MYD88 RefSeq, but it should.",
+            gene.getGrch37RefSeq(), consequence.getRefSeq());
+        assertEquals("Picked transcript isoform is not the same with MSKIMPACT MYD88 isoform, but it should.",
+            gene.getGrch37Isoform(), consequence.getTranscriptId());
+        assertTrue("We no longer return multiple terms, only return the first term", !consequence.getConsequenceTerms().contains(","));
+        assertEquals("The consequence term is not expected", "missense_variant", consequence.getConsequenceTerms());
+
+        // Test few more cases that reported by user which are supposed to have annotation
+        consequence = GenomeNexusUtils.getTranscriptConsequence(GNVariantAnnotationType.HGVS_G, "4:g.55593600_55593606delinsGTGG", mskReferenceGenome);
+        assertEquals("Picked transcript gene symbol is not expected, but it should.", "3815", consequence.getEntrezGeneId());
+        assertEquals("HGVSp short is not expected, but it should.", "p.Q556_K558delinsVE", consequence.getHgvspShort());
+        consequence = GenomeNexusUtils.getTranscriptConsequence(GNVariantAnnotationType.HGVS_G, "5:g.67589635_67589639delinsTA", mskReferenceGenome);
+        assertEquals("Picked transcript gene symbol is not expected, but it should.", "5295", consequence.getEntrezGeneId());
+        assertEquals("HGVSp short is not expected, but it should.", "p.L466_E468delinsFK", consequence.getHgvspShort());
     }
 
     public void testGetTranscriptConsequenceSummaryTerm() {
         // we do not have a mapping for test. We should default to the one that we do. In this case, intron_variant
         String consequenceTerms = "test,intron_variant";
-        String mostSevereConsequence = "test";
-        VariantConsequence variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
+        VariantConsequence variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
         assertEquals("intron_variant", variantConsequence.getTerm());
 
         consequenceTerms = "splice_region_variant,intron_variant,test";
-        mostSevereConsequence = "test";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
-        assertEquals("splice_region_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "splice_region_variant,intron_variant";
-        mostSevereConsequence = "intron_variant";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "splice_region_variant,intron_variant";
-        mostSevereConsequence = "splice_region_variant";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
+        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
         assertEquals("splice_region_variant", variantConsequence.getTerm());
 
         consequenceTerms = "intron_variant";
-        mostSevereConsequence = "intron_variant";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "intron_variant";
-        mostSevereConsequence = "";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "intron_variant";
-        mostSevereConsequence = null;
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
+        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
         assertEquals("intron_variant", variantConsequence.getTerm());
 
         consequenceTerms = "test";
-        mostSevereConsequence = null;
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
+        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
         assertNull(variantConsequence);
 
         consequenceTerms = "intron_variant , intron_variant";
-        mostSevereConsequence = "intron_variant";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "intron_variant , intron_variant";
-        mostSevereConsequence = " intron_variant ";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
+        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
         assertEquals("intron_variant", variantConsequence.getTerm());
 
         consequenceTerms = null;
-        mostSevereConsequence = null;
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms, mostSevereConsequence);
+        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
         assertNull(variantConsequence);
     }
 }


### PR DESCRIPTION
The mostSevereConsequence maybe different from the matched transcript. Example: https://grch38.genomenexus.org/variant/7:g.140753336A%3ET The most server is stop_lost but it really should be missense_variant

This fixes https://github.com/oncokb/oncokb-annotator/issues/148