### PR TITLE
Variants lookup endpoint should return the matched alteration only

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/VariantsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/VariantsApi.java
@@ -18,20 +18,10 @@ import java.util.List;
 @Api(tags = "Variants", description = "Endpoints related to OncoKB variants")
 public interface VariantsApi {
 
+    // We should remove it in the next release
+    @Deprecated
     @PremiumPublicApi
-    @ApiOperation(value = "", notes = "Get all annotated variants.", response = Alteration.class, responseContainer = "List")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK", response = Alteration.class, responseContainer = "List")})
-    @RequestMapping(value = "/variants",
-        produces = {"application/json"},
-        method = RequestMethod.GET)
-    ResponseEntity<List<Alteration>> variantsGet(
-        @ApiParam(value = "The fields to be returned.") @RequestParam(value = "fields", required = false) String fields
-    );
-
-
-    @PremiumPublicApi
-    @ApiOperation(value = "", notes = "Search for variants.", response = Alteration.class, responseContainer = "List")
+    @ApiOperation(value = "", notes = "Search for matched variants.", response = Alteration.class, responseContainer = "List")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "OK", response = Alteration.class, responseContainer = "List")})
     @RequestMapping(value = "/variants/lookup",
@@ -41,15 +31,12 @@ public interface VariantsApi {
         @ApiParam(value = "The entrez gene ID.") @RequestParam(value = "entrezGeneId", required = false) Integer entrezGeneId
         , @ApiParam(value = "The gene symbol used in Human Genome Organisation.") @RequestParam(value = "hugoSymbol", required = false) String hugoSymbol
         , @ApiParam(value = "variant name.") @RequestParam(value = "variant", required = false) String variant
-        , @ApiParam(value = "") @RequestParam(value = "variantType", required = false) String variantType
-        , @ApiParam(value = "") @RequestParam(value = "consequence", required = false) String consequence
-        , @ApiParam(value = "") @RequestParam(value = "proteinStart", required = false) Integer proteinStart
-        , @ApiParam(value = "") @RequestParam(value = "proteinEnd", required = false) Integer proteinEnd
-        , @ApiParam(value = "HGVS varaint. Its priority is higher than entrezGeneId/hugoSymbol + variant combination") @RequestParam(value = "hgvs", required = false) String hgvs
         , @ApiParam(value = "Reference genome, either GRCh37 or GRCh38. The default is GRCh37", required = false, defaultValue = "GRCh37") @RequestParam(value = "referenceGenome", required = false, defaultValue = "GRCh37") String referenceGenome
         , @ApiParam(value = "The fields to be returned.") @RequestParam(value = "fields", required = false) String fields
     );
 
+    // We cannot delete this method just yet since the curation platform is relaying on the endpoint
+    @Deprecated
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Search for variants.", response = List.class, responseContainer = "List")
     @ApiResponses(value = {


### PR DESCRIPTION
We have created an endpoint to return relevant alterations. This one should return matched one instead.