### PR TITLE
Modify utils/filterHgvsgBasedOnCoverage endpoint to include filter status of all original queries

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/TranscriptCoverageFilterResult.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/TranscriptCoverageFilterResult.java
@@ -1,0 +1,27 @@
+package org.mskcc.cbio.oncokb.apiModels;
+
+public class TranscriptCoverageFilterResult {
+    String variant;
+    Boolean isCovered;
+
+    public TranscriptCoverageFilterResult(String variant, Boolean isCovered) {
+        this.variant = variant;
+        this.isCovered = isCovered;
+    }
+
+    public String getVariant() {
+        return this.variant;
+    }
+
+    public void setVariant(String variant) {
+        this.variant = variant;
+    }
+
+    public Boolean getIsCovered() {
+        return this.isCovered;
+    }
+
+    public void setIsCovered(Boolean isCovered) {
+        this.isCovered = isCovered;
+    }
+}

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApi.java
@@ -268,7 +268,7 @@ public interface PrivateUtilsApi {
         consumes = {"application/json"},
         produces = {"application/json"},
         method = RequestMethod.POST)
-    ResponseEntity<List<String>> utilFilterHgvsgBasedOnCoveragePost(
+    ResponseEntity<List<TranscriptCoverageFilterResult>> utilFilterHgvsgBasedOnCoveragePost(
         @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByHGVSgQuery> body
     ) throws ApiException, org.genome_nexus.ApiException;
 
@@ -280,7 +280,7 @@ public interface PrivateUtilsApi {
         consumes = {"application/json"},
         produces = {"application/json"},
         method = RequestMethod.POST)
-    ResponseEntity<List<String>> utilFilterGenomicChangeBasedOnCoveragePost(
+    ResponseEntity<List<TranscriptCoverageFilterResult>> utilFilterGenomicChangeBasedOnCoveragePost(
         @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByGenomicChangeQuery> body
     ) throws ApiException, org.genome_nexus.ApiException;
 

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
@@ -571,40 +571,38 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
     }
 
     @Override
-    public ResponseEntity<List<String>> utilFilterHgvsgBasedOnCoveragePost(
+    public ResponseEntity<List<TranscriptCoverageFilterResult>> utilFilterHgvsgBasedOnCoveragePost(
         @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByHGVSgQuery> body
     ) throws ApiException, org.genome_nexus.ApiException {
         HttpStatus status = HttpStatus.OK;
-        List<String> result = new ArrayList<>();
+        List<TranscriptCoverageFilterResult> result = new ArrayList<>();
 
         if (body == null) {
             status = HttpStatus.BAD_REQUEST;
         } else {
             Set<org.oncokb.oncokb_transcript.client.Gene> genes = this.cacheFetcher.getAllTranscriptGenes();
             for (AnnotateMutationByHGVSgQuery query : body) {
-                if(this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, query.getHgvsg(), query.getReferenceGenome(), genes)){
-                    result.add(query.getHgvsg());
-                }
+                boolean shouldAnnotate = this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, query.getHgvsg(), query.getReferenceGenome(), genes);
+                result.add(new TranscriptCoverageFilterResult(query.getHgvsg(), shouldAnnotate));
             }
         }
         return new ResponseEntity<>(result, status);
     }
 
     @Override
-    public ResponseEntity<List<String>> utilFilterGenomicChangeBasedOnCoveragePost(
+    public ResponseEntity<List<TranscriptCoverageFilterResult>> utilFilterGenomicChangeBasedOnCoveragePost(
         @ApiParam(value = "List of queries.", required = true) @RequestBody List<AnnotateMutationByGenomicChangeQuery> body
     ) throws ApiException, org.genome_nexus.ApiException {
         HttpStatus status = HttpStatus.OK;
-        List<String> result = new ArrayList<>();
+        List<TranscriptCoverageFilterResult> result = new ArrayList<>();
 
         if (body == null) {
             status = HttpStatus.BAD_REQUEST;
         } else {
             Set<org.oncokb.oncokb_transcript.client.Gene> genes = this.cacheFetcher.getAllTranscriptGenes();
             for (AnnotateMutationByGenomicChangeQuery query : body) {
-                if(this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, query.getGenomicLocation(), query.getReferenceGenome(), genes)){
-                    result.add(query.getGenomicLocation());
-                }
+                boolean shouldAnnotate = this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, query.getGenomicLocation(), query.getReferenceGenome(), genes);
+                result.add(new TranscriptCoverageFilterResult(query.getGenomicLocation(), shouldAnnotate));
             }
         }
         return new ResponseEntity<>(result, status);


### PR DESCRIPTION
Instead of returning a list of strings of the filtered hgvsg/gl, we return an object that contains the hgvsg/gl and a boolean indicating whether or not it is filtered out.

This makes it easier in the gn pipeline script (https://github.com/oncokb/oncokb-pipeline/issues/107)