### PR TITLE
Include appVersion in the info endpoint

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -175,19 +175,13 @@
         <plugins>
           <!-- any other plugins -->
           <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
+            <artifactId>maven-jar-plugin</artifactId>
             <configuration>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
+                <archive>
+                    <manifest>
+                        <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                </archive>
             </configuration>
           </plugin>
         </plugins>

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/OncoKBInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/OncoKBInfo.java
@@ -1,5 +1,7 @@
 package org.mskcc.cbio.oncokb.model;
 
+import com.vdurmont.semver4j.Semver;
+import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.apiModels.InfoLevel;
 import org.mskcc.cbio.oncokb.util.*;
 
@@ -17,6 +19,7 @@ public class OncoKBInfo implements Serializable {
     String ncitVersion;
     List<InfoLevel> levels;
     Version dataVersion;
+    Semver appVersion;
     String apiVersion;
     Boolean publicInstance;
 
@@ -34,6 +37,11 @@ public class OncoKBInfo implements Serializable {
         this.dataVersion = dataVersion;
         this.apiVersion = PUBLIC_API_VERSION;
 
+        String appVersion = this.getClass().getPackage().getImplementationVersion();
+
+        if (StringUtils.isNotEmpty(appVersion)) {
+            this.appVersion = new Semver(appVersion, Semver.SemverType.STRICT);
+        }
         String isPublicInstance = PropertiesUtils.getProperties(IS_PUBLIC_INSTANCE);
 
         if (isPublicInstance != null && Boolean.valueOf(isPublicInstance)) {
@@ -57,6 +65,10 @@ public class OncoKBInfo implements Serializable {
 
     public Version getDataVersion() {
         return dataVersion;
+    }
+
+    public Semver getAppVersion() {
+        return appVersion;
     }
 
     public Boolean getPublicInstance() {

--- a/pom.xml
+++ b/pom.xml
@@ -118,5 +118,10 @@
             <artifactId>oncokb-java-api-client</artifactId>
             <version>8a9437488a</version>
         </dependency>
+        <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -316,6 +316,7 @@
                                     <type>jar</type>
                                     <outputDirectory>dist</outputDirectory>
                                     <overWrite>true</overWrite>
+                                    <excludes>META-INF/</excludes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -332,6 +333,11 @@
                             <targetPath></targetPath>
                         </resource>
                     </webResources>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/2897

The data looks like the following. I'm using https://github.com/vdurmont/semver4j
```
appVersion: {
  originalValue: "3.6.3",
  value: "3.6.3",
  major: 3,
  minor: 6,
  patch: 3,
  suffixTokens: [ ],
  build: null,
  type: "STRICT",
  stable: true
}
```