### PR TITLE
Added error message to 404 error for utils controller

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GitHubUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GitHubUtils.java
@@ -44,7 +44,7 @@ public class GitHubUtils {
             contents = repo.getDirectoryContent("/RELEASE/" + version);
         } catch (Exception e) {
             // in this case, is the directory is not available.
-            throw new HttpClientErrorException(HttpStatus.NOT_FOUND);
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "The version " + version + " is not available.");
         }
 
         Optional<GHContent> matchedContent = contents.stream().filter(content -> content.getName().equals(fileName)).findFirst();
@@ -53,7 +53,7 @@ public class GitHubUtils {
             GHBlob ghBlob = repo.getBlob(sha);
             return ghBlob;
         } else {
-            throw new HttpClientErrorException(HttpStatus.NOT_FOUND);
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "The file " + fileName + " is not available in version " + version + ".");
         }
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/HttpUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/HttpUtils.java
@@ -105,26 +105,26 @@ public class HttpUtils {
     }
 
 
-    public static <T> ResponseEntity<T> getDataDownloadResponseEntity(String version, FileName fileName, FileExtension fileExtension) {
+    public static ResponseEntity<?> getDataDownloadResponseEntity(String version, FileName fileName, FileExtension fileExtension) {
         return getDataDownloadResponseEntity(version, fileName.getName() + fileExtension.getExtension(), fileExtension);
     }
 
-    public static <T> ResponseEntity<T> getDataDownloadResponseEntity(String version, String fileName, FileExtension fileExtension) {
+    public static ResponseEntity<?> getDataDownloadResponseEntity(String version, String fileName, FileExtension fileExtension) {
         try {
             if (fileExtension.equals(FileExtension.JSON)) {
-                return new ResponseEntity<>((T) JsonUtils.jsonToArray(GitHubUtils.getOncoKBData(version, fileName)), HttpStatus.OK);
+                return new ResponseEntity<>(JsonUtils.jsonToArray(GitHubUtils.getOncoKBData(version, fileName)), HttpStatus.OK);
             } else if (fileExtension.equals(FileExtension.GZ)) {
                 HttpHeaders headers = new HttpHeaders();
                 headers.add("Content-Disposition", "attachment; filename=" + fileName);
-                return (ResponseEntity<T>) ResponseEntity.ok()
+                return ResponseEntity.ok()
                     .headers(headers)
                     .contentType(new MediaType("application", "gz"))
                     .body(GitHubUtils.getOncoKBDataInBytes(version, fileName));
             } else {
-                return new ResponseEntity<>((T) GitHubUtils.getOncoKBData(version, fileName), HttpStatus.OK);
+                return new ResponseEntity<>(GitHubUtils.getOncoKBData(version, fileName), HttpStatus.OK);
             }
         } catch (HttpClientErrorException exception) {
-            return new ResponseEntity<>(null, exception.getStatusCode());
+            return new ResponseEntity<>(exception.getMessage(), exception.getStatusCode());
         } catch (IOException exception) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (NoPropertyException exception) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.INCLUDE_EVIDENCE;
 import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.VERSION;
@@ -31,26 +30,26 @@ public interface UtilsApi {
     @ApiOperation(value = "", notes = "Get All Annotated Variants.", response = AnnotatedVariant.class, responseContainer = "List", tags = {"Variants"})
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "OK", response = AnnotatedVariant.class, responseContainer = "List"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/allAnnotatedVariants", produces = {"application/json"},
         method = RequestMethod.GET)
-    ResponseEntity<List<AnnotatedVariant>> utilsAllAnnotatedVariantsGet(
+    ResponseEntity<?> utilsAllAnnotatedVariantsGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     );
 
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get All Annotated Variants in text file.", tags = {"Variants"})
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 200, message = "OK", response = String.class),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/allAnnotatedVariants.txt",
         produces = TEXT_PLAIN_VALUE,
         method = RequestMethod.GET)
-    ResponseEntity<String> utilsAllAnnotatedVariantsTxtGet(
+    ResponseEntity<?> utilsAllAnnotatedVariantsTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     );
 
@@ -58,12 +57,12 @@ public interface UtilsApi {
     @ApiOperation(value = "", notes = "Get All Actionable Variants.", response = ActionableGene.class, responseContainer = "List", tags = {"Variants"})
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "OK", response = ActionableGene.class, responseContainer = "List"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/allActionableVariants", produces = {"application/json"},
         method = RequestMethod.GET)
-    ResponseEntity<List<ActionableGene>> utilsAllActionableVariantsGet(
+    ResponseEntity<?> utilsAllActionableVariantsGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     );
 
@@ -71,14 +70,14 @@ public interface UtilsApi {
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get All Actionable Variants in text file.", tags = {"Variants"})
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 200, message = "OK", response = String.class),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/allActionableVariants.txt",
         produces = TEXT_PLAIN_VALUE,
         method = RequestMethod.GET)
