### PR TITLE
Fix an issue when finding the matched alteration

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -65,7 +65,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
                         alteration.getProteinStart().equals(alt.getProteinStart()) &&
                         alteration.getProteinEnd().equals(alt.getProteinEnd()) &&
                         (StringUtils.isNullOrEmpty(alteration.getRefResidues()) || alteration.getRefResidues().equals(alt.getRefResidues())) &&
-                        alt.getVariantResidues().equals(alteration.getVariantResidues())
+                        (StringUtils.isNullOrEmpty(alteration.getVariantResidues()) || alteration.getVariantResidues().equals(alt.getVariantResidues()))
                 ).findAny();
                 if (match.isPresent()) {
                     return match.get();
@@ -378,6 +378,11 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
             if (includeAlternativeAllele) {
                 alterations.addAll(AlterationUtils.getAlleleAlterations(referenceGenome, alteration, fullAlterations));
+                if(complexMisMuts.size() > 0) {
+                    for (Alteration complexMisMut : complexMisMuts) {
+                        alterations.addAll(AlterationUtils.getAlleleAlterations(referenceGenome, complexMisMut, fullAlterations));
+                    }
+                }
                 // Include the range mutation
                 List<Alteration> mutationsByConsequenceAndPosition = findRelevantOverlapAlterations(alteration.getGene(), referenceGenome, alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), alteration.getAlteration(), fullAlterations);
                 for (Alteration alt : mutationsByConsequenceAndPosition) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/FindRelevantAlterationsTest.java
@@ -41,7 +41,7 @@ public class FindRelevantAlterationsTest {
                 {"BRAF", "V600E", null, "V600E, V600A, V600D, V600G, V600K, V600L, V600M, V600Q, V600R, VK600EI, V600, Oncogenic Mutations"},
                 {"SMARCB1", "R374Q", null, "R374Q, R374W, Oncogenic Mutations"},
                 {"EGFR", "S768I", null, "S768I, SV768IL, Oncogenic Mutations"},
-                {"EGFR", "S768_V769delinsIL", null, "S768I, V769L, V769M, SV768IL, Oncogenic Mutations"},
+                {"EGFR", "S768_V769delinsIL", null, "SV768IL, S768I, V769L, V769M, Oncogenic Mutations"},
 
                 // Check resisatnce mutations, they should be matched with Oncogenic Mutations
                 {"ALK", "G1202R", null, "G1202R, Oncogenic Mutations"},

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -207,8 +207,9 @@ public class IndicatorUtilsTest {
         query = new Query(null, DEFAULT_REFERENCE_GENOME, null, "EGFR", "S768_V769delinsIL", null, null, "Non-Small Cell Lung Cancer", MISSENSE_VARIANT, null, null, null);
         indicatorQueryResp = IndicatorUtils.processQuery(query, null, true, null);
         assertEquals("Gene should exist", true, indicatorQueryResp.getGeneExist());
-        assertEquals("Variant should not exist", false, indicatorQueryResp.getVariantExist());
-        assertEquals("Is expected to be likely oncogenic", Oncogenicity.LIKELY.getOncogenic(), indicatorQueryResp.getOncogenic());
+        // this is equivalent to SV768IL which we curated
+        assertEquals("Variant should exist", true, indicatorQueryResp.getVariantExist());
+        assertEquals("Is expected to be oncogenic", Oncogenicity.YES.getOncogenic(), indicatorQueryResp.getOncogenic());
         assertEquals("The highest sensitive level should be 1",
             LevelOfEvidence.LEVEL_1, indicatorQueryResp.getHighestSensitiveLevel());
 


### PR DESCRIPTION
When looking at the complex missense mutation, we want to match to the one with the same protein start/end but ref/var might be missing.
This fixes https://github.com/oncokb/oncokb/issues/3149