### PR TITLE
Generate pre-annotated variants from Genome Nexus

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/genomeNexusPreAnnotations/GenomeNexusAnnotatedVariantInfo.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/genomeNexusPreAnnotations/GenomeNexusAnnotatedVariantInfo.java
@@ -1,0 +1,97 @@
+package org.mskcc.cbio.oncokb.model.genomeNexusPreAnnotations;
+
+import org.mskcc.cbio.oncokb.model.ReferenceGenome;
+
+public class GenomeNexusAnnotatedVariantInfo {
+    private String originalVariantQuery;
+    private String hgvsg;
+    private String genomicLocation;
+    private ReferenceGenome referenceGenome;
+    private String hugoSymbol;
+    private Integer entrezGeneId;
+    private String hgvspShort;
+    private Integer proteinStart;
+    private Integer proteinEnd;
+    private String consequenceTerms;
+
+    public String getGenomicLocation() {
+        return this.genomicLocation;
+    }
+
+    public void setGenomicLocation(String genomicLocation) {
+        this.genomicLocation = genomicLocation;
+    }
+
+    public String getOriginalVariantQuery() {
+        return this.originalVariantQuery;
+    }
+
+    public void setOriginalVariantQuery(String originalVariantQuery) {
+        this.originalVariantQuery = originalVariantQuery;
+    }
+
+    public String getHgvsg() {
+        return this.hgvsg;
+    }
+
+    public void setHgvsg(String hgvsg) {
+        this.hgvsg = hgvsg;
+    }
+
+    public ReferenceGenome getReferenceGenome() {
+        return this.referenceGenome;
+    }
+
+    public void setReferenceGenome(ReferenceGenome referenceGenome) {
+        this.referenceGenome = referenceGenome;
+    }
+
+    public String getHugoSymbol() {
+        return this.hugoSymbol;
+    }
+
+    public void setHugoSymbol(String hugoSymbol) {
+        this.hugoSymbol = hugoSymbol;
+    }
+
+    public Integer getEntrezGeneId() {
+        return this.entrezGeneId;
+    }
+
+    public void setEntrezGeneId(Integer entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public String getHgvspShort() {
+        return this.hgvspShort;
+    }
+
+    public void setHgvspShort(String hgvspShort) {
+        this.hgvspShort = hgvspShort;
+    }
+
+    public Integer getProteinStart() {
+        return this.proteinStart;
+    }
+
+    public void setProteinStart(Integer proteinStart) {
+        this.proteinStart = proteinStart;
+    }
+
+    public Integer getProteinEnd() {
+        return this.proteinEnd;
+    }
+
+    public void setProteinEnd(Integer proteinEnd) {
+        this.proteinEnd = proteinEnd;
+    }
+
+    public String getConsequenceTerms() {
+        return this.consequenceTerms;
+    }
+
+    public void setConsequenceTerms(String consequenceTerms) {
+        this.consequenceTerms = consequenceTerms;
+    }
+
+}

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -596,7 +596,6 @@ public final class AlterationUtils {
                 String hugoSymbol = transcriptConsequenceSummary.getHugoGeneSymbol();
                 Integer entrezGeneId = StringUtils.isNumeric(transcriptConsequenceSummary.getEntrezGeneId()) ? Integer.parseInt(transcriptConsequenceSummary.getEntrezGeneId()) : null;
                 if (StringUtils.isNotEmpty(transcriptConsequenceSummary.getHugoGeneSymbol())) {
-
                     Gene gene = GeneUtils.getGene(hugoSymbol);
                     if (gene == null) {
                         gene = new Gene();

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateGenomeNexusController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateGenomeNexusController.java
@@ -2,6 +2,7 @@ package org.mskcc.cbio.oncokb.api.pvt;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.genome_nexus.ApiException;
@@ -9,12 +10,21 @@ import org.genome_nexus.client.EnsemblTranscript;
 import org.mskcc.cbio.oncokb.apiModels.TranscriptMatchResult;
 import org.mskcc.cbio.oncokb.apiModels.TranscriptPair;
 import org.mskcc.cbio.oncokb.apiModels.TranscriptResult;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByGenomicChangeQuery;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
+import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.ReferenceGenome;
+import org.mskcc.cbio.oncokb.model.genomeNexusPreAnnotations.GenomeNexusAnnotatedVariantInfo;
+import org.mskcc.cbio.oncokb.util.GenomeNexusUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 import static org.mskcc.cbio.oncokb.util.GenomeNexusUtils.getCanonicalEnsemblTranscript;
 import static org.mskcc.cbio.oncokb.util.GenomeNexusUtils.matchTranscript;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**1
  * Controller to authenticate users.
@@ -46,5 +56,54 @@ public class PrivateGenomeNexusController {
         return new ResponseEntity<>(transcriptResult, HttpStatus.OK);
     }
 
+    @ApiOperation(value = "", notes = "Fetch Genome Nexus variant info by HGVSg", response = GenomeNexusAnnotatedVariantInfo.class, responseContainer = "List")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK", response = GenomeNexusAnnotatedVariantInfo.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Error, error message will be given.", response = String.class)})
+    @RequestMapping(value = "/fetchGnVariants/byHGVSg",
+        consumes = {"application/json"},
+        produces = {"application/json"},
+        method = RequestMethod.POST)
+    public ResponseEntity<List<GenomeNexusAnnotatedVariantInfo>> fetchGenomeNexusVariantInfoByHGVSgPost(
+        @ApiParam(value = "List of queries. Please see swagger.json for request body format.", required = true) @RequestBody() List<AnnotateMutationByHGVSgQuery> body
+    ) throws ApiException, org.genome_nexus.ApiException {
+        HttpStatus status = HttpStatus.OK;
+        List<GenomeNexusAnnotatedVariantInfo> result = new ArrayList<>();
+
+        if (body == null) {
+            status = HttpStatus.BAD_REQUEST;
+        } else {
+            for (AnnotateMutationByHGVSgQuery query : body) {
+                GenomeNexusAnnotatedVariantInfo resp = GenomeNexusUtils.getAnnotatedVariantFromGenomeNexus(GNVariantAnnotationType.HGVS_G, query.getHgvsg(), query.getReferenceGenome());
+                result.add(resp);
+            }
+        }
+        return new ResponseEntity<>(result, status);
+    }
+
+    @ApiOperation(value = "", notes = "Fetch Genome Nexus variant info by genomic change", response = GenomeNexusAnnotatedVariantInfo.class, responseContainer = "List")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK", response = GenomeNexusAnnotatedVariantInfo.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Error, error message will be given.", response = String.class)})
+    @RequestMapping(value = "/fetchGnVariants/byGenomicChange",
+        consumes = {"application/json"},
+        produces = {"application/json"},
+        method = RequestMethod.POST)
+    public ResponseEntity<List<GenomeNexusAnnotatedVariantInfo>> fetchGenomeNexusVariantInfoByGenomicChangePost(
+        @ApiParam(value = "List of queries. Please see swagger.json for request body format.", required = true) @RequestBody() List<AnnotateMutationByGenomicChangeQuery> body
+    ) throws ApiException, org.genome_nexus.ApiException {
+        HttpStatus status = HttpStatus.OK;
+        List<GenomeNexusAnnotatedVariantInfo> result = new ArrayList<>();
+
+        if (body == null) {
+            status = HttpStatus.BAD_REQUEST;
+        } else {
+            for (AnnotateMutationByGenomicChangeQuery query : body) {
+                GenomeNexusAnnotatedVariantInfo resp = GenomeNexusUtils.getAnnotatedVariantFromGenomeNexus(GNVariantAnnotationType.GENOMIC_LOCATION, query.getGenomicLocation(), query.getReferenceGenome());
+                result.add(resp);
+            }
+        }
+        return new ResponseEntity<>(result, status);
+    }
 
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApi.java
@@ -2,6 +2,8 @@ package org.mskcc.cbio.oncokb.api.pvt;
 
 import io.swagger.annotations.*;
 import org.mskcc.cbio.oncokb.apiModels.*;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByGenomicChangeQuery;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
 import org.mskcc.cbio.oncokb.apiModels.download.DownloadAvailability;
 import org.mskcc.cbio.oncokb.apiModels.ensembl.EnsemblGene;
 import org.mskcc.cbio.oncokb.model.*;
