### PR TITLE
Update to how the range inframe mutation is called hotspot

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/HotspotUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/HotspotUtils.java
@@ -65,7 +65,8 @@ class EnrichedHotspot extends Hotspot {
 public class HotspotUtils {
     private static final String HOTSPOT_FILE_PATH = "/data/cancer-hotspots-gn.json";
     private static Map<Gene, List<EnrichedHotspot>> hotspotMutations = new HashMap<>();
-    private static String POSITIONAL_MUTATION_TYPE="positional";
+    private static final String POSITIONAL_MUTATION_TYPE="positional";
+    private static final String RANGE_INFRAME_MUTATION_TYPE="rangeInframe";
 
     static {
         System.out.println("Cache all hotspots at " + MainUtils.getCurrentTime());
@@ -117,7 +118,13 @@ public class HotspotUtils {
         ProteinLocation proteinLocation = new ProteinLocation();
         proteinLocation.setStart(alteration.getProteinStart());
         proteinLocation.setEnd(alteration.getProteinEnd());
-        proteinLocation.setMutationType(AlterationUtils.isPositionedAlteration(alteration) ? POSITIONAL_MUTATION_TYPE : toGNMutationType(alteration.getConsequence()));
+        String mutationType = toGNMutationType(alteration.getConsequence());
+        if (AlterationUtils.isPositionedAlteration(alteration)) {
+            mutationType = POSITIONAL_MUTATION_TYPE;
+        } else if (AlterationUtils.isRangeInframeAlteration(alteration)) {
+            mutationType = RANGE_INFRAME_MUTATION_TYPE;
+        }
+        proteinLocation.setMutationType(mutationType);
         List<EnrichedHotspot> hotspots = new ArrayList<>();
 
         if (hotspotMutations.get(alteration.getGene()) == null) {
@@ -150,17 +157,22 @@ public class HotspotUtils {
             // Protein location
             int hotspotStart = hotspot.getStart();
             int hotspotStop = hotspot.getEnd();
-            validPosition &= (start <= hotspotStop && end >= hotspotStart);
+            if (type.equals(RANGE_INFRAME_MUTATION_TYPE)) {
+                validPosition = (start >= hotspotStart && end <= hotspotStop);
+            } else {
+                validPosition = (start <= hotspotStop && end >= hotspotStart);
+            }
 
             // Mutation type
             boolean validPositional = type.equals(POSITIONAL_MUTATION_TYPE) && (hotspot.getType().contains("3d") || hotspot.getType().contains("single residue"));
             boolean validMissense = type.equals("Missense_Mutation") && (hotspot.getType().contains("3d") || hotspot.getType().contains("single residue"));
+            boolean validInFrameRange = type.equals(RANGE_INFRAME_MUTATION_TYPE) && (hotspot.getType().contains("in-frame"));
             boolean validInFrameInsertion = type.equals("In_Frame_Ins") && (hotspot.getType().contains("in-frame"));
             boolean validInFrameDeletion = type.equals("In_Frame_Del") && (hotspot.getType().contains("in-frame"));
             boolean validSplice = (type.equals("Splice_Site") || type.equals("Splice_Region")) && (hotspot.getType().contains("splice"));
 
             // Add hotspot
-            if (validPosition && (validPositional || validMissense || validInFrameInsertion || validInFrameDeletion || validSplice)) {
+            if (validPosition && (validPositional || validMissense || validInFrameRange || validInFrameInsertion || validInFrameDeletion || validSplice)) {
                 if(validPositional || validMissense) {
                     boolean validReferenceResidues = (referenceResidues + proteinLocation.getStart()).equals(hotspot.getResidue());
                     if (validReferenceResidues) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/HotspotUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/HotspotUtilsTest.java
@@ -93,6 +93,23 @@ public class HotspotUtilsTest extends TestCase {
         assertTrue(HotspotUtils.isHotspot(alteration));
         alteration = AlterationUtils.getAlteration("BRAF", "A600E", null, null, null, null, null);
         assertFalse(HotspotUtils.isHotspot(alteration));
+
+        // for range alteration, unless the hotspot covers the whole range, it should not be considered hotspot
+        // the exact range
+        alteration = AlterationUtils.getAlteration("EGFR", "745_759del", null, null, null, null, null);
+        assertTrue(HotspotUtils.isHotspot(alteration));
+        alteration = AlterationUtils.getAlteration("EGFR", "745_759ins", null, null, null, null, null);
+        assertTrue(HotspotUtils.isHotspot(alteration));
+        // the range covered by hotspot
+        alteration = AlterationUtils.getAlteration("EGFR", "746_759del", null, null, null, null, null);
+        assertTrue(HotspotUtils.isHotspot(alteration));
+        alteration = AlterationUtils.getAlteration("EGFR", "746_759ins", null, null, null, null, null);
+        assertTrue(HotspotUtils.isHotspot(alteration));
+        // partial the range is outside the hotspot range
+        alteration = AlterationUtils.getAlteration("EGFR", "744_759del", null, null, null, null, null);
+        assertFalse(HotspotUtils.isHotspot(alteration));
+        alteration = AlterationUtils.getAlteration("EGFR", "744_759ins", null, null, null, null, null);
+        assertFalse(HotspotUtils.isHotspot(alteration));
     }
 
 }


### PR DESCRIPTION
For range inframe mutation, we should only call it hotspot when the range is the exact start/end with the hotspot list