### PR TITLE
Support searching by cancer type

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/CancerTypeMatch.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/CancerTypeMatch.java
@@ -1,0 +1,62 @@
+package org.mskcc.cbio.oncokb.apiModels;
+
+import kotlin.Pair;
+import org.mskcc.cbio.oncokb.model.Alteration;
+import org.mskcc.cbio.oncokb.model.Gene;
+import org.mskcc.cbio.oncokb.model.LevelOfEvidence;
+import org.mskcc.cbio.oncokb.model.TumorType;
+import java.util.*;
+
+import java.util.Objects;
+
+
+public class CancerTypeMatch extends LevelsOfEvidenceMatch {
+    private TumorType cancerType;
+    private Map<LevelOfEvidence, Set<Alteration>> alterationsByLevel = new TreeMap<>();
+
+    public TumorType getCancerType() {
+        return cancerType;
+    }
+
+    public void setCancerType(TumorType cancerType) {
+        this.cancerType = cancerType;
+    }
+
+    public Map<LevelOfEvidence, Set<Alteration>> getAlterationsByLevel() {
+        return alterationsByLevel;
+    }
+
+    public void setAlterationsByLevel(Map<LevelOfEvidence, Set<Alteration>> alterationsByLevel) {
+        this.alterationsByLevel = alterationsByLevel;
+    }
+
+    public LevelOfEvidence findHighestLevel(List<LevelOfEvidence> txLevels) {
+        if (alterationsByLevel != null) {
+            LevelOfEvidence highestLevel = null;
+            for (int i = txLevels.size() - 1; i >= 0; --i){
+                if (alterationsByLevel.containsKey(txLevels.get(i))){
+                    highestLevel = txLevels.get(i);
+                }
+            }
+            return highestLevel;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CancerTypeMatch)) return false;
+        CancerTypeMatch cancerTypeMatch = (CancerTypeMatch) o;
+        return getWeight() == cancerTypeMatch.getWeight() &&
+            Objects.equals(getGene(), cancerTypeMatch.getGene()) &&
+            Objects.equals(getAlterations(), cancerTypeMatch.getAlterations()) &&
+            getLevelOfEvidence() == cancerTypeMatch.getLevelOfEvidence() &&
+            Objects.equals(getCancerType(), cancerTypeMatch.getCancerType());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getGene(), getAlterations(), getLevelOfEvidence(), getCancerType(), getWeight());
+    }
+}

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/DrugMatch.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/DrugMatch.java
@@ -13,37 +13,10 @@ import java.util.Set;
 /**
  * Created by Hongxin Zhang on 2019-04-23.
  */
