### PR TITLE
Use Snappy Codec over GZip for zipping the redis cache && Add redis cluster support

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -5,8 +5,6 @@ import org.mskcc.cbio.oncokb.util.PropertiesUtils;
 import org.mskcc.oncokb.meta.enumeration.RedisType;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
-import org.redisson.client.codec.StringCodec;
-import org.redisson.codec.MarshallingCodec;
 import org.redisson.codec.SnappyCodecV2;
 import org.redisson.config.Config;
 import org.springframework.cache.CacheManager;
@@ -57,6 +55,9 @@ public class CacheConfiguration {
                     " is not supported. Only single, sentinel, and cluster are supported."
             );
         }
+        // Instead of using GZip to compress data manually, we can use configure Redisson to use
+        // snappy codec. Redisson will serialize and compress our cache values.
+        config.setCodec(new SnappyCodecV2());
         return Redisson.create(config);
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -55,7 +55,7 @@ public class CacheConfiguration {
                     " is not supported. Only single, sentinel, and cluster are supported."
             );
         }
-        // Instead of using GZip to compress data manually, we can use configure Redisson to use
+        // Instead of using GZip to compress data manually, we can configure Redisson to use
         // snappy codec. Redisson will serialize and compress our cache values.
         config.setCodec(new SnappyCodecV2());
         return Redisson.create(config);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -5,6 +5,9 @@ import org.mskcc.cbio.oncokb.util.PropertiesUtils;
 import org.mskcc.oncokb.meta.enumeration.RedisType;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.codec.MarshallingCodec;
+import org.redisson.codec.SnappyCodecV2;
 import org.redisson.config.Config;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -42,11 +45,16 @@ public class CacheConfiguration {
                 .setDnsMonitoringInterval(-1)
                 .addSentinelAddress(redisAddress)
                 .setPassword(redisPassword);
+        } else if (redisType.equals(RedisType.CLUSTER.getType())) {
+            config
+                .useClusterServers()
+                .addNodeAddress(redisAddress)
+                .setPassword(redisPassword);
         } else {
             throw new Exception(
                 "The redis type " +
                     redisType +
-                    " is not supported. Only single and sentinel are supported."
+                    " is not supported. Only single, sentinel, and cluster are supported."
             );
         }
         return Redisson.create(config);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCache.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCache.java
@@ -48,8 +48,7 @@ public abstract class CustomRedisCache extends AbstractValueAdaptingCache {
 
     @Override
     protected Object lookup(Object key) {
-        Object value = this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).get();
-        return value;
+        return this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).get();
     }
 
     private void asyncRefresh(Object key) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCache.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCache.java
@@ -49,10 +49,6 @@ public abstract class CustomRedisCache extends AbstractValueAdaptingCache {
     @Override
     protected Object lookup(Object key) {
         Object value = this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).get();
-        if (value != null){
-            value = fromStoreValue(value);
-            asyncRefresh(key);
-        }
         return value;
     }
 
@@ -65,9 +61,9 @@ public abstract class CustomRedisCache extends AbstractValueAdaptingCache {
     @Override
     public void put(Object key, Object value) {
         if (ttlMinutes == INFINITE_TTL) {
-            this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).setAsync(toStoreValue(value));
+            this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).setAsync(value);
         } else {
-            this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).setAsync(toStoreValue(value), ttlMinutes, TimeUnit.MINUTES);
+            this.store.getBucket(name + REDIS_KEY_SEPARATOR + key).setAsync(value, ttlMinutes, TimeUnit.MINUTES);
         }
     }
 

--- a/core/src/main/resources/properties-EXAMPLE/config.properties
+++ b/core/src/main/resources/properties-EXAMPLE/config.properties
@@ -47,10 +47,11 @@ aws.s3.region=
 # Redis configurations to cache the annotation contents
 # only when set to true, the redis will be enabled
 redis.enable=false
-# single/sentinel
+# single/sentinel/cluster
 redis.type=single
 redis.address=redis://localhost:6379
 redis.password=oncokb-redis-password
+# only for redis sentinel
 redis.masterName=oncokb-master
 # in minutes
 redis.expiration=30

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.github.oncokb</groupId>
             <artifactId>oncokb-meta</artifactId>
-            <version>49fd530a58</version>
+            <version>ee9b767985</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
             <version>3.15.5</version>
         </dependency>
         <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.8.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.oncokb</groupId>
             <artifactId>oncokb-meta</artifactId>
             <version>ee9b767985</version>


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3241

## Changes
- Update CacheConfiguration to support redis cluster
- Used JProfiler to identify bottlenecks and then removed the `toStoreValue`, `fromStoreValue`, and `asyncRefresh` methods.
- Tested Redisson's SnappyCodecV2 to compress data after removing our own methods for zipping data.

## In Progress
- [x] Test snappy with redis sentinel before merging