### PR TITLE
Expose endpoint to return all variants of unknown significance

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/VariantOfUnknownSignificance.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/VariantOfUnknownSignificance.java
@@ -1,0 +1,37 @@
+package org.mskcc.cbio.oncokb.apiModels;
+
+public class VariantOfUnknownSignificance {
+    Integer entrezGeneId;
+    String gene;
+    String variant;
+
+    public Integer getEntrezGeneId() {
+        return entrezGeneId;
+    }
+
+    public void setEntrezGeneId(Integer entrezGeneId) {
+        this.entrezGeneId = entrezGeneId;
+    }
+
+    public String getGene() {
+        return gene;
+    }
+
+    public void setGene(String gene) {
+        this.gene = gene;
+    }
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public void setVariant(String variant) {
+        this.variant = variant;
+    }
+
+    public VariantOfUnknownSignificance(Integer entrezGeneId, String gene, String variant) {
+        this.entrezGeneId = entrezGeneId;
+        this.gene = gene;
+        this.variant = variant;
+    }
+}

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -1,9 +1,6 @@
 package org.mskcc.cbio.oncokb.util;
 
-import org.mskcc.cbio.oncokb.apiModels.ActionableGene;
-import org.mskcc.cbio.oncokb.apiModels.AnnotatedVariant;
-import org.mskcc.cbio.oncokb.apiModels.Citations;
-import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
+import org.mskcc.cbio.oncokb.apiModels.*;
 import org.mskcc.cbio.oncokb.model.*;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
@@ -735,6 +732,10 @@ public class MainUtils {
                 return result;
             }
         });
+    }
+
+    public static void sortVusVariants(List<VariantOfUnknownSignificance> variants) {
+        Collections.sort(variants, Comparator.comparing(VariantOfUnknownSignificance::getGene).thenComparing(VariantOfUnknownSignificance::getVariant));
     }
 
     public static void sortActionableVariants(List<ActionableGene> variants) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.*;
 import org.mskcc.cbio.oncokb.apiModels.ActionableGene;
 import org.mskcc.cbio.oncokb.apiModels.AnnotatedVariant;
 import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
+import org.mskcc.cbio.oncokb.apiModels.VariantOfUnknownSignificance;
 import org.mskcc.cbio.oncokb.config.annotation.PremiumPublicApi;
 import org.mskcc.cbio.oncokb.config.annotation.PublicApi;
 import org.mskcc.cbio.oncokb.model.CancerGene;
@@ -53,6 +54,29 @@ public interface UtilsApi {
     ResponseEntity<String> utilsAllAnnotatedVariantsTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     );
+
+    @PremiumPublicApi
+    @ApiOperation(value = "", notes = "Get All Variants of Unknown Significance.", response = VariantOfUnknownSignificance.class, responseContainer = "List", tags = {"Variants"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK", response = VariantOfUnknownSignificance.class, responseContainer = "List"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 503, message = "Service Unavailable")
+    })
+    @RequestMapping(value = "/utils/allVariantsOfUnknownSignificance", produces = {"application/json"},
+        method = RequestMethod.GET)
+    ResponseEntity<List<VariantOfUnknownSignificance>> utilsAllVariantsOfUnknownSignificanceGet();
+
+    @PremiumPublicApi
+    @ApiOperation(value = "", notes = "Get All Variants of Unknown Significance in text file.", tags = {"Variants"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 503, message = "Service Unavailable")
+    })
+    @RequestMapping(value = "/utils/allVariantsOfUnknownSignificance.txt",
+        produces = TEXT_PLAIN_VALUE,
+        method = RequestMethod.GET)
+    ResponseEntity<String> utilsAllVariantsOfUnknownSignificanceTxtGet();
 
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get All Actionable Variants.", response = ActionableGene.class, responseContainer = "List", tags = {"Variants"})


### PR DESCRIPTION
These two endpoints do not have version as parameter. We don't have vus files listed in previous versions, and we don't have intention to maintain that.

This fixes https://github.com/oncokb/oncokb-pipeline/issues/291