### PR TITLE
Revert the inframe-indel overlap rules

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -66,18 +66,6 @@ public final class AlterationUtils {
         VariantConsequence inframeDeletionConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm(IN_FRAME_DELETION);
         for (Alteration alteration : alterations) {
             if (alteration.getGene().equals(gene) && alteration.getConsequence() != null && consequenceRelated(consequence, alteration.getConsequence()) && (referenceGenome == null || alteration.getReferenceGenomes().contains(referenceGenome))) {
-                if (isInframeAlteration(alteration)) {
-                    if (alteration.getConsequence().equals(inframeDeletionConsequence)) {
-                        if (alteration.getProteinStart() == start && alteration.getProteinEnd() == end && (proteinChange.equals(alteration.getAlteration()) || (!alteration.getAlteration().contains("delins") && !proteinChange.contains("delins")))) {
-                            overlaps.add(alteration);
-                            continue;
-                        }
-                    }
-                    // for inframe-deletion, we want to find the overlap of ranges.
-                    if (!isRangeInframeAlteration(alteration)) {
-                        continue;
-                    }
-                }
                 //For alteration without specific position, do not do intersection
                 if (start <= AlterationPositionBoundary.START.getValue() || end >= AlterationPositionBoundary.END.getValue()) {
                     if (start >= alteration.getProteinStart()

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
@@ -51,8 +51,8 @@ public class FindRelevantAlterationsTest {
                 {"BRAF", "V600E", null, "V600E, V600A, V600D, V600G, V600K, V600L, V600M, V600Q, V600R, VK600EI, V600, Oncogenic Mutations"},
                 {"BRAF", "V600A", null, "V600A, V600D, V600E, V600G, V600K, V600L, V600M, V600Q, V600R, VK600EI, V600, Oncogenic Mutations, V600 {excluding V600E ; V600K}"},
                 {"BRAF", "L597S", null, "L597S, L597P, L597Q, L597R, L597V, L597, Oncogenic Mutations, Oncogenic Mutations {excluding V600}"},
-                {"EGFR", "Y764_D770dup", null, "762_823ins, Oncogenic Mutations, 762_823ins {excluding A763_Y764insFQEA}"},
-                {"EGFR", "A763_Y764insFQEA", null, "A763_Y764insFQEA, 762_823ins, Oncogenic Mutations"},
+                {"EGFR", "Y764_D770dup", null, "762_823ins, A767_V769dup, S768_D770dup, A767_S768insASV, S768_V769insSVD, S768_V769insVAS, V769_D770insASV, V769_D770insGVV, D770delinsGTH, D770delinsGY, A763_Y764insFQEA, D770_N771insD, D770_N771insNPG, D770_N771insSVD, D770_N771insVDSVDNP, D770_P772dup, Oncogenic Mutations, 762_823ins {excluding A763_Y764insFQEA}"},
+                {"EGFR", "A763_Y764insFQEA", null, "A763_Y764insFQEA, 762_823ins, A763insLQEA, Oncogenic Mutations"},
 
                 // The revert fusion should get picked
                 {"ABL1", "ABL1-BCR fusion", null, "BCR-ABL1 Fusion, Fusions"},
@@ -73,10 +73,10 @@ public class FindRelevantAlterationsTest {
                 {"MAP2K4", "R304*", null, "R304*, Truncating Mutations"},
 
                 // Check inframe-insertion, inframe-deletion
-                {"EGFR", "Y764_D770dup", null, "762_823ins, Oncogenic Mutations, 762_823ins {excluding A763_Y764insFQEA}"},
-                {"EGFR", "A763_Y764insFQEA", null, "A763_Y764insFQEA, 762_823ins, Oncogenic Mutations"},
-                {"EGFR", "E746_A750del", null, "E746_A750del, 729_761del, Oncogenic Mutations"},
-                {"EGFR", "E746_A750delinsQ", null, "E746_A750delinsQ, 729_761del, Oncogenic Mutations"},
+                {"EGFR", "Y764_D770dup", null, "762_823ins, A767_V769dup, S768_D770dup, A767_S768insASV, S768_V769insSVD, S768_V769insVAS, V769_D770insASV, V769_D770insGVV, D770delinsGTH, D770delinsGY, A763_Y764insFQEA, D770_N771insD, D770_N771insNPG, D770_N771insSVD, D770_N771insVDSVDNP, D770_P772dup, Oncogenic Mutations, 762_823ins {excluding A763_Y764insFQEA}"},
+                {"EGFR", "A763_Y764insFQEA", null, "A763_Y764insFQEA, 762_823ins, A763insLQEA, Oncogenic Mutations"},
+                {"EGFR", "E746_A750del", null, "E746_A750del, E746_A750delinsQ, E746_T751delinsA, E746_T751delinsL, E746_T751delinsVA, K745_A750del, E746_S752delinsA, E746_S752delinsI, E746_S752delinsV, 729_761del, L747_A750del, L747_A750delinsP, L747_T751del, L747_T751delinsP, L747_S752del, L747_P753del, L747_P753delinsS, L747_K754delinsATSPE, L747_E749del, A750_E758del, A750_E758delinsP, Oncogenic Mutations"},
+                {"EGFR", "E746_A750delinsQ", null, "E746_A750delinsQ, E746_A750del, E746_T751delinsA, E746_T751delinsL, E746_T751delinsVA, K745_A750del, E746_S752delinsA, E746_S752delinsI, E746_S752delinsV, 729_761del, L747_A750del, L747_A750delinsP, L747_T751del, L747_T751delinsP, L747_S752del, L747_P753del, L747_P753delinsS, L747_K754delinsATSPE, L747_E749del, A750_E758del, A750_E758delinsP, Oncogenic Mutations"},
 
                 // EGFR exon deletion
                 {"EGFR", "vIII", null, "vIII, Oncogenic Mutations"},
@@ -107,7 +107,7 @@ public class FindRelevantAlterationsTest {
                 {"PDGFRA", "D842V", null, "D842V, D842H, D842I, D842Y, D842_I843delinsIM, 814_852mis, Oncogenic Mutations"},
 
                 // Check whether the overlapped variants(with the same consequence) will be mapped
-                {"MAP2K1", "E41_F53del", null, "E41_F53del, Oncogenic Mutations"},
+                {"MAP2K1", "E41_F53del", null, "E41_F53del, E41_L54del, L42_K57del, E51_Q58del, F53_Q58del, F53_Q58delinsL, Oncogenic Mutations"},
 
                 // Truncating Mutations in the Oncogene should not be mapped to any range mutation unless the consequence is truncating
                 {"KIT", "K509Nfs*2", null, "K509Nfs*2"},

--- a/core/src/test/resources/test_variant_treatments.tsv
+++ b/core/src/test/resources/test_variant_treatments.tsv
@@ -30,7 +30,7 @@ PDGFRA	D842V	R1 (Gastrointestinal Stromal Tumor): Imatinib; 1 (Gastrointestinal 
 EGFR	A763_Y764insFQEA	1 (Non-Small Cell Lung Cancer): Amivantamab; 1 (Non-Small Cell Lung Cancer): Mobocertinib; 2 (Non-Small Cell Lung Cancer): Erlotinib; 3A (Non-Small Cell Lung Cancer): Poziotinib; 3A (Non-Small Cell Lung Cancer): CLN-081; 4 (Non-Small Cell Lung Cancer): Afatinib;
 
 # this one overlaps with A763_Y764insFQEA, but the rule only applies to exact match, so R1 will be used	
-EGFR	Y764_D770dup	R1 (Non-Small Cell Lung Cancer): Erlotinib; R1 (Non-Small Cell Lung Cancer): Gefitinib; R1 (Non-Small Cell Lung Cancer): Afatinib; 1 (Non-Small Cell Lung Cancer): Amivantamab; 1 (Non-Small Cell Lung Cancer): Mobocertinib; 3A (Non-Small Cell Lung Cancer): Poziotinib; 3A (Non-Small Cell Lung Cancer): CLN-081;
+EGFR	Y764_D770dup	R1 (Non-Small Cell Lung Cancer): Erlotinib; R1 (Non-Small Cell Lung Cancer): Gefitinib; R1 (Non-Small Cell Lung Cancer): Afatinib; 1 (Non-Small Cell Lung Cancer): Amivantamab; 1 (Non-Small Cell Lung Cancer): Mobocertinib; 2 (Non-Small Cell Lung Cancer): Erlotinib; 3A (Non-Small Cell Lung Cancer): Poziotinib; 3A (Non-Small Cell Lung Cancer): CLN-081; 4 (Non-Small Cell Lung Cancer): Afatinib;
 
 # this one does not overlap with A763_Y764insFQEA, so R1 for sure
 EGFR	N771delinsSTH	R1 (Non-Small Cell Lung Cancer): Erlotinib; R1 (Non-Small Cell Lung Cancer): Gefitinib; R1 (Non-Small Cell Lung Cancer): Afatinib; 1 (Non-Small Cell Lung Cancer): Amivantamab; 1 (Non-Small Cell Lung Cancer): Mobocertinib; 3A (Non-Small Cell Lung Cancer): Poziotinib; 3A (Non-Small Cell Lung Cancer): CLN-081;


### PR DESCRIPTION
After the discussion with the team, we do want to only use the range mutation for overlapping. But without the all the range mutation coverage, we cannot change the rule, it will remove a lot of annotations. Reverting back to previous.
Related pr: https://github.com/oncokb/oncokb/pull/3005/files
This fixes https://github.com/oncokb/oncokb/issues/3028