-    ResponseEntity<String> utilsAllActionableVariantsTxtGet(
+    ResponseEntity<?> utilsAllActionableVariantsTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     );
 
@@ -86,14 +85,14 @@ public interface UtilsApi {
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get cancer gene list", tags = {"Cancer Genes"})
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 200, message = "OK", response = CancerGene.class, responseContainer = "List"),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/cancerGeneList",
         produces = {"application/json"},
         method = RequestMethod.GET)
-    ResponseEntity<List<CancerGene>> utilsCancerGeneListGet(
+    ResponseEntity<?> utilsCancerGeneListGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) throws ApiException, IOException;
 
@@ -101,14 +100,14 @@ public interface UtilsApi {
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get cancer gene list in text file.", tags = {"Cancer Genes"})
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 200, message = "OK", response = String.class),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/cancerGeneList.txt",
         produces = TEXT_PLAIN_VALUE,
         method = RequestMethod.GET)
-    ResponseEntity<String> utilsCancerGeneListTxtGet(
+    ResponseEntity<?> utilsCancerGeneListTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) throws ApiException, IOException;
 
@@ -116,14 +115,14 @@ public interface UtilsApi {
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get list of genes OncoKB curated", tags = {"Cancer Genes"})
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 200, message = "OK", response = CuratedGene.class, responseContainer = "List"),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/allCuratedGenes",
         produces = {"application/json"},
         method = RequestMethod.GET)
-    ResponseEntity<List<CuratedGene>> utilsAllCuratedGenesGet(
+    ResponseEntity<?> utilsAllCuratedGenesGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
         , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
     );
@@ -132,14 +131,14 @@ public interface UtilsApi {
     @PremiumPublicApi
     @ApiOperation(value = "", notes = "Get list of genes OncoKB curated in text file.", tags = {"Cancer Genes"})
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 200, message = "OK", response = String.class),
+        @ApiResponse(code = 404, message = "Not Found", response = String.class),
         @ApiResponse(code = 503, message = "Service Unavailable")
     })
     @RequestMapping(value = "/utils/allCuratedGenes.txt",
         produces = TEXT_PLAIN_VALUE,
         method = RequestMethod.GET)
-    ResponseEntity<String> utilsAllCuratedGenesTxtGet(
+    ResponseEntity<?> utilsAllCuratedGenesTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
         , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
     );

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -3,7 +3,6 @@ package org.mskcc.cbio.oncokb.api.pub.v1;
 import io.swagger.annotations.ApiParam;
 import org.mskcc.cbio.oncokb.apiModels.ActionableGene;
 import org.mskcc.cbio.oncokb.apiModels.AnnotatedVariant;
-import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
 import org.mskcc.cbio.oncokb.apiModels.download.FileName;
 import org.mskcc.cbio.oncokb.apiModels.download.FileExtension;
 import org.mskcc.cbio.oncokb.cache.CacheFetcher;
