### PR TITLE
Use GN variant classification when the consequence cannot be mapped

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -205,6 +205,9 @@ public class GenomeNexusUtils {
         // Only return one consequence term
         if (summary != null) {
             VariantConsequence consequence = getTranscriptConsequenceSummaryTerm(summary.getConsequenceTerms());
+            if (consequence == null && StringUtils.isNotEmpty(summary.getVariantClassification())) {
+                consequence = VariantConsequenceUtils.findVariantConsequenceByTerm(summary.getVariantClassification());
+            }
             summary.setConsequenceTerms(consequence == null ? "" : consequence.getTerm());
         }
         return summary;

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtilsTest.java
@@ -126,9 +126,11 @@ public class GenomeNexusUtilsTest extends TestCase {
         consequence = GenomeNexusUtils.getTranscriptConsequence(GNVariantAnnotationType.HGVS_G, "4:g.55593600_55593606delinsGTGG", mskReferenceGenome);
         assertEquals("Picked transcript gene symbol is not expected, but it should.", "3815", consequence.getEntrezGeneId());
         assertEquals("HGVSp short is not expected, but it should.", "p.Q556_K558delinsVE", consequence.getHgvspShort());
+        assertEquals("Consequence is not expected, but it should.", "inframe_deletion", consequence.getConsequenceTerms());
         consequence = GenomeNexusUtils.getTranscriptConsequence(GNVariantAnnotationType.HGVS_G, "5:g.67589635_67589639delinsTA", mskReferenceGenome);
         assertEquals("Picked transcript gene symbol is not expected, but it should.", "5295", consequence.getEntrezGeneId());
         assertEquals("HGVSp short is not expected, but it should.", "p.L466_E468delinsFK", consequence.getHgvspShort());
+        assertEquals("Consequence is not expected, but it should.", "inframe_deletion", consequence.getConsequenceTerms());
     }
 
     public void testGetTranscriptConsequenceSummaryTerm() {


### PR DESCRIPTION
There are consequences that we do not have the mapping for but GN is able to resolved to VariantClassification which can be mapped to OncoKB consequence.
This fixes https://github.com/oncokb/oncokb/issues/2834