### PR TITLE
Add sentryExceptionResolver for mvcPublic and mvcPrivate

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/oncokb/config/MvcConfigurationPrivate.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/config/MvcConfigurationPrivate.java
@@ -1,8 +1,12 @@
 package org.mskcc.cbio.oncokb.config;
 
+import io.sentry.spring.SentryExceptionResolver;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
@@ -13,6 +17,9 @@ import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import static org.mskcc.cbio.oncokb.Constants.PRIVATE_API_VERSION;
 
@@ -50,5 +57,39 @@ public class MvcConfigurationPrivate extends WebMvcConfigurerAdapter {
                 "Terms of Use",
                 "https://www.oncokb.org/terms"
             ));
+    }
+
+    @Bean
+    public ServletContextInitializer sentryServletContextInitializer() {
+        return new io.sentry.spring.SentryServletContextInitializer();
+    }
+
+    @Bean
+    public HandlerExceptionResolver sentryExceptionResolver() {
+        // Exclude specific events https://stackoverflow.com/questions/48914391/avoid-reporting-broken-pipe-errors-to-sentry-in-a-spring-boot-application
+        return new SentryExceptionResolver() {
+            @Override
+            public ModelAndView resolveException(HttpServletRequest request,
+                                                 HttpServletResponse response,
+                                                 Object handler,
+                                                 Exception ex) {
+                Throwable rootCause = ex;
+
+                while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+                    rootCause = rootCause.getCause();
+                }
+
+                if (rootCause.getMessage() == null || (!rootCause.getMessage().contains("Broken pipe")
+                    && !rootCause.getMessage().contains("Required request body content is missing")
+                    && !rootCause.getMessage().contains("Required request body is missing")
+                    && !rootCause.getMessage().contains("Failed to convert value of type 'java.lang.String' to required type 'java.lang.Integer'")
+                    && !rootCause.getMessage().contains("Required String parameter "))
+                ) {
+                    super.resolveException(request, response, handler, ex);
+                }
+                return null;
+            }
+
+        };
     }
 }


### PR DESCRIPTION
The sentryExceptionResolver in the MvcConfiguration does not seem to apply to public/private, probably because they have higher order of the WebMvcConfigurerAdapter, so the lower version is not used.
However it works in the legacy apis