@@ -33,7 +32,7 @@ public class UtilsApiController implements UtilsApi {
     CacheFetcher cacheFetcher;
 
     @Override
-    public ResponseEntity<List<AnnotatedVariant>> utilsAllAnnotatedVariantsGet(
+    public ResponseEntity<?> utilsAllAnnotatedVariantsGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) {
         if (version != null) {
@@ -43,7 +42,7 @@ public class UtilsApiController implements UtilsApi {
     }
 
     @Override
-    public ResponseEntity<String> utilsAllAnnotatedVariantsTxtGet(
+    public ResponseEntity<?> utilsAllAnnotatedVariantsTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) {
         if (version != null) {
@@ -136,7 +135,7 @@ public class UtilsApiController implements UtilsApi {
     }
 
     @Override
-    public ResponseEntity<List<ActionableGene>> utilsAllActionableVariantsGet(
+    public ResponseEntity<?> utilsAllActionableVariantsGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) {
         if (version != null) {
@@ -146,7 +145,7 @@ public class UtilsApiController implements UtilsApi {
     }
 
     @Override
-    public ResponseEntity<String> utilsAllActionableVariantsTxtGet(
+    public ResponseEntity<?> utilsAllActionableVariantsTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) {
         if (version != null) {
@@ -261,7 +260,7 @@ public class UtilsApiController implements UtilsApi {
     }
 
     @Override
-    public ResponseEntity<List<CancerGene>> utilsCancerGeneListGet(
+    public ResponseEntity<?> utilsCancerGeneListGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) throws ApiException, IOException {
         if (version != null) {
@@ -272,7 +271,7 @@ public class UtilsApiController implements UtilsApi {
     }
 
     @Override
-    public ResponseEntity<String> utilsCancerGeneListTxtGet(
+    public ResponseEntity<?> utilsCancerGeneListTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
     ) throws ApiException, IOException {
         if (version != null) {
@@ -283,7 +282,7 @@ public class UtilsApiController implements UtilsApi {
 
 
     @Override
-    public ResponseEntity<List<CuratedGene>> utilsAllCuratedGenesGet(
+    public ResponseEntity<?> utilsAllCuratedGenesGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
         , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
     ) {
@@ -294,7 +293,7 @@ public class UtilsApiController implements UtilsApi {
     }
 
     @Override
-    public ResponseEntity<String> utilsAllCuratedGenesTxtGet(
+    public ResponseEntity<?> utilsAllCuratedGenesTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
         , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
     ) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApi.java
@@ -250,14 +250,14 @@ public interface PrivateUtilsApi {
     @RequestMapping(value = "/utils/data/readme",
         produces = TEXT_PLAIN_VALUE,
         method = RequestMethod.GET)
-    ResponseEntity<String> utilDataReadmeGet(
+    ResponseEntity<?> utilDataReadmeGet(
         @ApiParam(value = "version", required = true) @RequestParam(value = "version") String version
     );
 
     @RequestMapping(value = "/utils/data/sqlDump",
         produces = {"application/gz"},
         method = RequestMethod.GET)
-    ResponseEntity<byte[]> utilDataSqlDumpGet(
+    ResponseEntity<?> utilDataSqlDumpGet(
         @ApiParam(value = "version", required = true) @RequestParam(value = "version") String version
     );
 

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
@@ -569,14 +569,14 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
     }
 
     @Override
-    public ResponseEntity<String> utilDataReadmeGet(
+    public ResponseEntity<?> utilDataReadmeGet(
         @ApiParam(value = "version") @RequestParam(value = "version", required = false) String version
     ) {
         return getDataDownloadResponseEntity(version, FileName.README, FileExtension.MARK_DOWN);
     }
 
     @Override
-    public ResponseEntity<byte[]> utilDataSqlDumpGet(
+    public ResponseEntity<?> utilDataSqlDumpGet(
         @ApiParam(value = "version") @RequestParam(value = "version", required = false) String version
     ) {
         return getDataDownloadResponseEntity(version, getOncoKBSqlDumpFileName(version), FileExtension.GZ);


### PR DESCRIPTION
The byte[] was giving me issues when I tried to change the type to ResponseEntity<byte[]> so I instead switched it to ResponseEntity<?>. 

I did some further reading an it seems like the proper way to do this is by using a "@ControllerAdvice"
[stack overflow question about returning success or error](https://stackoverflow.com/questions/38117717/what-is-the-best-way-to-return-different-types-of-responseentity-in-spring-boot)
[Article about @ControllerAdvice](https://www.toptal.com/java/spring-boot-rest-api-error-handling)
[Spring blog post about @ControllerAdvice](https://spring.io/blog/2013/11/01/exception-handling-in-spring-mvc)

I feel like using a @ControllerAdvice is a bigger change than what you were looking for, but let me know what you want me to do.