### PR TITLE
Revert "Bump jackson-databind from 2.9.10.8 to 2.12.6.1 in /core"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
+            <version>2.9.10.8</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Reverts oncokb/oncokb#3048

The swagger2 relies on 2.9