### PR TITLE
Update logics of removeAlternativeAllele

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Alteration.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Alteration.java
@@ -235,9 +235,7 @@ public class Alteration implements java.io.Serializable {
         if (getId() != null && that.getId() != null) {
             return Objects.equals(getId(), that.getId());
         }
-        return Objects.equals(getId(), that.getId()) &&
-            Objects.equals(getUuid(), that.getUuid()) &&
-            Objects.equals(getGene(), that.getGene()) &&
+        return Objects.equals(getGene(), that.getGene()) &&
             getAlterationType() == that.getAlterationType() &&
             Objects.equals(getConsequence(), that.getConsequence()) &&
             Objects.equals(getAlteration(), that.getAlteration()) &&

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -1071,8 +1071,15 @@ public final class AlterationUtils {
         if (alteration != null && alteration.getConsequence() != null && alteration.getConsequence().getTerm().equals(MISSENSE_VARIANT)) {
             // check for positional variant when the consequence is forced to be missense variant
             boolean isMissensePositionalVariant = StringUtils.isEmpty(alteration.getVariantResidues()) && alteration.getProteinStart() != null && alteration.getProteinEnd() != null && alteration.getProteinStart().equals(alteration.getProteinEnd());
-            List<Alteration> alternativeAlleles = alterationBo.findRelevantOverlapAlterations(alteration.getGene(), referenceGenome, alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), alteration.getAlteration(), relevantAlterations);
-            for (Alteration allele : alternativeAlleles) {
+            List<Alteration> overlapAlterations = alterationBo.findRelevantOverlapAlterations(alteration.getGene(), referenceGenome, alteration.getConsequence(), alteration.getProteinStart(), alteration.getProteinEnd(), alteration.getAlteration(), relevantAlterations);
+            for (Alteration allele : overlapAlterations) {
+//                if (allele.equals(alteration)) {
+//                    continue;
+//                }
+                // range missense mutations is not alternative allele
+                if(allele.getAlteration().endsWith("mis")){
+                    continue;
+                }
                 // remove all alleles if the alteration variant residue is empty
                 if (isMissensePositionalVariant && !StringUtils.isEmpty(allele.getVariantResidues())) {
                     relevantAlterations.remove(allele);


### PR DESCRIPTION
- Do not exclude alteration itself when removing alternative allele
- Do not exclude range missense mutation when excluding alternative allele

This fixes https://github.com/oncokb/oncokb/issues/3649