### PR TITLE
Add endpoint to cache pre-annotated gn variants

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
@@ -22,7 +22,7 @@ public final class Constants {
     public static final String UPSTREAM_GENE = "upstream_gene_variant";
 
     public static final String PUBLIC_API_VERSION = "v1.4.0";
-    public static final String PRIVATE_API_VERSION = "v1.4.0";
+    public static final String PRIVATE_API_VERSION = "v1.4.1";
 
     // Defaults
     public static final String SWAGGER_DEFAULT_DESCRIPTION="OncoKB, a comprehensive and curated precision oncology knowledge base, offers oncologists detailed, evidence-based information about individual somatic mutations and structural alterations present in patient tumors with the goal of supporting optimal treatment decisions.";

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -253,8 +253,8 @@ public class CacheFetcher {
         Alteration alteration = new Alteration();
 
         // Build the Alteration object from the pre-annotated GN variant object.
-        if (StringUtils.isNotEmpty(gnAnnotatedVariantInfo.getHugoSymbol())) {
-            Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getHugoSymbol());
+        if (StringUtils.isNotEmpty(gnAnnotatedVariantInfo.getHugoSymbol()) && gnAnnotatedVariantInfo.getEntrezGeneId() != null) {
+            Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getEntrezGeneId(), gnAnnotatedVariantInfo.getHugoSymbol());
             if (gene == null) {
                 gene = new Gene();
                 gene.setHugoSymbol(gnAnnotatedVariantInfo.getHugoSymbol());
@@ -274,12 +274,12 @@ public class CacheFetcher {
         // Store pre-annotated alteration into Redis cache
         Cache cache = cacheManager.getCache(CacheCategory.GENERAL.getKey() + REDIS_KEY_SEPARATOR + "getAlterationFromGenomeNexus");
         if (StringUtils.isNotEmpty(hgvsg)) {
-            String cacheKey = org.springframework.util.StringUtils.arrayToDelimitedString(new Object[]{GNVariantAnnotationType.HGVS_G, referenceGenome, hgvsg}, REDIS_KEY_SEPARATOR);
+            String cacheKey = String.join(REDIS_KEY_SEPARATOR, new String[]{GNVariantAnnotationType.HGVS_G.name(), referenceGenome.name(), hgvsg});
             cache.putIfAbsent(cacheKey, alteration);
         }
 
         if (StringUtils.isNotEmpty(genomicLocation)) {
-            String cacheKey = org.springframework.util.StringUtils.arrayToDelimitedString(new Object[]{GNVariantAnnotationType.GENOMIC_LOCATION, referenceGenome, genomicLocation}, REDIS_KEY_SEPARATOR);
+            String cacheKey = String.join(REDIS_KEY_SEPARATOR, new String[]{GNVariantAnnotationType.GENOMIC_LOCATION.name(), referenceGenome.name(), genomicLocation});
             cache.putIfAbsent(cacheKey, alteration);
         }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -9,13 +9,15 @@ import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
 import org.mskcc.cbio.oncokb.bo.OncokbTranscriptService;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.*;
+import org.mskcc.cbio.oncokb.model.genomeNexusPreAnnotations.GenomeNexusAnnotatedVariantInfo;
 import org.mskcc.cbio.oncokb.util.*;
 import org.oncokb.oncokb_transcript.ApiException;
 import org.oncokb.oncokb_transcript.client.EnsemblGene;
 import org.oncokb.oncokb_transcript.client.TranscriptDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -24,11 +26,14 @@ import java.util.stream.Collectors;
 
 import static org.mskcc.cbio.oncokb.Constants.DEFAULT_REFERENCE_GENOME;
 import static org.mskcc.cbio.oncokb.util.MainUtils.rangesIntersect;
+import static org.mskcc.cbio.oncokb.cache.Constants.REDIS_KEY_SEPARATOR;
 
 @Component
 public class CacheFetcher {
     OncokbTranscriptService oncokbTranscriptService = new OncokbTranscriptService();
     NotationConverter notationConverter = new NotationConverter();
+
+    @Autowired CacheManager cacheManager;
 
     @Cacheable(cacheResolver = "generalCacheResolver", key = "'all'")
     public OncoKBInfo getOncoKBInfo() {
@@ -242,6 +247,42 @@ public class CacheFetcher {
         keyGenerator = "concatKeyGenerator")
     public Alteration getAlterationFromGenomeNexus(GNVariantAnnotationType gnVariantAnnotationType, ReferenceGenome referenceGenome, String genomicLocation) throws org.genome_nexus.ApiException {
         return AlterationUtils.getAlterationFromGenomeNexus(gnVariantAnnotationType, genomicLocation, referenceGenome);
+    }
+
+    public void cacheAlterationFromGenomeNexus(GenomeNexusAnnotatedVariantInfo gnAnnotatedVariantInfo) {
+        Alteration alteration = new Alteration();
+
+        // Build the Alteration object from the pre-annotated GN variant object.
+        if (StringUtils.isNotEmpty(gnAnnotatedVariantInfo.getHugoSymbol())) {
+            Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getHugoSymbol());
+            if (gene == null) {
+                gene = new Gene();
+                gene.setHugoSymbol(gnAnnotatedVariantInfo.getHugoSymbol());
+                gene.setEntrezGeneId(gnAnnotatedVariantInfo.getEntrezGeneId());
+            }
+            alteration.setGene(gene);
+        }
+        alteration.setAlteration(gnAnnotatedVariantInfo.getHgvspShort());
+        alteration.setProteinStart(gnAnnotatedVariantInfo.getProteinStart());
+        alteration.setProteinEnd(gnAnnotatedVariantInfo.getProteinEnd());
+        alteration.setConsequence(VariantConsequenceUtils.findVariantConsequenceByTerm(gnAnnotatedVariantInfo.getConsequenceTerms()));
+
+        String hgvsg = gnAnnotatedVariantInfo.getHgvsg();
+        String genomicLocation = gnAnnotatedVariantInfo.getGenomicLocation();
+        ReferenceGenome referenceGenome = gnAnnotatedVariantInfo.getReferenceGenome();
+
+        // Store pre-annotated alteration into Redis cache
+        Cache cache = cacheManager.getCache(CacheCategory.GENERAL.getKey() + REDIS_KEY_SEPARATOR + "getAlterationFromGenomeNexus");
+        if (StringUtils.isNotEmpty(hgvsg)) {
+            String cacheKey = org.springframework.util.StringUtils.arrayToDelimitedString(new Object[]{GNVariantAnnotationType.HGVS_G, referenceGenome, hgvsg}, REDIS_KEY_SEPARATOR);
+            cache.putIfAbsent(cacheKey, alteration);
+        }
+
+        if (StringUtils.isNotEmpty(genomicLocation)) {
+            String cacheKey = org.springframework.util.StringUtils.arrayToDelimitedString(new Object[]{GNVariantAnnotationType.GENOMIC_LOCATION, referenceGenome, genomicLocation}, REDIS_KEY_SEPARATOR);
+            cache.putIfAbsent(cacheKey, alteration);
+        }
+
     }
 
     @Cacheable(cacheResolver = "generalCacheResolver",

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -33,7 +33,8 @@ public class CacheFetcher {
     OncokbTranscriptService oncokbTranscriptService = new OncokbTranscriptService();
     NotationConverter notationConverter = new NotationConverter();
 
-    @Autowired CacheManager cacheManager;
+    @Autowired(required = false) 
+    CacheManager cacheManager;
 
     @Cacheable(cacheResolver = "generalCacheResolver", key = "'all'")
     public OncoKBInfo getOncoKBInfo() {
@@ -249,7 +250,11 @@ public class CacheFetcher {
         return AlterationUtils.getAlterationFromGenomeNexus(gnVariantAnnotationType, genomicLocation, referenceGenome);
     }
 
-    public void cacheAlterationFromGenomeNexus(GenomeNexusAnnotatedVariantInfo gnAnnotatedVariantInfo) {
+    public void cacheAlterationFromGenomeNexus(GenomeNexusAnnotatedVariantInfo gnAnnotatedVariantInfo) throws IllegalStateException {
+        if (cacheManager == null) {
+            throw new IllegalStateException("Cannot cache pre-annotated GN variants. Change property redis.enable to True.");
+        }
+
         Alteration alteration = new Alteration();
 
         // Build the Alteration object from the pre-annotated GN variant object.

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -159,11 +159,17 @@ public class GenomeNexusUtils {
             e.printStackTrace();
         }
         
+        // Get HGVSg and Genomic Location from Genome Nexus annotation
         if (annotation != null) {
-            preAnnotatedVariantInfo.setHgvsg(annotation.getHgvsg());
+            if (StringUtils.isNotEmpty(annotation.getHgvsg())) {
+                preAnnotatedVariantInfo.setHgvsg(annotation.getHgvsg());
+            }
 
-            if (type.equals(GNVariantAnnotationType.GENOMIC_LOCATION) && annotation.isSuccessfullyAnnotated()) {
-                preAnnotatedVariantInfo.setGenomicLocation(query);
+            if (annotation.getAnnotationSummary() != null && annotation.getAnnotationSummary().getGenomicLocation() != null) {
+                String genomicLocation = annotation.getAnnotationSummary().getGenomicLocation().toString();
+                if (StringUtils.isNotEmpty(genomicLocation)) {
+                    preAnnotatedVariantInfo.setGenomicLocation(genomicLocation);
+                }
             }
         }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -167,8 +167,8 @@ public class GenomeNexusUtils {
 
             if (annotation.getAnnotationSummary() != null && annotation.getAnnotationSummary().getGenomicLocation() != null) {
                 org.genome_nexus.client.GenomicLocation gl = annotation.getAnnotationSummary().getGenomicLocation();
-                String glString = gl.getChromosome() + "," + gl.getStart() + "," + gl.getEnd() + "," + gl.getReferenceAllele() + "," + gl.getVariantAllele();
-                if (StringUtils.isNotEmpty(glString)) {
+                if (gl.getChromosome() != null && gl.getStart() != null && gl.getEnd() != null && gl.getReferenceAllele() != null && gl.getVariantAllele() != null ) {
+                    String glString = gl.getChromosome() + "," + gl.getStart() + "," + gl.getEnd() + "," + gl.getReferenceAllele() + "," + gl.getVariantAllele();
                     preAnnotatedVariantInfo.setGenomicLocation(glString);
                 }
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -166,9 +166,10 @@ public class GenomeNexusUtils {
             }
 
             if (annotation.getAnnotationSummary() != null && annotation.getAnnotationSummary().getGenomicLocation() != null) {
-                String genomicLocation = annotation.getAnnotationSummary().getGenomicLocation().toString();
-                if (StringUtils.isNotEmpty(genomicLocation)) {
-                    preAnnotatedVariantInfo.setGenomicLocation(genomicLocation);
+                org.genome_nexus.client.GenomicLocation gl = annotation.getAnnotationSummary().getGenomicLocation();
+                String glString = gl.getChromosome() + "," + gl.getStart() + "," + gl.getEnd() + "," + gl.getReferenceAllele() + "," + gl.getVariantAllele();
+                if (StringUtils.isNotEmpty(glString)) {
+                    preAnnotatedVariantInfo.setGenomicLocation(glString);
                 }
             }
         }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -172,6 +172,16 @@ public class GenomeNexusUtils {
                     preAnnotatedVariantInfo.setGenomicLocation(glString);
                 }
             }
+
+            // Use the original query if HGVSg or Genomic Location is missing
+            if (annotation.isSuccessfullyAnnotated()) {
+                if (StringUtils.isEmpty(preAnnotatedVariantInfo.getHgvsg()) && type == GNVariantAnnotationType.HGVS_G) {
+                    preAnnotatedVariantInfo.setHgvsg(query);
+                }
+                if (StringUtils.isEmpty(preAnnotatedVariantInfo.getGenomicLocation()) && type == GNVariantAnnotationType.GENOMIC_LOCATION) {
+                    preAnnotatedVariantInfo.setGenomicLocation(query);
+                }
+            }
         }
 
         TranscriptConsequenceSummary transcriptConsequenceSummary = getConsequence(annotation, referenceGenome);

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateGenomeNexusController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateGenomeNexusController.java
@@ -119,7 +119,7 @@ public class PrivateGenomeNexusController {
         method = RequestMethod.POST)
     public ResponseEntity<Void> cacheGenomeNexusVariantInfoPost(
         @ApiParam(value = "List of queries. Please see swagger.json for request body format.", required = true) @RequestBody() List<GenomeNexusAnnotatedVariantInfo> body
-    ) throws ApiException, org.genome_nexus.ApiException {
+    ) throws ApiException, org.genome_nexus.ApiException, IllegalStateException {
         HttpStatus status = HttpStatus.OK;
 
         if (body == null) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateGenomeNexusController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateGenomeNexusController.java
@@ -12,6 +12,7 @@ import org.mskcc.cbio.oncokb.apiModels.TranscriptPair;
 import org.mskcc.cbio.oncokb.apiModels.TranscriptResult;
 import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByGenomicChangeQuery;
 import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
+import org.mskcc.cbio.oncokb.cache.CacheFetcher;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
 import org.mskcc.cbio.oncokb.model.ReferenceGenome;
 import org.mskcc.cbio.oncokb.model.genomeNexusPreAnnotations.GenomeNexusAnnotatedVariantInfo;
@@ -32,6 +33,8 @@ import java.util.List;
 @RestController
 @Api(tags = "Transcript", description = "The transcript API")
 public class PrivateGenomeNexusController {
+
+    @Autowired CacheFetcher cacheFetcher;
 
     @ApiOperation(value = "", notes = "Get transcript info in both GRCh37 and 38.", response = TranscriptResult.class)
     @ApiResponses(value = {
@@ -104,6 +107,29 @@ public class PrivateGenomeNexusController {
             }
         }
         return new ResponseEntity<>(result, status);
+    }
+
+    @ApiOperation(value = "", notes = "cache Genome Nexus variant info")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 400, message = "Error, error message will be given.", response = String.class)})
+    @RequestMapping(value = "/cacheGnVariantInfo",
+        consumes = {"application/json"},
+        produces = {"application/json"},
+        method = RequestMethod.POST)
+    public ResponseEntity<Void> cacheGenomeNexusVariantInfoPost(
+        @ApiParam(value = "List of queries. Please see swagger.json for request body format.", required = true) @RequestBody() List<GenomeNexusAnnotatedVariantInfo> body
+    ) throws ApiException, org.genome_nexus.ApiException {
+        HttpStatus status = HttpStatus.OK;
+
+        if (body == null) {
+            status = HttpStatus.BAD_REQUEST;
+        } else {
+            for (GenomeNexusAnnotatedVariantInfo query : body) {
+                cacheFetcher.cacheAlterationFromGenomeNexus(query);
+            }
+        }
+        return new ResponseEntity<>(status);
     }
 
 }


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3304
- Endpoint to import annotated variants into redis cache: https://github.com/oncokb/oncokb/pull/3380/commits/d1c5af84092938d5d4f4959d5a5ba8cae939c82e
- GN annotation API provides the `hgsvg` and `genomicLocation` in response, so made changes to use those: https://github.com/oncokb/oncokb/pull/3380/commits/544da19cc50c38bdcb4b5d952c651239ec54d954
  - We can't use [GenomicLocation.toString()](https://github.com/genome-nexus/genome-nexus/blob/master/model/src/main/java/org/cbioportal/genome_nexus/model/GenomicLocation.java#L63-L65) because the swagger code generator override the [toString()](https://github.com/genome-nexus/genome-nexus-java-api-client/blob/master/genomeNexusPublicApiClient/src/main/java/org/genome_nexus/client/GenomicLocation.java#L159-L171). The gl string was built manually from object.

<img src="https://user-images.githubusercontent.com/59149377/214949675-147d8409-01d6-4efa-9c06-cb86c30d3522.png" width="267.5" height="379" />
