### PR TITLE
Add property to update swagger hostname

### DIFF
--- a/core/src/main/resources/properties-EXAMPLE/config.properties
+++ b/core/src/main/resources/properties-EXAMPLE/config.properties
@@ -36,8 +36,10 @@ google.password=
 #where all log emails go
 curation.log.email.to=
 
-#parameters to change the text in the swagger API page
+#parameter to change the text in the swagger API page
 swagger_description=
+#parameter to change swagger hostname
+swagger_hostname=
 
 # AWS s3 access key and secret Key
 aws.s3.accessKey=


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3192

- Added a new property `swagger_hostname`
- When property is not set, then the default host will be supplied by the swagger config. When property is set, then the default will be overriden.

![image](https://user-images.githubusercontent.com/59149377/191094763-73d90fc7-7e30-4cdf-a9a6-5c8dbb14fdcd.png)
