### PR TITLE
Add redis connection size properties and upgrade Redisson to v3.17.7

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -1,12 +1,18 @@
 package org.mskcc.cbio.oncokb.cache;
 
+import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.cache.keygenerator.ConcatGenerator;
 import org.mskcc.cbio.oncokb.util.PropertiesUtils;
 import org.mskcc.oncokb.meta.enumeration.RedisType;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.codec.SnappyCodecV2;
+import org.redisson.config.BaseConfig;
+import org.redisson.config.BaseMasterSlaveServersConfig;
+import org.redisson.config.ClusterServersConfig;
 import org.redisson.config.Config;
+import org.redisson.config.SentinelServersConfig;
+import org.redisson.config.SingleServerConfig;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.CacheResolver;
@@ -17,7 +23,14 @@ import org.springframework.context.annotation.*;
 @EnableCaching
 @Conditional(EnableCacheCondition.class)
 public class CacheConfiguration {
+    
     private final int DEFAULT_TTL = 60;
+    private String redisSlaveConnectionMinimumIdleSize;
+    private String redisSlaveConnectionPoolSize;
+    private String redisMasterConnectionMinimumIdleSize;
+    private String redisMasterConnectionPoolSize;
+    private String redisClientName;
+
     @Bean
     public RedissonClient redissonClient()
         throws Exception {
@@ -26,28 +39,41 @@ public class CacheConfiguration {
         String redisPassword = PropertiesUtils.getProperties("redis.password");
         String redisAddress = PropertiesUtils.getProperties("redis.address");
         String redisMasterName = PropertiesUtils.getProperties("redis.masterName");
+        redisSlaveConnectionMinimumIdleSize = PropertiesUtils.getProperties("redis.slaveConnectionMinimumIdleSize");
+        redisSlaveConnectionPoolSize = PropertiesUtils.getProperties("redis.slaveConnectionPoolSize");
+        redisMasterConnectionMinimumIdleSize = PropertiesUtils.getProperties("redis.masterConnectionMinimumIdleSize");
+        redisMasterConnectionPoolSize = PropertiesUtils.getProperties("redis.masterConnectionPoolSize");
+        redisClientName = PropertiesUtils.getProperties("redis.clientName");
 
         if (redisType.equals(RedisType.SINGLE.getType())) {
-            config
+            SingleServerConfig singleServerConfig = config
                 .useSingleServer()
                 .setAddress(redisAddress)
                 .setConnectionMinimumIdleSize(1)
                 .setConnectionPoolSize(2)
+                .setSubscriptionConnectionMinimumIdleSize(0)
+                .setSubscriptionConnectionPoolSize(0)
                 .setDnsMonitoringInterval(-1)
                 .setPassword(redisPassword);
+            setRedisClientName(singleServerConfig);
         } else if (redisType.equals(RedisType.SENTINEL.getType())) {
-            config
+            SentinelServersConfig sentinelConfig = config
                 .useSentinelServers()
                 .setMasterName(redisMasterName)
                 .setCheckSentinelsList(false)
                 .setDnsMonitoringInterval(-1)
                 .addSentinelAddress(redisAddress)
                 .setPassword(redisPassword);
+            setRedisConnectionPoolSize(sentinelConfig);
+            setRedisClientName(sentinelConfig);
         } else if (redisType.equals(RedisType.CLUSTER.getType())) {
-            config
-                .useClusterServers()
-                .addNodeAddress(redisAddress)
-                .setPassword(redisPassword);
+            ClusterServersConfig clusterConfig = 
+                config
+                    .useClusterServers()
+                    .addNodeAddress(redisAddress)
+                    .setPassword(redisPassword);
+            setRedisConnectionPoolSize(clusterConfig);
+            setRedisClientName(clusterConfig);
         } else {
             throw new Exception(
                 "The redis type " +
@@ -55,10 +81,37 @@ public class CacheConfiguration {
                     " is not supported. Only single, sentinel, and cluster are supported."
             );
         }
+
         // Instead of using GZip to compress data manually, we can configure Redisson to use
         // snappy codec. Redisson will serialize and compress our cache values.
         config.setCodec(new SnappyCodecV2());
         return Redisson.create(config);
+    }
+
+    private void setRedisConnectionPoolSize(BaseMasterSlaveServersConfig baseMasterSlaveServersConfig) {
+        baseMasterSlaveServersConfig.setSubscriptionConnectionMinimumIdleSize(0);
+        baseMasterSlaveServersConfig.setSubscriptionConnectionPoolSize(0);
+
+        if (StringUtils.isNotEmpty(redisSlaveConnectionMinimumIdleSize)) {
+            baseMasterSlaveServersConfig.setSlaveConnectionMinimumIdleSize(Integer.parseInt(redisSlaveConnectionMinimumIdleSize));
+        }
+        if (StringUtils.isNotEmpty(redisSlaveConnectionPoolSize)) {
+            baseMasterSlaveServersConfig.setSlaveConnectionPoolSize(Integer.parseInt(redisSlaveConnectionPoolSize));
+        }
+        if (StringUtils.isNotEmpty(redisMasterConnectionMinimumIdleSize)) {
+            baseMasterSlaveServersConfig.setMasterConnectionMinimumIdleSize(Integer.parseInt(redisMasterConnectionMinimumIdleSize));
+        }
+        if (StringUtils.isNotEmpty(redisMasterConnectionPoolSize)) {
+            baseMasterSlaveServersConfig.setMasterConnectionPoolSize(Integer.parseInt(redisMasterConnectionPoolSize));
+        }
+    }
+
+    private void setRedisClientName(BaseConfig baseConfig) {
+        if (StringUtils.isNotEmpty(redisClientName)) {
+            baseConfig.setClientName(redisClientName);
+        } else {
+            baseConfig.setClientName("oncokb-core-client");
+        }
     }
 
     @Bean

--- a/core/src/main/resources/properties-EXAMPLE/config.properties
+++ b/core/src/main/resources/properties-EXAMPLE/config.properties
@@ -57,6 +57,11 @@ redis.password=oncokb-redis-password
 redis.masterName=oncokb-master
 # in minutes
 redis.expiration=30
+redis.slaveConnectionMinimumIdleSize=
+redis.slaveConnectionPoolSize=
+redis.masterConnectionMinimumIdleSize=
+redis.masterConnectionPoolSize=
+redis.clientName=
 
 #curation platform properties (only enable when build curation platform)
 

--- a/core/src/main/resources/properties-EXAMPLE/config.properties
+++ b/core/src/main/resources/properties-EXAMPLE/config.properties
@@ -29,6 +29,9 @@ genome_nexus.grch38.url=https://grch38.genomenexus.org
 
 # Optional properties
 
+#Name of application
+app.name=
+
 #Google account info. They are used to send email (Optional)
 google.username=
 google.password=
@@ -61,7 +64,6 @@ redis.slaveConnectionMinimumIdleSize=
 redis.slaveConnectionPoolSize=
 redis.masterConnectionMinimumIdleSize=
 redis.masterConnectionPoolSize=
-redis.clientName=
 
 #curation platform properties (only enable when build curation platform)
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
-            <version>3.15.5</version>
+            <version>3.17.7</version>
         </dependency>
         <dependency>
             <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
- This will make it easier to change the `slaveConnectionMinimumIdleSize`, `slaveConnectionPoolSize`, `masterConnectionMinimumIdleSize`, `masterConnectionPoolSize` Redis properties.

- Upgrade Redisson from 3.15.5 to 3.17.7
  - There are some fixes related to Redis Cluster
- Add client name