-public class DrugMatch {
-     private Gene gene;
-     private Set<Alteration> alterations = new HashSet<>();
-     private LevelOfEvidence levelOfEvidence;
+public class DrugMatch extends LevelsOfEvidenceMatch{
+
      private Drug drug;
      private Set<TumorType> tumorTypes = new HashSet<>();
-     private Double weight = 0.0;
-
-    public Gene getGene() {
-        return gene;
-    }
-
-    public void setGene(Gene gene) {
-        this.gene = gene;
-    }
-
-    public Set<Alteration> getAlterations() {
-        return alterations;
-    }
-
-    public void setAlterations(Set<Alteration> alterations) {
-        this.alterations = alterations;
-    }
-
-    public LevelOfEvidence getLevelOfEvidence() {
-        return levelOfEvidence;
-    }
-
-    public void setLevelOfEvidence(LevelOfEvidence levelOfEvidence) {
-        this.levelOfEvidence = levelOfEvidence;
-    }
 
     public Drug getDrug() {
         return drug;
@@ -59,14 +32,6 @@ public class DrugMatch {
 
     public void setTumorTypes(Set<TumorType> tumorTypes) {
         this.tumorTypes = tumorTypes;
-    }
-
-    public Double getWeight() {
-        return weight;
-    }
-
-    public void setWeight(Double weight) {
-        this.weight = weight;
     }
 
     @Override

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/LevelsOfEvidenceMatch.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/LevelsOfEvidenceMatch.java
@@ -1,0 +1,48 @@
+package org.mskcc.cbio.oncokb.apiModels;
+
+import org.mskcc.cbio.oncokb.model.Alteration;
+import org.mskcc.cbio.oncokb.model.Gene;
+import org.mskcc.cbio.oncokb.model.LevelOfEvidence;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class LevelsOfEvidenceMatch {
+    private Gene gene;
+    private Set<Alteration> alterations = new HashSet<>();
+    private LevelOfEvidence levelOfEvidence;
+    private Double weight = 0.0;
+
+    public Gene getGene() {
+        return gene;
+    }
+
+    public void setGene(Gene gene) {
+        this.gene = gene;
+    }
+
+    public Set<Alteration> getAlterations() {
+        return alterations;
+    }
+
+    public void setAlterations(Set<Alteration> alterations) {
+        this.alterations = alterations;
+    }
+
+    public LevelOfEvidence getLevelOfEvidence() {
+        return levelOfEvidence;
+    }
+
+    public void setLevelOfEvidence(LevelOfEvidence levelOfEvidence) {
+        this.levelOfEvidence = levelOfEvidence;
+    }
+
+    public Double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Double weight) {
+        this.weight = weight;
+    }
+}
+

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/LevelOfEvidence.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/LevelOfEvidence.java
@@ -2,9 +2,12 @@
 
 package org.mskcc.cbio.oncokb.model;
 
+import org.mskcc.cbio.oncokb.apiModels.LevelsOfEvidenceMatch;
+
 import java.awt.*;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.List;
+import static org.mskcc.cbio.oncokb.util.LevelUtils.*;
 
 /**
  *

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/TypeaheadQueryType.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/TypeaheadQueryType.java
@@ -4,5 +4,5 @@ package org.mskcc.cbio.oncokb.model;
  * Created by Hongxin Zhang on 8/20/20.
  */
 public enum TypeaheadQueryType {
-    GENE, VARIANT, DRUG, TEXT, GENOMIC
+    GENE, VARIANT, DRUG, TEXT, GENOMIC, CANCER_TYPE
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/TypeaheadSearchResp.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/TypeaheadSearchResp.java
@@ -1,5 +1,6 @@
 package org.mskcc.cbio.oncokb.model;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,6 +20,7 @@ public class TypeaheadSearchResp {
     private String annotation;
     private TypeaheadQueryType queryType;
     private String link;
+    private Map<LevelOfEvidence, Set<Alteration>> alterationsByLevel;
 
     public Gene getGene() {
         return gene;
@@ -114,6 +116,14 @@ public class TypeaheadSearchResp {
 
     public void setVUS(Boolean VUS) {
         isVUS = VUS;
+    }
+
+    public Map<LevelOfEvidence, Set<Alteration>> getAlterationsByLevel() {
+        return alterationsByLevel;
+    }
+
+    public void setAlterationsByLevel(Map<LevelOfEvidence, Set<Alteration>> alterationsByLevel) {
+        this.alterationsByLevel = alterationsByLevel;
     }
 
     @Override

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -97,7 +97,8 @@ public class EvidenceUtils {
 
     public static Set<Evidence> getEvidenceByEvidenceTypesAndLevels(Set<EvidenceType> types, Set<LevelOfEvidence> levels) {
         List<Evidence> evidences = new ArrayList<>();
-        for (Evidence evidence : CacheUtils.getAllEvidences()) {
+        Set<Evidence> cachedEvidences = CacheUtils.getAllEvidences();
+        for (Evidence evidence : cachedEvidences) {
             if (types != null && types.size() > 0 && !types.contains(evidence.getEvidenceType())) {
                 continue;
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/LevelUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/LevelUtils.java
@@ -26,12 +26,12 @@ public class LevelUtils {
 
     // Levels related to therapy
 
-    private static final List<LevelOfEvidence> THERAPEUTIC_SENSITIVE_LEVELS = Collections.unmodifiableList(
+    public static final List<LevelOfEvidence> THERAPEUTIC_SENSITIVE_LEVELS = Collections.unmodifiableList(
         Arrays.asList(LevelOfEvidence.LEVEL_4, LevelOfEvidence.LEVEL_3B, LevelOfEvidence.LEVEL_3A,
             LevelOfEvidence.LEVEL_2, LevelOfEvidence.LEVEL_1)
     );
 
-    private static final List<LevelOfEvidence> THERAPEUTIC_RESISTANCE_LEVELS = Collections.unmodifiableList(
+    public static final List<LevelOfEvidence> THERAPEUTIC_RESISTANCE_LEVELS = Collections.unmodifiableList(
         Arrays.asList(LevelOfEvidence.LEVEL_R2, LevelOfEvidence.LEVEL_R1)
     );
 
@@ -51,17 +51,17 @@ public class LevelUtils {
     );
 
     // Levels related to prognostic implications
-    private static final List<LevelOfEvidence> PROGNOSTIC_LEVELS = Collections.unmodifiableList(
+    public static final List<LevelOfEvidence> PROGNOSTIC_LEVELS = Collections.unmodifiableList(
         Arrays.asList(LevelOfEvidence.LEVEL_Px3, LevelOfEvidence.LEVEL_Px2, LevelOfEvidence.LEVEL_Px1)
     );
 
     // Levels related to diagnostic implications
-    private static final List<LevelOfEvidence> DIAGNOSTIC_LEVELS = Collections.unmodifiableList(
+    public static final List<LevelOfEvidence> DIAGNOSTIC_LEVELS = Collections.unmodifiableList(
         Arrays.asList(LevelOfEvidence.LEVEL_Dx3, LevelOfEvidence.LEVEL_Dx2, LevelOfEvidence.LEVEL_Dx1)
     );
 
     // FDA Levels of Evidence
-    private static final List<LevelOfEvidence> FDA_LEVELS = Collections.unmodifiableList(
+    public static final List<LevelOfEvidence> FDA_LEVELS = Collections.unmodifiableList(
         Arrays.asList(LevelOfEvidence.LEVEL_Fda3, LevelOfEvidence.LEVEL_Fda2, LevelOfEvidence.LEVEL_Fda1)
     );
 

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateSearchApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateSearchApiController.java
@@ -4,7 +4,9 @@ import io.swagger.annotations.ApiParam;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang3.StringUtils;
+import org.mskcc.cbio.oncokb.apiModels.CancerTypeMatch;
 import org.mskcc.cbio.oncokb.apiModels.DrugMatch;
+import org.mskcc.cbio.oncokb.apiModels.LevelsOfEvidenceMatch;
 import org.mskcc.cbio.oncokb.bo.OncokbTranscriptService;
 import org.mskcc.cbio.oncokb.cache.CacheFetcher;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 import static org.mskcc.cbio.oncokb.Constants.DEFAULT_REFERENCE_GENOME;
 import static org.mskcc.cbio.oncokb.util.AlterationUtils.GENOMIC_CHANGE_FORMAT;
 import static org.mskcc.cbio.oncokb.util.AlterationUtils.HGVSG_FORMAT;
+import static org.mskcc.cbio.oncokb.util.LevelUtils.*;
 
 /**
  * Created by Hongxin on 10/28/16.
@@ -95,7 +98,7 @@ public class PrivateSearchApiController implements PrivateSearchApi {
 
     @Override
     public ResponseEntity<LinkedHashSet<TypeaheadSearchResp>> searchTypeAheadGet(
-        @ApiParam(value = "The search query, it could be hugoSymbol, entrezGeneId or variant. At least two characters. Maximum two keywords are supported, separated by space", required = true) @RequestParam(value = "query") String query,
+        @ApiParam(value = "The search query, it could be hugoSymbol, entrezGeneId, variant, or cancer type. At least two characters. Maximum two keywords are supported, separated by space", required = true) @RequestParam(value = "query") String query,
         @ApiParam(value = "The limit of returned result.") @RequestParam(value = "limit", defaultValue = "5", required = false) Integer limit) {
         final int QUERY_MIN_LENGTH = 2;
         LinkedHashSet<TypeaheadSearchResp> result = new LinkedHashSet<>();
@@ -152,6 +155,9 @@ public class PrivateSearchApiController implements PrivateSearchApi {
                     // Blur search drug
                     result.addAll(findEvidencesWithDrugAssociated(keywords.get(0), false));
 
+                    // Blur search cancer type
+                    result.addAll(findMatchingCancerTypes(keywords.get(0), false));
+
                     // If the keyword contains dash and result is empty, then we should return both fusion genes
                     if (keywords.get(0).contains("-") && result.isEmpty()) {
                         for (String subKeyword : keywords.get(0).split("-")) {
@@ -178,6 +184,9 @@ public class PrivateSearchApiController implements PrivateSearchApi {
                     // If there is no match, the key words could referring to a variant, try to do a blur variant search
                     String fullKeywords = StringUtils.join(keywords, " ");
                     result.addAll(convertVariant(AlterationUtils.lookupVariant(fullKeywords, false, AlterationUtils.getAllAlterations()), fullKeywords));
+
+                    // Blur search for cancer type
+                    result.addAll(findMatchingCancerTypes(fullKeywords, false));
 
                     // If there is no match in OncoKB database, still try to annotate variant
                     // Only when the oncogenicity is not empty
@@ -227,6 +236,122 @@ public class PrivateSearchApiController implements PrivateSearchApi {
         }
         OncokbTranscriptService oncokbTranscriptService = new OncokbTranscriptService();
         return new ResponseEntity<>(getLimit(new LinkedHashSet<>(oncokbTranscriptService.findDrugs(query)), limit), HttpStatus.OK);
+    }
+
+     private List<TypeaheadSearchResp> findMatchingCancerTypes(String query, Boolean exactMatch) {
+         // got all evidences and level
+         Set<Evidence> evidences = EvidenceUtils.getEvidenceByEvidenceTypesAndLevels(EvidenceTypeUtils.getTreatmentEvidenceTypes(), LevelUtils.getPublicLevels());
+         Map<String, CancerTypeMatch> result = new HashMap<>();
+
+         query = query.toLowerCase();
+
+         ArrayList<TumorType> matchedTumorTypes = new ArrayList<>();
+
+         if (exactMatch){
+             matchedTumorTypes.add(ApplicationContextSingleton.getTumorTypeBo().getByName(query));
+         } else {
+             for (Map.Entry<String, TumorType> currSubtype : CacheUtils.getLowercaseSubtypeTumorTypeMap().entrySet()) {
+                 if(currSubtype.getKey().startsWith(query) || currSubtype.getKey().contains(query)){
+                     matchedTumorTypes.add(currSubtype.getValue());
+                 }
+             }
+
+             for (Map.Entry<String, TumorType> currMainType : CacheUtils.getMainTypeTumorTypeMap().entrySet()) {
+                 if(currMainType.getKey().toLowerCase().startsWith(query) || currMainType.getKey().toLowerCase().contains(query)){
+                     matchedTumorTypes.add(currMainType.getValue());
+                 }
+             }
+         }
+
+        // cancer type not found, return an empty list
+         if (matchedTumorTypes.isEmpty()){
+             return Collections.emptyList();
+         }
+
+         // definitely a matching cancer type, now searching evidence for relevant ones
+         for (TumorType currMatchedCancer : matchedTumorTypes){
+             String matchKey = TumorTypeUtils.getTumorTypeName(currMatchedCancer).toLowerCase();
+
+             for (Evidence evidence : evidences) {
+                 // exact match found
+                 if (TumorTypeUtils.findEvidenceRelevantCancerTypes(evidence).contains(currMatchedCancer)){
+                     if (matchKey.startsWith(query)){
+                         updateCancerMap(result, matchKey, evidence.getAlterations(), currMatchedCancer, evidence.getLevelOfEvidence(), 4.0);
+                     } else {
+                         updateCancerMap(result, matchKey, evidence.getAlterations(), currMatchedCancer, evidence.getLevelOfEvidence(), 3.5);
+                     }
+                 }
+             }
+             if(matchKey.startsWith(query)){
+                 updateCancerMap(result, matchKey, null, currMatchedCancer, null, 2.0);
+             } else {
+                 updateCancerMap(result, matchKey, null, currMatchedCancer, null, 1.0);
+             }
+
+         }
+
+         TreeSet<CancerTypeMatch> cancerMatches = new TreeSet<>(new CancerTypeMatchComp());
+         for(Map.Entry<String, CancerTypeMatch> entry : result.entrySet()) {
+             cancerMatches.add(entry.getValue());
+         }
+
+         // conversion to desired list output
+         return cancerMatches.stream().map(cancerMatch -> newTypeaheadCancer(cancerMatch)).collect(Collectors.toList());
+     }
+
+    private static TypeaheadSearchResp newTypeaheadCancer(CancerTypeMatch cancerMatch) {
+        TypeaheadSearchResp typeaheadSearchResp = new TypeaheadSearchResp();
+        typeaheadSearchResp.setAlterationsByLevel(cancerMatch.getAlterationsByLevel());
+
+        Set<TumorType> curr_tumor = new HashSet<>(Collections.singleton(cancerMatch.getCancerType()));
+        typeaheadSearchResp.setTumorTypes(curr_tumor);
+
+        List<LevelOfEvidence> txLevels = new ArrayList<>();
+        txLevels.addAll(THERAPEUTIC_RESISTANCE_LEVELS);
+        txLevels.addAll(THERAPEUTIC_SENSITIVE_LEVELS);
+
+        if (cancerMatch.getAlterationsByLevel() != null && cancerMatch.findHighestLevel(txLevels) != null){
+            LevelOfEvidence highestLevel = cancerMatch.findHighestLevel(txLevels);
+
+            if (LevelUtils.isSensitiveLevel(highestLevel)){
+                typeaheadSearchResp.setHighestSensitiveLevel(highestLevel.getLevel());
+            } else {
+                typeaheadSearchResp.setHighestResistanceLevel(highestLevel.getLevel());
+            }
+
+            typeaheadSearchResp.setLink("actionableGenes#sections=Tx&tumorType=" + cancerMatch.getCancerType().getCode());
+        } else {
+            typeaheadSearchResp.setLink("");
+        }
+
+        typeaheadSearchResp.setQueryType(TypeaheadQueryType.CANCER_TYPE);
+
+        return typeaheadSearchResp;
+    }
+
+    private static void updateCancerMap(Map<String, CancerTypeMatch> map, String key, Set<Alteration> alterations, TumorType cancer, LevelOfEvidence level, Double weight ) {
+        // gene, alterations, level of evidence can be null
+        if(!map.containsKey(key)) {
+            CancerTypeMatch cancerMatch = new CancerTypeMatch();
+            cancerMatch.setCancerType(cancer);
+            cancerMatch.setWeight(weight);
+
+            List<LevelOfEvidence> txLevels = new ArrayList<>();
+            txLevels.addAll(THERAPEUTIC_RESISTANCE_LEVELS);
+            txLevels.addAll(THERAPEUTIC_SENSITIVE_LEVELS);
+            cancerMatch.setAlterationsByLevel(new TreeMap<>(new LevelOfEvidenceComp(txLevels)));
+
+            map.put(key, cancerMatch);
+        }
+        if (alterations != null){
+            Set<Alteration> alterationsForLevel = map.get(key).getAlterationsByLevel().get(level);
+            if (alterationsForLevel == null) {
+                alterationsForLevel = new HashSet<>();
+                map.get(key).getAlterationsByLevel().put(level, alterationsForLevel);
+            }
+
+            alterationsForLevel.addAll(alterations);
+        }
     }
 
     private LinkedHashSet<TypeaheadSearchResp> getMatch(Map<String, Set<Gene>> map, List<String> keywords, Boolean exactMatch) {
@@ -411,10 +536,11 @@ public class PrivateSearchApiController implements PrivateSearchApi {
             }
         }
 
-        TreeSet<DrugMatch> drugMatches = new TreeSet<>(new DrugMatchComp());
+        TreeSet<DrugMatch> drugMatches = new TreeSet<>(new LevelsOfEvidenceMatchComp());
         for (Map.Entry<String, DrugMatch> entry : result.entrySet()) {
             drugMatches.add(entry.getValue());
         }
+
         return drugMatches.stream().map(drugMatch -> newTypeaheadDrug(drugMatch)).collect(Collectors.toList());
     }
 
@@ -559,7 +685,7 @@ class VariantComp implements Comparator<TypeaheadSearchResp> {
                 // Compare highest sensitive level
                 result = LevelUtils.compareLevel(LevelOfEvidence.getByLevel(e1.getHighestSensitiveLevel()), LevelOfEvidence.getByLevel(e2.getHighestSensitiveLevel()));
                 if (result == 0) {
-                    // Compare highest resistance level
+                    // Compare which is the highest resistance level
                     result = LevelUtils.compareLevel(LevelOfEvidence.getByLevel(e1.getHighestResistanceLevel()), LevelOfEvidence.getByLevel(e2.getHighestResistanceLevel()));
                     if (result == 0) {
                         result = name1.compareTo(name2);
@@ -581,16 +707,53 @@ class VariantComp implements Comparator<TypeaheadSearchResp> {
     }
 }
 
-class DrugMatchComp implements Comparator<DrugMatch> {
+class LevelsOfEvidenceMatchComp implements Comparator<LevelsOfEvidenceMatch> {
     @Override
-    public int compare(DrugMatch d1, DrugMatch d2) {
-        int result = d2.getWeight().compareTo(d1.getWeight());
+    public int compare(LevelsOfEvidenceMatch o1, LevelsOfEvidenceMatch o2) {
+        int result = o2.getWeight().compareTo(o1.getWeight());
         if (result == 0) {
-            result = LevelUtils.compareLevel(d1.getLevelOfEvidence(), d2.getLevelOfEvidence());
-            if (result == 0) {
-                result = d1.getGene().getHugoSymbol().compareTo(d2.getGene().getHugoSymbol());
+            result = LevelUtils.compareLevel(o1.getLevelOfEvidence(), o2.getLevelOfEvidence());
+            if(result == 0) {
+                result = o1.getGene().getHugoSymbol().compareTo(o2.getGene().getHugoSymbol());
             }
         }
         return result;
     }
 }
+
+class CancerTypeMatchComp implements Comparator<CancerTypeMatch> {
+    @Override
+    public int compare(CancerTypeMatch o1, CancerTypeMatch o2) {
+        int result = o2.getWeight().compareTo(o1.getWeight());
+        double weightForNoEvidenceFound = 2.0;
+
+        if(result == 0 && o1.getWeight() > weightForNoEvidenceFound && o2.getWeight() > weightForNoEvidenceFound) {
+            List<LevelOfEvidence> txLevels = new ArrayList<>();
+            txLevels.addAll(THERAPEUTIC_RESISTANCE_LEVELS);
+            txLevels.addAll(THERAPEUTIC_SENSITIVE_LEVELS);
+
+            LevelOfEvidence o1HighestLevelOfEvidence = o1.findHighestLevel(txLevels);
+            LevelOfEvidence o2HighestLevelOfEvidence = o2.findHighestLevel(txLevels);
+
+            result = LevelUtils.compareLevel(o1HighestLevelOfEvidence, o2HighestLevelOfEvidence, txLevels);
+        }
+
+        if(result == 0) {
+            result = TumorTypeUtils.getTumorTypeName(o1.getCancerType()).compareTo(TumorTypeUtils.getTumorTypeName(o2.getCancerType()));
+        }
+
+        return result;
+    }
+}
+class LevelOfEvidenceComp implements Comparator<LevelOfEvidence> {
+    private final List<LevelOfEvidence> customLevels;
+    public LevelOfEvidenceComp(List<LevelOfEvidence> levels) {
+        this.customLevels = levels;
+    }
+
+    @Override
+    public int compare(LevelOfEvidence o1, LevelOfEvidence o2) {
+        return LevelUtils.compareLevel(o1, o2, customLevels);
+    }
+}
+


### PR DESCRIPTION
for #3415 

Adding the logic for search by cancer type, would it be ok to loop through entirely and not have a isMatch for when a match is found inside the for loop searching a list of cancers under evidence. 

This is because nothing would be found if we search for Leukemia, since it's not the name of any subtypes. It is the name for the main type, which will have multiple matches.