### PR TITLE
Updates to findMatchedAlt & relevantAlts

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/AlterationBo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/AlterationBo.java
@@ -40,7 +40,7 @@ public interface AlterationBo extends GenericBo<Alteration> {
      */
     Alteration findAlterationFromDao(Gene gene, AlterationType alterationType, ReferenceGenome referenceGenome, String alteration, String name);
 
-
+    Alteration findExactlyMatchedAlteration(ReferenceGenome referenceGenome, Alteration alteration, Set<Alteration> fullAlterations);
     /**
      * @param gene
      * @param consequence

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -199,14 +199,7 @@ public class IndicatorUtils {
             List<TumorType> relevantUpwardTumorTypes = new ArrayList<>();
             List<TumorType> relevantDownwardTumorTypes = new ArrayList<>();
 
-            Alteration matchedAlt = null;
-
-            LinkedHashSet<Alteration> matchedAlterations = AlterationUtils.findMatchedAlterations(query.getReferenceGenome(), alteration);
-            if (matchedAlterations.size() > 1) {
-                matchedAlt = pickMatchedAlteration(new ArrayList<>(matchedAlterations), query, levels, highestLevelOnly, evidenceTypes);
-            } else if (matchedAlterations.size() == 1) {
-                matchedAlt = matchedAlterations.iterator().next();
-            }
+            Alteration matchedAlt = ApplicationContextSingleton.getAlterationBo().findExactlyMatchedAlteration(query.getReferenceGenome(), alteration, AlterationUtils.getAllAlterations(query.getReferenceGenome(), gene));
 
             if (matchedAlt == null && isStructuralVariantEvent) {
                 matchedAlt = AlterationUtils.getRevertFusions(query.getReferenceGenome(), alteration);
@@ -636,8 +629,9 @@ public class IndicatorUtils {
         }
 
         if (indicatorQueryMutationEffect.getMutationEffect() == null || indicatorQueryMutationEffect.getMutationEffect().equals(MutationEffect.UNKNOWN)) {
+            boolean isPositionalVariant = AlterationUtils.isPositionedAlteration(alteration);
             // Find mutation effect from alternative alleles
-            if (alternativeAllele.size() > 0) {
+            if (alternativeAllele.size() > 0 && !isPositionalVariant) {
                 indicatorQueryMutationEffect =
                     MainUtils.setToAlternativeAlleleMutationEffect(
                         MainUtils.findHighestMutationEffectByEvidence(

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
@@ -1,7 +1,6 @@
 package org.mskcc.cbio.oncokb.util;
 
 import junit.framework.TestCase;
-import org.apache.commons.lang3.AnnotationUtils;
 import org.mskcc.cbio.oncokb.model.Alteration;
 import org.mskcc.cbio.oncokb.model.Gene;
 
@@ -9,7 +8,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.mskcc.cbio.oncokb.Constants.DEFAULT_REFERENCE_GENOME;
 
@@ -347,5 +345,34 @@ public class AlterationUtilsTest extends TestCase
 
         AlterationUtils.removeAlternativeAllele(DEFAULT_REFERENCE_GENOME,delins, relevantAlterations);
         assertEquals(3, relevantAlterations.size());
+    }
+
+    public void testGetMissenseProteinChangesFromComplexProteinChange() {
+        String test = "S768_V769delinsIL";
+        List<Alteration> alterations = AlterationUtils.getMissenseProteinChangesFromComplexProteinChange(test);
+        String alt = AlterationUtils.toString(alterations);
+        assertEquals("768I, 769L", alt);
+
+        test = "SV768IL";
+        alterations = AlterationUtils.getMissenseProteinChangesFromComplexProteinChange(test);
+        alt = AlterationUtils.toString(alterations);
+        assertEquals("S768I, V769L", alt);
+
+        // inframe insertion should not get any match
+        test = "S768_V769delinsILA";
+        alterations = AlterationUtils.getMissenseProteinChangesFromComplexProteinChange(test);
+        assertEquals(alterations.size(), 0);
+        test = "SV768ILA";
+        alterations = AlterationUtils.getMissenseProteinChangesFromComplexProteinChange(test);
+        alt = AlterationUtils.toString(alterations);
+        assertEquals(alterations.size(), 0);
+        // inframe deletion should not get any match
+        test = "S768_V769delinsI";
+        alterations = AlterationUtils.getMissenseProteinChangesFromComplexProteinChange(test);
+        assertEquals(alterations.size(), 0);
+        test = "SV768I";
+        alterations = AlterationUtils.getMissenseProteinChangesFromComplexProteinChange(test);
+        alt = AlterationUtils.toString(alterations);
+        assertEquals(alterations.size(), 0);
     }
 }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsIndependentTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsIndependentTest.java
@@ -55,12 +55,6 @@ public class FindRelevantAlterationsIndependentTest extends TestCase {
 
         relevantAlterations =
             ApplicationContextSingleton.getAlterationBo()
-                .findRelevantAlterations(ReferenceGenome.GRCh37, query, allAlterations, true);
-
-        assertEquals(2, relevantAlterations.size());
-
-        relevantAlterations =
-            ApplicationContextSingleton.getAlterationBo()
                 .findRelevantAlterations(ReferenceGenome.GRCh38, query, allAlterations, true);
 
         assertEquals(1, relevantAlterations.size());

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
@@ -40,6 +40,9 @@ public class FindRelevantAlterationsTest {
                 // Critical cases
                 {"BRAF", "V600E", null, "V600E, V600A, V600D, V600G, V600K, V600L, V600M, V600Q, V600R, VK600EI, V600, Oncogenic Mutations"},
                 {"SMARCB1", "R374Q", null, "R374Q, R374W, Oncogenic Mutations"},
+                {"EGFR", "S768I", null, "S768I, SV768IL, Oncogenic Mutations"},
+                {"EGFR", "S768_V769delinsIL", null, "S768I, V769L, V769M, SV768IL, Oncogenic Mutations"},
+
 
                 // Check Fusions
                 {"BRAF", "PAPSS1-BRAF Fusion", null, "PAPSS1-BRAF Fusion, Fusions, Oncogenic Mutations, Oncogenic Mutations {excluding V600}"},

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -118,6 +118,20 @@ public class IndicatorUtilsTest {
         assertTrue("Shouldn't have any significant level", indicatorQueryResp.getOtherSignificantSensitiveLevels().size() == 0);
         assertTrue(treatmentsContainLevel(indicatorQueryResp.getTreatments(), LevelOfEvidence.LEVEL_3B));
 
+        // check variant exist
+        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "BRAF", "V600E", null, null, null, null, null, null, null);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
+        assertTrue("The variantExist should be true, but it's not", indicatorQueryResp.getVariantExist());
+        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "PIK3CA", "V105_R108delVGNR", null, null, null, null, null, null, null);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
+        assertTrue("The variantExist should be true, but it's not", indicatorQueryResp.getVariantExist());
+        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "PIK3CA", "V105_R108del", null, null, null, null, null, null, null);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
+        assertTrue("The variantExist should be true, but it's not", indicatorQueryResp.getVariantExist());
+        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "PIK3CA", "V10000", null, null, null, null, null, null, null);
+        indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
+        assertFalse("The variantExist should be false, but it's not", indicatorQueryResp.getVariantExist());
+
         // For treatments include both 2B and 3A, 3A should be shown first
         // Test disabled: we no longer have 2B which means the other significant levels are not used
 //        query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "RET", "Fusions", null, null, "Medullary Thyroid Cancer", null, null, null, null);
@@ -195,8 +209,8 @@ public class IndicatorUtilsTest {
         query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "EGFR", "S768_V769delinsIL", null, null, "Non-Small Cell Lung Cancer", MISSENSE_VARIANT, null, null, null);
         indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
         assertEquals("Gene should exist", true, indicatorQueryResp.getGeneExist());
-        assertEquals("Variant should exist(mapped to S768I)", true, indicatorQueryResp.getVariantExist());
-        assertEquals("Is expected to be likely oncogenic", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
+        assertEquals("Variant should not exist", false, indicatorQueryResp.getVariantExist());
+        assertEquals("Is expected to be likely oncogenic", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level should be 1",
             LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
 

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/VariantsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/VariantsApiController.java
@@ -56,7 +56,10 @@ public class VariantsApiController implements VariantsApi {
                 Alteration alteration = new Alteration();
                 alteration.setGene(gene);
                 alteration.setAlteration(variant);
-                result = new ArrayList<>(AlterationUtils.findMatchedAlterations(matchedRG, alteration));
+                Alteration matchedAlteration = ApplicationContextSingleton.getAlterationBo().findExactlyMatchedAlteration(matchedRG, alteration, AlterationUtils.getAllAlterations(matchedRG, gene));
+                if (matchedAlteration != null) {
+                    result.add(matchedAlteration);
+                }
             }
         }
         return ResponseEntity.ok().body(JsonResultFactory.getAlteration(result, fields));


### PR DESCRIPTION
- We have two methods to find the exact match which is quite confusing, removing the one in the AlterationUtils
- Deal with complex missense mutations(for instance S768_V769delinsIL). Include the relevant missense mutations on the same spot. They should not be treated as alternative alleles.
- Positional variant should not have mutation effect propagated from others unless it's specifically curated.