@@ -257,5 +259,30 @@ public interface PrivateUtilsApi {
     ResponseEntity<byte[]> utilDataSqlDumpGet(
         @ApiParam(value = "version", required = true) @RequestParam(value = "version") String version
     );
+
+    @ApiOperation(value = "", notes = "Filter HGVSg based on oncokb coverage", response = String.class, responseContainer = "List")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Error, error message will be given.", response = String.class)})
+    @RequestMapping(value = "/utils/filterHgvsgBasedOnCoverage",
+        consumes = {"application/json"},
+        produces = {"application/json"},
+        method = RequestMethod.POST)
+    ResponseEntity<List<String>> utilFilterHgvsgBasedOnCoveragePost(
+        @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByHGVSgQuery> body
+    ) throws ApiException, org.genome_nexus.ApiException;
+
+    @ApiOperation(value = "", notes = "Filter genomic change based on oncokb coverage", response = String.class, responseContainer = "List")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Error, error message will be given.", response = String.class)})
+    @RequestMapping(value = "/utils/filterGenomicChangeBasedOnCoverage",
+        consumes = {"application/json"},
+        produces = {"application/json"},
+        method = RequestMethod.POST)
+    ResponseEntity<List<String>> utilFilterGenomicChangeBasedOnCoveragePost(
+        @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByGenomicChangeQuery> body
+    ) throws ApiException, org.genome_nexus.ApiException;
+
 }
 

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
@@ -3,6 +3,8 @@ package org.mskcc.cbio.oncokb.api.pvt;
 import com.mysql.jdbc.StringUtils;
 import io.swagger.annotations.ApiParam;
 import org.mskcc.cbio.oncokb.apiModels.*;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByGenomicChangeQuery;
