### PR TITLE
Excluding criteria in inframe-ins/del should only consider the matched alteration

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -414,7 +414,13 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
             relevantAlterationsWithoutAlternativeAlleles.add(alteration);
         }
         relevantAlterationsWithoutAlternativeAlleles.removeAll(AlterationUtils.getAlleleAlterations(referenceGenome, alteration, fullAlterations));
-        Set<String> alterationsName = relevantAlterationsWithoutAlternativeAlleles.stream().map(Alteration::getAlteration).collect(Collectors.toSet());
+        Set<String> alterationsName = new HashSet<>();
+        // if the alteration is inframe-ins/del, we should only match the alteration
+        if(alteration.getConsequence() != null && (alteration.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm("inframe_deletion")) || alteration.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm("inframe_insertion")))) {
+            alterationsName.add(alteration.getAlteration());
+        } else {
+            alterationsName.addAll(relevantAlterationsWithoutAlternativeAlleles.stream().map(Alteration::getAlteration).collect(Collectors.toSet()));
+        }
         alterations.stream().filter(alt -> AlterationUtils.hasExclusionCriteria(alt.getAlteration()))
             .forEach(alt -> {
                 Set<String> altsShouldBeExcluded = AlterationUtils.getExclusionAlterations(alt.getAlteration()).stream().map(alteration1->alteration1.getAlteration()).collect(Collectors.toSet());


### PR DESCRIPTION
In other alterations, we consider all relevant alterations. The relevant alts of in-frame del/ins includes all intersected del/ins which causes the issue.