### PR TITLE
Do not update oncokb-transcript when releasing gene

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
@@ -51,15 +51,7 @@ public class DriveAnnotationParser {
             if (vus != null) {
                 jsonArray = new JSONArray(vus);
             }
-            Gene persistenceGene = parseGene(jsonObj, releaseGene, jsonArray);
-
-            if (releaseGene && persistenceGene != null) {
-                this.oncokbTranscriptService.updateTranscriptUsage(
-                    persistenceGene,
-                    persistenceGene.getGrch37Isoform(),
-                    persistenceGene.getGrch38Isoform()
-                );
-            }
+            parseGene(jsonObj, releaseGene, jsonArray);
         }
     }
 


### PR DESCRIPTION
We will update the transcript database to include all canonical info for all genes. No need to update the transcript when releasing gene.

This fixes https://github.com/oncokb/oncokb/issues/3545