+import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
 import org.mskcc.cbio.oncokb.apiModels.download.DownloadAvailability;
 import org.mskcc.cbio.oncokb.apiModels.download.FileExtension;
 import org.mskcc.cbio.oncokb.apiModels.download.FileName;
@@ -561,4 +563,45 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
     ) {
         return getDataDownloadResponseEntity(version, getOncoKBSqlDumpFileName(version), FileExtension.GZ);
     }
+
+    @Override
+    public ResponseEntity<List<String>> utilFilterHgvsgBasedOnCoveragePost(
+        @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByHGVSgQuery> body
+    ) throws ApiException, org.genome_nexus.ApiException {
+        HttpStatus status = HttpStatus.OK;
+        List<String> result = new ArrayList<>();
+    
+        if (body == null) {
+            status = HttpStatus.BAD_REQUEST;
+        } else {
+            Set<org.oncokb.oncokb_transcript.client.Gene> genes = this.cacheFetcher.getAllTranscriptGenes();
+            for (AnnotateMutationByHGVSgQuery query : body) {
+                if(this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, query.getHgvsg(), query.getReferenceGenome(), genes)){
+                    result.add(query.getHgvsg());
+                }
+            }
+        }
+        return new ResponseEntity<>(result, status);
+    }
+
+    @Override
+    public ResponseEntity<List<String>> utilFilterGenomicChangeBasedOnCoveragePost(
+        @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByGenomicChangeQuery> body
+    ) throws ApiException, org.genome_nexus.ApiException {
+        HttpStatus status = HttpStatus.OK;
+        List<String> result = new ArrayList<>();
+    
+        if (body == null) {
+            status = HttpStatus.BAD_REQUEST;
+        } else {
+            Set<org.oncokb.oncokb_transcript.client.Gene> genes = this.cacheFetcher.getAllTranscriptGenes();
+            for (AnnotateMutationByGenomicChangeQuery query : body) {
+                if(this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, query.getGenomicLocation(), query.getReferenceGenome(), genes)){
+                    result.add(query.getGenomicLocation());
+                }
+            }
+        }
+        return new ResponseEntity<>(result, status);
+    }
+
 }


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb/issues/3303

We are using the core to generate a text file containing the annotation results return by Genome Nexus for our gc, hgvsg grch37, and hgvsg grch38 variants files.

### Improving current workflow:
- [x] We should return the GN annotation results through api endpoint and let our script aggregate the results into a file.