### PR TITLE
Improve performance of annotate by hgvsg and gc endpoints

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -333,14 +333,14 @@ public class CacheFetcher {
         }
         GenomicLocation finalGl = gl;
         int bpBuffer = 10000; // add some buffer on determine which genomic change should be annotated. We use the gene range from oncokb-transcript but that does not include gene regulatory sequence. Before having proper range, we use a buffer range instead.
-        List<org.oncokb.oncokb_transcript.client.Gene> filtered = allTranscriptsGenes.stream().filter(gene -> {
+        Boolean shouldBeAnnotated = allTranscriptsGenes.stream().anyMatch(gene -> {
             Set<EnsemblGene> ensemblGenes = gene.getEnsemblGenes().stream().filter(ensemblGene -> ensemblGene.getCanonical() && ensemblGene.getReferenceGenome().equals(referenceGenome.name())).collect(Collectors.toSet());
             if (ensemblGenes.size() > 0) {
-                return ensemblGenes.stream().filter(ensemblGene -> finalGl.getChromosome().equals(ensemblGene.getChromosome()) && rangesIntersect(ensemblGene.getStart() > bpBuffer ? (ensemblGene.getStart() - bpBuffer) : 0, ensemblGene.getEnd() + bpBuffer, finalGl.getStart(), finalGl.getEnd())).count() > 0;
+                return ensemblGenes.stream().anyMatch(ensemblGene -> finalGl.getChromosome().equals(ensemblGene.getChromosome()) && rangesIntersect(ensemblGene.getStart() > bpBuffer ? (ensemblGene.getStart() - bpBuffer) : 0, ensemblGene.getEnd() + bpBuffer, finalGl.getStart(), finalGl.getEnd()));
             } else {
                 return false;
             }
-        }).collect(Collectors.toList());
-        return filtered.size() > 0;
+        });
+        return shouldBeAnnotated;
     }
 }


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3431

## Changes
- The main bottleneck was calling `cacheFetcher.getAllTranscriptGenes()` for each query inside the post body. For post requests, this call is moved outside the for loop, so it is only called once per request.
- A smaller improvement was using java stream's `anyMatch()` instead of `filter().count() > 0`, to when determining if the gc/hgvsg should be annotated by GN. `anyMatch()` will return when the first element is True, whereas filter will continue.

## Performance comparison
- 1 oncokb-core pod
- 1 thread, iterating 5 times and taking average
- POST request with 500 HGVSg, [test-post-body.zip](https://github.com/oncokb/oncokb/files/11151835/test-post-body.zip)


Original implementation: 5.4s
Moving `cacheFetcher.getAllTranscriptGenes()` outside for loop:  1.7s
Using `anyMatch()`: 1.2s