### PR TITLE
Support chr prefix in HGVSg format

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -30,7 +30,7 @@ public final class AlterationUtils {
 
     // We do not intend to do comprehensive checking, but only eliminate some basic errors.
     // GenomeNexus will evaluate it further
-    public static Pattern HGVSG_FORMAT = Pattern.compile("[\\dXY]+:g\\.\\d+.*", Pattern.CASE_INSENSITIVE);
+    public static Pattern HGVSG_FORMAT = Pattern.compile("(chr)?[\\dxy]+:g\\.\\d+.*", Pattern.CASE_INSENSITIVE);
 
 
     private AlterationUtils() {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/AlterationUtilsTest.java
@@ -391,6 +391,18 @@ public class AlterationUtilsTest extends TestCase
         hgvsg = "y:g.140453136A>T";
         assertTrue(AlterationUtils.isValidHgvsg(hgvsg));
 
+        // we should allow the chr prefix
+        hgvsg = "chr7:g.140453136A>T";
+        assertTrue(AlterationUtils.isValidHgvsg(hgvsg));
+        hgvsg = "CHR7:g.140453136A>T";
+        assertTrue(AlterationUtils.isValidHgvsg(hgvsg));
+        hgvsg = "Chr7:g.140453136A>T";
+        assertTrue(AlterationUtils.isValidHgvsg(hgvsg));
+        hgvsg = " chr7:g.140453136A>T";
+        assertTrue(AlterationUtils.isValidHgvsg(hgvsg));
+        hgvsg = "chr7:g.140453136A>T ";
+        assertTrue(AlterationUtils.isValidHgvsg(hgvsg));
+
         hgvsg = "";
         assertFalse(AlterationUtils.isValidHgvsg(hgvsg));
         hgvsg = " ";
@@ -410,5 +422,6 @@ public class AlterationUtilsTest extends TestCase
         assertFalse(AlterationUtils.isValidHgvsg(hgvsg));
         hgvsg = "a:g.140453136A>T";
         assertFalse(AlterationUtils.isValidHgvsg(hgvsg));
+
     }
 }


### PR DESCRIPTION
It seems like HGVSg with chr as prefix has been used in some of the MAF files. GN supports the format, and we actually normalize it too. No reason we should not support it.

This fixes https://github.com/oncokb/oncokb-pipeline/issues/91