### PR TITLE
Fix gn cache endpoint returning null gene object

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -255,18 +255,20 @@ public class CacheFetcher {
             throw new IllegalStateException("Cannot cache pre-annotated GN variants. Change property redis.enable to True.");
         }
 
+        // Build the Alteration object from the pre-annotated GN variant object.
         Alteration alteration = new Alteration();
 
-        // Build the Alteration object from the pre-annotated GN variant object.
-        if (StringUtils.isNotEmpty(gnAnnotatedVariantInfo.getHugoSymbol()) && gnAnnotatedVariantInfo.getEntrezGeneId() != null) {
-            Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getEntrezGeneId(), gnAnnotatedVariantInfo.getHugoSymbol());
-            if (gene == null) {
-                gene = new Gene();
-                gene.setHugoSymbol(gnAnnotatedVariantInfo.getHugoSymbol());
-                gene.setEntrezGeneId(gnAnnotatedVariantInfo.getEntrezGeneId());
-            }
-            alteration.setGene(gene);
+        // Sometimes the VEP does not return the entrezGeneId and only returns the hugoSymbol.
+        Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getEntrezGeneId(), gnAnnotatedVariantInfo.getHugoSymbol());
+
+        // If gene cannot be found in our database, then we create a new Gene object.
+        if (gene == null) {
+            gene = new Gene();
+            gene.setHugoSymbol(gnAnnotatedVariantInfo.getHugoSymbol());
+            gene.setEntrezGeneId(gnAnnotatedVariantInfo.getEntrezGeneId());
         }
+        alteration.setGene(gene);
+
         alteration.setAlteration(gnAnnotatedVariantInfo.getHgvspShort());
         alteration.setProteinStart(gnAnnotatedVariantInfo.getProteinStart());
         alteration.setProteinEnd(gnAnnotatedVariantInfo.getProteinEnd());

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -259,15 +259,15 @@ public class CacheFetcher {
         Alteration alteration = new Alteration();
 
         // Sometimes the VEP does not return the entrezGeneId and only returns the hugoSymbol.
-        Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getEntrezGeneId(), gnAnnotatedVariantInfo.getHugoSymbol());
-
-        // If gene cannot be found in our database, then we create a new Gene object.
-        if (gene == null) {
-            gene = new Gene();
-            gene.setHugoSymbol(gnAnnotatedVariantInfo.getHugoSymbol());
-            gene.setEntrezGeneId(gnAnnotatedVariantInfo.getEntrezGeneId());
+        if (StringUtils.isNotEmpty(gnAnnotatedVariantInfo.getHugoSymbol()) || gnAnnotatedVariantInfo.getEntrezGeneId() != null) {
+            Gene gene = GeneUtils.getGene(gnAnnotatedVariantInfo.getEntrezGeneId(), gnAnnotatedVariantInfo.getHugoSymbol());
+            if (gene == null) {
+                gene = new Gene();
+                gene.setHugoSymbol(gnAnnotatedVariantInfo.getHugoSymbol());
+                gene.setEntrezGeneId(gnAnnotatedVariantInfo.getEntrezGeneId());
+            }
+            alteration.setGene(gene);
         }
-        alteration.setGene(gene);
 
         alteration.setAlteration(gnAnnotatedVariantInfo.getHgvspShort());
         alteration.setProteinStart(gnAnnotatedVariantInfo.getProteinStart());


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb-pipeline/issues/141

> Look into why some annotations got changed to -2 or Other Biomarkers

We should change the `and` condition to `or`. If neither entrezGeneId nor hugoSymbol are returned, then we can return a null Gene object. If either of them are available, we should always create a Gene object.