### PR TITLE
Add promoter as alteration when working with HGVSg/Genomic change queries

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/QueryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/QueryUtils.java
@@ -3,10 +3,9 @@ package org.mskcc.cbio.oncokb.util;
 import com.mysql.jdbc.StringUtils;
 import org.mskcc.cbio.oncokb.model.*;
 
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 
-import static org.mskcc.cbio.oncokb.util.FusionUtils.FUSION_SEPARATOR;
+import static org.mskcc.cbio.oncokb.Constants.UPSTREAM_GENE;
 
 /**
  * Created by Hongxin Zhang on 8/23/17.
@@ -45,7 +44,7 @@ public class QueryUtils {
         return name;
     }
 
-    public static Query getQueryForHgvsg(ReferenceGenome referenceGenome, String hgvsg, String tumorType, Alteration alteration) {
+    public static Query getQueryFromAlteration(ReferenceGenome referenceGenome, String tumorType, Alteration alteration, String hgvsg) {
         Query query = new Query();
         query.setReferenceGenome(referenceGenome);
         query.setHgvs(hgvsg);
@@ -59,6 +58,9 @@ public class QueryUtils {
         query.setProteinEnd(alteration.getProteinEnd());
         if (alteration.getConsequence() != null) {
             query.setConsequence(alteration.getConsequence().getTerm());
+            if (alteration.getConsequence().getTerm().equals(UPSTREAM_GENE) && StringUtils.isNullOrEmpty(query.getAlteration())) {
+                query.setAlteration(SpecialVariant.PROMOTER.getVariant());
+            }
         }
         return query;
     }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -4,11 +4,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.mskcc.cbio.oncokb.apiModels.Implication;
 import org.mskcc.cbio.oncokb.apiModels.MainType;
-import org.mskcc.cbio.oncokb.cache.CacheFetcher;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.apiModels.TumorType;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -635,7 +633,7 @@ public class IndicatorUtilsTest {
         // Test indicator endpoint supports HGVS
         String hgvsg = "7:g.140453136A>T";
         Alteration alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, hgvsg, DEFAULT_REFERENCE_GENOME);
-        query = QueryUtils.getQueryForHgvsg(DEFAULT_REFERENCE_GENOME, hgvsg, "Melanoma", alteration);
+        query = QueryUtils.getQueryFromAlteration(DEFAULT_REFERENCE_GENOME, "Melanoma", alteration, hgvsg);
         indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
         assertTrue("The geneExist is not true, but it should be.", indicatorQueryResp.getGeneExist() == true);
         assertEquals("The oncogenicity is not Oncogenic, but it should be.", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
@@ -643,7 +641,7 @@ public class IndicatorUtilsTest {
 
         hgvsg = "7:g.140453136A>T";
         alteration = AlterationUtils.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, hgvsg, DEFAULT_REFERENCE_GENOME);
-        query1 = QueryUtils.getQueryForHgvsg(DEFAULT_REFERENCE_GENOME, hgvsg, "Melanoma", alteration);
+        query1 = QueryUtils.getQueryFromAlteration(DEFAULT_REFERENCE_GENOME, "Melanoma", alteration, hgvsg);
         query2 = new Query(null, DEFAULT_REFERENCE_GENOME, null, "BRAF", "V600E", null, null, "Melanoma", null, null, null, null);
 
         resp1 = IndicatorUtils.processQuery(query1, null, false, null);

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
@@ -508,8 +508,7 @@ public class AnnotationsApiController {
         } else {
             alteration = this.cacheFetcher.getAlterationFromGenomeNexus(GNVariantAnnotationType.GENOMIC_LOCATION, referenceGenome, genomicLocation);
         }
-        Query query = new Query();
-        query = new Query(null, referenceGenome, null, alteration.getGene() == null ? null : alteration.getGene().getHugoSymbol(), alteration.getAlteration(), null, null, tumorType, alteration.getConsequence() == null ? null : alteration.getConsequence().getTerm(), alteration.getProteinStart(), alteration.getProteinEnd(), null);
+        Query query = QueryUtils.getQueryFromAlteration(referenceGenome, tumorType, alteration, null);
         return this.cacheFetcher.processQuery(
             referenceGenome,
             query.getEntrezGeneId(),
@@ -535,7 +534,7 @@ public class AnnotationsApiController {
         } else {
             alteration = this.cacheFetcher.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, referenceGenome, hgvsg);
         }
-        Query query = QueryUtils.getQueryForHgvsg(referenceGenome, hgvsg, tumorType, alteration);
+        Query query = QueryUtils.getQueryFromAlteration(referenceGenome, tumorType, alteration, hgvsg);
 
         return this.cacheFetcher.processQuery(
             referenceGenome,

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
@@ -424,7 +424,7 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
             } else {
                 alterationModel = this.cacheFetcher.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, matchedRG, hgvsg);
             }
-            query = QueryUtils.getQueryForHgvsg(matchedRG, hgvsg, tumorType, alterationModel);
+            query = QueryUtils.getQueryFromAlteration(matchedRG, tumorType, alterationModel, hgvsg);
             gene = GeneUtils.getGeneByEntrezId(query.getEntrezGeneId());
         }
         query.setTumorType(tumorType);


### PR DESCRIPTION
After annotating HGVSg and genomic change from  genome nexus, we should update alteration field to promoter when consequence is upstream gene variant.
This is related to https://github.com/oncokb/oncokb/issues/3087