### PR TITLE
Include the internal public api link in the curation platform configs

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/CurationPlatformConfigs.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/CurationPlatformConfigs.java
@@ -14,6 +14,7 @@ public class CurationPlatformConfigs {
     String privateApiLink;
     String internalPrivateApiLink;
     String publicApiLink;
+    String internalPublicApiLink;
     String websocketApiLink;
     Boolean testing;
     Boolean production;
@@ -57,6 +58,14 @@ public class CurationPlatformConfigs {
 
     public void setPublicApiLink(String publicApiLink) {
         this.publicApiLink = publicApiLink;
+    }
+
+    public String getInternalPublicApiLink() {
+        return internalPublicApiLink;
+    }
+
+    public void setInternalPublicApiLink(String internalPublicApiLink) {
+        this.internalPublicApiLink = internalPublicApiLink;
     }
 
     public String getWebsocketApiLink() {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/PropertiesUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/PropertiesUtils.java
@@ -65,6 +65,7 @@ public final class PropertiesUtils {
         curationPlatformConfigs.setPrivateApiLink(getProperties("curation_platform.private_link"));
         curationPlatformConfigs.setInternalPrivateApiLink(getProperties("curation_platform.internal_private_link"));
         curationPlatformConfigs.setPublicApiLink(getProperties("curation_platform.public_api_link"));
+        curationPlatformConfigs.setInternalPublicApiLink(getProperties("curation_platform.internal_public_api_link"));
         curationPlatformConfigs.setWebsocketApiLink(getProperties("curation_platform.websocket_api_link"));
         curationPlatformConfigs.setProduction(Boolean.valueOf(getProperties("curation_platform.production")));
         curationPlatformConfigs.setTesting(Boolean.valueOf(getProperties("curation_platform.testing")));

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -80,7 +80,7 @@
         <profile>
             <id>curate</id>
             <properties>
-                <frontend.version>0.6.13</frontend.version>
+                <frontend.version>0.7.0</frontend.version>
                 <frontend.groupId>com.github.oncokb</frontend.groupId>
                 <frontend.artifactId>curation-platform</frontend.artifactId>
             </properties>


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb/issues/3160 and https://github.com/oncokb/curation-platform/releases/tag/0.7.0