### PR TITLE
Allow fallback to non-cached version when redis cluster node is down

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheConfiguration.java
@@ -15,6 +15,7 @@ import org.redisson.config.SentinelServersConfig;
 import org.redisson.config.SingleServerConfig;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.cache.interceptor.CacheResolver;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.*;
@@ -110,12 +111,18 @@ public class CacheConfiguration {
     }
 
     @Bean
+    public CacheErrorHandler cacheErrorHandler() {
+        return new LoggingCacheErrorHandler();
+    }
+
+    @Bean
     public org.springframework.cache.CacheManager cacheManager(
         RedissonClient redissonClient,
-        CacheNameResolver cacheNameResolver
+        CacheNameResolver cacheNameResolver,
+        CacheErrorHandler cacheErrorHandler
     ) {
         Integer redisExpiration = Integer.parseInt(PropertiesUtils.getProperties("redis.expiration"));
-        CustomRedisCacheManager cm = new CustomRedisCacheManager(redissonClient, redisExpiration == null ? DEFAULT_TTL : redisExpiration, cacheNameResolver);
+        CustomRedisCacheManager cm = new CustomRedisCacheManager(redissonClient, redisExpiration == null ? DEFAULT_TTL : redisExpiration, cacheNameResolver, cacheErrorHandler);
         cm.clearAll();
         return cm;
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomBucketRedisCache.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomBucketRedisCache.java
@@ -1,9 +1,10 @@
 package org.mskcc.cbio.oncokb.cache;
 
 import org.redisson.api.RedissonClient;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 
 public class CustomBucketRedisCache extends CustomRedisCache {
-    public CustomBucketRedisCache(String name, RedissonClient client, long ttlMinutes) {
-        super(name, client, ttlMinutes);
+    public CustomBucketRedisCache(String name, RedissonClient client, long ttlMinutes, CacheErrorHandler cacheErrorHandler) {
+        super(name, client, ttlMinutes, cacheErrorHandler);
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomMapRedisCache.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomMapRedisCache.java
@@ -1,28 +1,42 @@
 package org.mskcc.cbio.oncokb.cache;
 
 import org.redisson.api.RedissonClient;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 
 public class CustomMapRedisCache extends CustomRedisCache {
-    public CustomMapRedisCache(String name, RedissonClient client, long ttlMinutes) {
-        super(name, client, ttlMinutes);
+    public CustomMapRedisCache(String name, RedissonClient client, long ttlMinutes, CacheErrorHandler cacheErrorHandler) {
+        super(name, client, ttlMinutes, cacheErrorHandler);
     }
 
     @Override
     protected Object lookup(Object key) {
-        Object value = this.store.getMap(name).get(key);
-        if (value != null) {
-            value = fromStoreValue(value);
+        try {
+            Object value = this.store.getMap(name).get(key);
+            if (value != null) {
+                value = fromStoreValue(value);
+            }
+            return value;        
+        } catch (RuntimeException e) {
+            cacheErrorHandler.handleCacheGetError(e, this, key);
+            return null;
         }
-        return value;
     }
 
     @Override
     public void put(Object key, Object value) {
-        this.store.getMap(name).putAsync(key, toStoreValue(value));
+        try {
+            this.store.getMap(name).putAsync(key, toStoreValue(value));
+        } catch (RuntimeException e) {
+            cacheErrorHandler.handleCachePutError(e, this, key, value);
+        }
     }
 
     @Override
     public void clear() {
-        this.store.getMap(name).clear();
+        try {
+            this.store.getMap(name).clear();
+        } catch (RuntimeException e) {
+            cacheErrorHandler.handleCacheClearError(e, this);
+        }
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CustomRedisCacheManager.java
@@ -3,6 +3,7 @@ package org.mskcc.cbio.oncokb.cache;
 import org.redisson.api.RedissonClient;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
@@ -13,11 +14,13 @@ public class CustomRedisCacheManager implements CacheManager {
     private final RedissonClient client;
     private final long ttlInMins;
     private CacheNameResolver cacheNameResolver;
+    private CacheErrorHandler cacheErrorHandler;
 
-    public CustomRedisCacheManager(RedissonClient client, long ttlInMins, CacheNameResolver cacheNameResolver) {
+    public CustomRedisCacheManager(RedissonClient client, long ttlInMins, CacheNameResolver cacheNameResolver, CacheErrorHandler cacheErrorHandler) {
         this.client = client;
         this.ttlInMins = ttlInMins;
         this.cacheNameResolver = cacheNameResolver;
+        this.cacheErrorHandler = cacheErrorHandler;
     }
 
     /**
@@ -48,7 +51,7 @@ public class CustomRedisCacheManager implements CacheManager {
         long clientTTLInMinutes = expires ? ttlInMins : CustomRedisCache.INFINITE_TTL;
         String cacheName = this.cacheNameResolver.getCacheName(name);
         return caches.computeIfAbsent(cacheName, k -> {
-            return new CustomBucketRedisCache(cacheName, client, clientTTLInMinutes);
+            return new CustomBucketRedisCache(cacheName, client, clientTTLInMinutes, cacheErrorHandler);
         });
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/LoggingCacheErrorHandler.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/LoggingCacheErrorHandler.java
@@ -1,5 +1,7 @@
 package org.mskcc.cbio.oncokb.cache;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cache.Cache;
 import org.springframework.cache.interceptor.CacheErrorHandler;
 
@@ -12,27 +14,29 @@ import org.springframework.cache.interceptor.CacheErrorHandler;
 
 public class LoggingCacheErrorHandler implements CacheErrorHandler {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingCacheErrorHandler.class);
+
     @Override
     public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
-        System.out.println(String.format("Cache '%s' failed to get entry with key '%s'", cache.getName(), key));
+        LOG.error(String.format("Cache '%s' failed to get entry with key '%s'", cache.getName(), key), exception);
         exception.printStackTrace();
     }
 
     @Override
     public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
-        System.out.println(String.format("Cache '%s' failed to put entry with key '%s'", cache.getName(), key));
+        LOG.error(String.format("Cache '%s' failed to put entry with key '%s'", cache.getName(), key), exception);
         exception.printStackTrace();
     }
 
     @Override
     public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
-        System.out.println(String.format("Cache '%s' failed to evict entry with key '%s'", cache.getName(), key));
+        LOG.error(String.format("Cache '%s' failed to evict entry with key '%s'", cache.getName(), key), exception);
         exception.printStackTrace();
     }
 
     @Override
     public void handleCacheClearError(RuntimeException exception, Cache cache) {
-        System.out.println(String.format("Cache '%s' failed to clear entries", cache.getName()));
+        LOG.error(String.format("Cache '%s' failed to clear entries", cache.getName()), exception);
         exception.printStackTrace();
     }
     

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/LoggingCacheErrorHandler.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/LoggingCacheErrorHandler.java
@@ -1,0 +1,39 @@
+package org.mskcc.cbio.oncokb.cache;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+
+/**
+ * Implementation of org.springframework.cache.interceptor.CacheErrorHandler 
+ * that logs the error messages when performing Redis operations.
+ * Redis will throw a RuntimeException causing our APIs to return HTTP 500 responses, so we defined
+ * this class to just log the errors and allow our app fallback to the non-cached version.
+ */
+
+public class LoggingCacheErrorHandler implements CacheErrorHandler {
+
+    @Override
+    public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        System.out.println(String.format("Cache '%s' failed to get entry with key '%s'", cache.getName(), key));
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+        System.out.println(String.format("Cache '%s' failed to put entry with key '%s'", cache.getName(), key));
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        System.out.println(String.format("Cache '%s' failed to evict entry with key '%s'", cache.getName(), key));
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        System.out.println(String.format("Cache '%s' failed to clear entries", cache.getName()));
+        exception.printStackTrace();
+    }
+    
+}

--- a/core/src/main/resources/properties-EXAMPLE/log4j.properties
+++ b/core/src/main/resources/properties-EXAMPLE/log4j.properties
@@ -1,3 +1,8 @@
+# The default location where log4j looks for the properties file is src/main/resources/log4j.properties
+# Since the our config is located in directory called properties, we need to add the following java parameter
+# -Dlog4j.configuration=file:core/src/main/resources/properties/log4j.properties
+# to setup the file logger.
+
 # Change INFO to DEBUG, if you want to see debugging info on underlying libraries we use.
 log4j.rootLogger=INFO, a
 


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3330

Changes:
- Add LoggingCacheErrorHandler to log the error messages when Redisson  GET, PUT, or CLEAR fails. This avoids our API returning 500 responses when  a redis cluster node may be down
- Allow redis lookup method to return `null` when Redis node is down (cache miss) to allow for fallback to non-cache-version

- [x] Do a test using beta