### PR TITLE
Add variant consequence resolver

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
@@ -7,6 +7,7 @@ import org.mskcc.cbio.oncokb.util.VariantConsequenceUtils;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,6 +21,7 @@ public final class Constants {
     public static final String IN_FRAME_INSERTION = "inframe_insertion";
     public static final String FIVE_UTR = "5_prime_UTR_variant";
     public static final String UPSTREAM_GENE = "upstream_gene_variant";
+    public static final String PROTEIN_ALTERING_VARIANT = "protein_altering_variant";
 
     public static final String PUBLIC_API_VERSION = "v1.4.0";
     public static final String PRIVATE_API_VERSION = "v1.4.1";
@@ -34,7 +36,7 @@ public final class Constants {
 
     public static final ReferenceGenome DEFAULT_REFERENCE_GENOME = ReferenceGenome.GRCh37;
 
-    public static final Set<VariantConsequence> SPLICE_SITE_VARIANTS = Arrays.asList("splice_acceptor_variant", "splice_donor_variant", "splice_region_variant").stream().map(term -> VariantConsequenceUtils.findVariantConsequenceByTerm(term)).collect(Collectors.toSet());
+    public static final List<VariantConsequence> SPLICE_SITE_VARIANTS = Arrays.asList("splice_acceptor_variant", "splice_donor_variant", "splice_region_variant").stream().map(term -> VariantConsequenceUtils.findVariantConsequenceByTerm(term)).collect(Collectors.toList());
 
     private Constants() {
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import static org.mskcc.cbio.oncokb.Constants.*;
 import static org.mskcc.cbio.oncokb.model.StructuralAlteration.TRUNCATING_MUTATIONS;
 import static org.mskcc.cbio.oncokb.util.MainUtils.isOncogenic;
+import static org.mskcc.cbio.oncokb.util.VariantConsequenceUtils.TOO_BROAD_CONSEQUENCES;
 
 /**
  * @author jgao, Hongxin Zhang
@@ -488,6 +489,10 @@ public final class AlterationUtils {
             }
             // if alteration is a positional vairant and the consequence is manually assigned to others than NA, we should change it
             if (isPositionedAlteration(alteration) && alteration.getConsequence().equals(VariantConsequenceUtils.findVariantConsequenceByTerm(MISSENSE_VARIANT))) {
+                alteration.setConsequence(variantConsequence);
+            }
+            // if the consequence provided by the user is too broad, we ignore and use the interpreted variant consequence
+            if (TOO_BROAD_CONSEQUENCES.contains(alteration.getConsequence().getTerm())) {
                 alteration.setConsequence(variantConsequence);
             }
         }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -21,6 +21,8 @@ import org.springframework.web.client.RestTemplate;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.mskcc.cbio.oncokb.util.VariantConsequenceUtils.consequenceResolver;
+
 /**
  * Created by Hongxin on 6/26/17.
  */
@@ -233,19 +235,6 @@ public class GenomeNexusUtils {
         return variantAnnotation;
     }
 
-    public static VariantConsequence getTranscriptConsequenceSummaryTerm(String consequenceTerms) {
-        if (StringUtils.isEmpty(consequenceTerms)) {
-            return null;
-        }
-        List<VariantConsequence> terms = Arrays.asList(consequenceTerms.split(",")).stream().map(consequence -> VariantConsequenceUtils.findVariantConsequenceByTerm(consequence.trim())).filter(Objects::nonNull).collect(Collectors.toList());
-        // if we cannot find the matched variant consequence using the mostSevereConsequence, we should use the one from the consequence term list
-        if (terms.size() > 0) {
-            return terms.iterator().next();
-        } else {
-            return null;
-        }
-    }
-
     private static TranscriptConsequenceSummary getConsequence(VariantAnnotation variantAnnotation, ReferenceGenome referenceGenome) {
         List<TranscriptConsequenceSummary> summaries = new ArrayList<>();
 
@@ -288,7 +277,7 @@ public class GenomeNexusUtils {
 
         // Only return one consequence term
         if (summary != null) {
-            VariantConsequence consequence = getTranscriptConsequenceSummaryTerm(summary.getConsequenceTerms());
+            VariantConsequence consequence = consequenceResolver(summary.getConsequenceTerms(), summary.getVariantClassification());
             if (consequence == null && StringUtils.isNotEmpty(summary.getVariantClassification())) {
                 consequence = VariantConsequenceUtils.findVariantConsequenceByTerm(summary.getVariantClassification());
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/VariantConsequenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/VariantConsequenceUtils.java
@@ -107,12 +107,9 @@ public class VariantConsequenceUtils {
         if (consequenceTerms == null) {
             consequenceTerms = "";
         }
-        if (variantClass == null) {
-            variantClass = "";
-        }
 
         VariantConsequence consequence = findVariantConsequenceByTerm(consequenceTerms.contains(",") ? pickConsequenceTerm(consequenceTerms) : consequenceTerms);
-        VariantConsequence variantClassConsequence = variantClass == null ? null : findVariantConsequenceByTerm(variantClass);
+        VariantConsequence variantClassConsequence = StringUtils.isEmpty(variantClass) ? null : findVariantConsequenceByTerm(variantClass);
 
         if (consequence == null) {
             if (variantClassConsequence != null) {
@@ -121,7 +118,7 @@ public class VariantConsequenceUtils {
                 return null;
             }
         } else {
-            if (variantClassConsequence != null && variantClassConsequence != consequence) {
+            if (variantClassConsequence != null && !variantClassConsequence.equals(consequence)) {
                 // we should compare the granularity of the consequence for splice site
                 if (SPLICE_SITE_VARIANTS.contains(consequence) && SPLICE_SITE_VARIANTS.contains(variantClassConsequence)) {
                     return SPLICE_SITE_VARIANTS.indexOf(consequence) < SPLICE_SITE_VARIANTS.indexOf(variantClassConsequence) ? consequence : variantClassConsequence;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/VariantConsequenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/VariantConsequenceUtils.java
@@ -1,11 +1,11 @@
 package org.mskcc.cbio.oncokb.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.model.VariantConsequence;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.mskcc.cbio.oncokb.Constants.*;
 
@@ -16,6 +16,7 @@ public class VariantConsequenceUtils {
 
     private static final String VARIANT_CONSEQUENCE_FILE_PATH = "/data/variant-consequences.txt";
     private static Map<String, VariantConsequence> VariantConsequencesMap = null;
+    public static final List<String> TOO_BROAD_CONSEQUENCES = Arrays.asList(new String[]{PROTEIN_ALTERING_VARIANT});
     private static final Map<String, String> TCGAMapping = new HashMap<String, String>() {{
         put("3'flank", "downstream_gene_variant");
         put("3'utr", "3_prime_UTR_variant");
@@ -94,6 +95,46 @@ public class VariantConsequenceUtils {
         }
     }
 
+    public static VariantConsequence consequenceResolver(String consequenceTerms) {
+        return consequenceResolver(consequenceTerms, null);
+    }
+
+    // The goal is to reserve the details of the consequence if possible, but when consequence conflicts with variant class, we need to decide which one to use
+    public static VariantConsequence consequenceResolver(String consequenceTerms, String variantClass) {
+        if (StringUtils.isEmpty(consequenceTerms) && StringUtils.isEmpty(variantClass)) {
+            return null;
+        }
+        if (consequenceTerms == null) {
+            consequenceTerms = "";
+        }
+        if (variantClass == null) {
+            variantClass = "";
+        }
+
+        VariantConsequence consequence = findVariantConsequenceByTerm(consequenceTerms.contains(",") ? pickConsequenceTerm(consequenceTerms) : consequenceTerms);
+        VariantConsequence variantClassConsequence = variantClass == null ? null : findVariantConsequenceByTerm(variantClass);
+
+        if (consequence == null) {
+            if (variantClassConsequence != null) {
+                return variantClassConsequence;
+            } else {
+                return null;
+            }
+        } else {
+            if (variantClassConsequence != null && variantClassConsequence != consequence) {
+                // we should compare the granularity of the consequence for splice site
+                if (SPLICE_SITE_VARIANTS.contains(consequence) && SPLICE_SITE_VARIANTS.contains(variantClassConsequence)) {
+                    return SPLICE_SITE_VARIANTS.indexOf(consequence) < SPLICE_SITE_VARIANTS.indexOf(variantClassConsequence) ? consequence : variantClassConsequence;
+                } else {
+                    return variantClassConsequence;
+                }
+            } else {
+                // Replace generic terms with empty string
+                return TOO_BROAD_CONSEQUENCES.contains(consequence.getTerm()) ? null : consequence;
+            }
+        }
+    }
+
     public static VariantConsequence findVariantConsequenceByTerm(String searchTerm) {
         VariantConsequence variantConsequence = findVariantConsequenceBySoTerm(searchTerm);
         if (variantConsequence == null) {
@@ -119,6 +160,19 @@ public class VariantConsequenceUtils {
                 matchStr = TCGAMapping.get(term);
             }
             return findVariantConsequenceBySoTerm(matchStr);
+        }
+    }
+
+    public static String pickConsequenceTerm(String consequenceTerms) {
+        if (StringUtils.isEmpty(consequenceTerms)) {
+            return "";
+        }
+        List<String> terms = Arrays.asList(consequenceTerms.split(",")).stream().map(consequence -> consequence.trim()).filter(StringUtils::isNotEmpty).collect(Collectors.toList());
+        // if we cannot find the matched variant consequence using the mostSevereConsequence, we should use the one from the consequence term list
+        if (terms.size() > 0) {
+            return terms.iterator().next();
+        } else {
+            return "";
         }
     }
 

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtilsTest.java
@@ -146,31 +146,4 @@ public class GenomeNexusUtilsTest extends TestCase {
         assertEquals("Picked transcript gene symbol is not expected, but it should.", "TERT", consequence.getHugoGeneSymbol());
         assertEquals("Consequence is not expected, but it should.", "upstream_gene_variant", consequence.getConsequenceTerms());
     }
-
-    public void testGetTranscriptConsequenceSummaryTerm() {
-        // we do not have a mapping for test. We should default to the one that we do. In this case, intron_variant
-        String consequenceTerms = "test,intron_variant";
-        VariantConsequence variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "splice_region_variant,intron_variant,test";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
-        assertEquals("splice_region_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "intron_variant";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = "test";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
-        assertNull(variantConsequence);
-
-        consequenceTerms = "intron_variant , intron_variant";
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
-        assertEquals("intron_variant", variantConsequence.getTerm());
-
-        consequenceTerms = null;
-        variantConsequence = GenomeNexusUtils.getTranscriptConsequenceSummaryTerm(consequenceTerms);
-        assertNull(variantConsequence);
-    }
 }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/VariantConsequenceUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/VariantConsequenceUtilsTest.java
@@ -1,0 +1,74 @@
+package org.mskcc.cbio.oncokb.util;
+
+import junit.framework.TestCase;
+import org.mskcc.cbio.oncokb.model.VariantConsequence;
+
+import static org.mskcc.cbio.oncokb.Constants.PROTEIN_ALTERING_VARIANT;
+import static org.mskcc.cbio.oncokb.util.VariantConsequenceUtils.consequenceResolver;
+
+public class VariantConsequenceUtilsTest extends TestCase {
+
+    public void testConsequenceResolver() {
+        // Test consequence without variant class
+        assertConsequenceResolver(consequenceResolver(null), "");
+        assertConsequenceResolver(consequenceResolver(""), "");
+        assertConsequenceResolver(consequenceResolver("splice_donor_variant"), "splice_donor_variant");
+        assertConsequenceResolver(consequenceResolver(PROTEIN_ALTERING_VARIANT), "");
+        assertConsequenceResolver(consequenceResolver("splice_donor_variant," + PROTEIN_ALTERING_VARIANT), "splice_donor_variant");
+        assertConsequenceResolver(consequenceResolver("splice_acceptor_variant," + PROTEIN_ALTERING_VARIANT), "splice_acceptor_variant");
+
+        // Test consequence with variant class
+        assertConsequenceResolver(consequenceResolver(null, ""), "");
+        assertConsequenceResolver(consequenceResolver("", ""), "");
+        assertConsequenceResolver(consequenceResolver(null, "Splice_Site"), "splice_region_variant");
+        assertConsequenceResolver(consequenceResolver("", "Splice_Site"), "splice_region_variant");
+        assertConsequenceResolver(consequenceResolver("splice_donor_variant", "Splice_Site"), "splice_donor_variant");
+        assertConsequenceResolver(consequenceResolver(PROTEIN_ALTERING_VARIANT, "Splice_Site"), "splice_region_variant");
+        assertConsequenceResolver(consequenceResolver("splice_donor_variant," + PROTEIN_ALTERING_VARIANT, "Splice_Site"), "splice_donor_variant");
+        assertConsequenceResolver(consequenceResolver("splice_acceptor_variant," + ",splice_donor_variant" + PROTEIN_ALTERING_VARIANT, "Splice_Site"), "splice_acceptor_variant");
+
+        // Test real cases
+        assertConsequenceResolver(consequenceResolver("coding_sequence_variant,5_prime_UTR_variant", "In_Frame_Del"), "inframe_deletion");
+        assertConsequenceResolver(consequenceResolver("coding_sequence_variant,5_prime_UTR_variant", "Frame_Shift_Del"), "frameshift_variant");
+        assertConsequenceResolver(consequenceResolver("", "In_Frame_Del"), "inframe_deletion");
+        assertConsequenceResolver(consequenceResolver(PROTEIN_ALTERING_VARIANT, "In_Frame_Del"), "inframe_deletion");
+
+    }
+
+    private void assertConsequenceResolver(VariantConsequence consequence, String expectedTerm) {
+        String consequenceTerm = consequence == null ? "" : consequence.getTerm();
+        assertEquals(expectedTerm, consequenceTerm);
+    }
+
+
+    public void testTrimConsequenceTerms() {
+        // we do not have a mapping for test. We should default to the one that we do. In this case, intron_variant
+        String consequenceTerms = "intron_variant";
+        String variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("intron_variant", variantConsequence);
+
+        consequenceTerms = "splice_region_variant,intron_variant";
+        variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("splice_region_variant", variantConsequence);
+
+        consequenceTerms = "intron_variant , intron_variant";
+        variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("intron_variant", variantConsequence);
+
+        consequenceTerms = "intron_variant , intron_variant,splice_region_variant";
+        variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("intron_variant", variantConsequence);
+
+        consequenceTerms = " , intron_variant";
+        variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("intron_variant", variantConsequence);
+
+        consequenceTerms = ", intron_variant";
+        variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("intron_variant", variantConsequence);
+
+        consequenceTerms = null;
+        variantConsequence = VariantConsequenceUtils.pickConsequenceTerm(consequenceTerms);
+        assertEquals("", variantConsequence);
+    }
+}


### PR DESCRIPTION
When consequence is specified by user or by GenomeNexus, there are situations that
- there are multiple consequences associated with the variant
- conflict with variant classification

This resolver fixes https://github.com/oncokb/oncokb/issues/3554