### PR TITLE
Update alteration name conversion logics

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -815,20 +815,20 @@ public class MainUtils {
         }
     }
 
-    public static String toLowerCaseExceptAllCaps(String text) {
-        Pattern pattern = Pattern.compile("\\w*[a-z]\\w*");
+    public static String lowerCaseAlterationName(String text) {
+        Pattern pattern = Pattern.compile("[A-Z]{2,}|\\b[A-Z]+\\b");
         Matcher matcher = pattern.matcher(text);
         StringBuilder sb = new StringBuilder();
         int currentIndex = 0;
         while (matcher.find()) {
-            sb.append(text, currentIndex, matcher.start());
-            sb.append(text.substring(matcher.start(), matcher.end()).toLowerCase());
+            sb.append(text.substring(currentIndex, matcher.start()).toLowerCase());
+            sb.append(text.substring(matcher.start(), matcher.end()));
             currentIndex = matcher.end();
         }
         if (currentIndex != text.length() - 1) {
-            sb.append(text.substring(currentIndex));
+            sb.append(text.substring(currentIndex).toLowerCase());
         } else if (sb.length() != text.length()) {
-            sb.append(text);
+            sb.append(text.toLowerCase());
         }
         return sb.toString();
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
@@ -4,9 +4,7 @@ import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.model.TumorType;
-import org.mskcc.cbio.oncokb.model.clinicalTrialsMathcing.Tumor;
 
-import java.sql.Ref;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -15,9 +13,8 @@ import java.util.stream.Collectors;
 
 import static org.mskcc.cbio.oncokb.Constants.IN_FRAME_DELETION;
 import static org.mskcc.cbio.oncokb.Constants.IN_FRAME_INSERTION;
-import static org.mskcc.cbio.oncokb.model.StructuralAlteration.TRUNCATING_MUTATIONS;
 import static org.mskcc.cbio.oncokb.util.MainUtils.altNameShouldConvertToLowerCase;
-import static org.mskcc.cbio.oncokb.util.MainUtils.toLowerCaseExceptAllCaps;
+import static org.mskcc.cbio.oncokb.util.MainUtils.lowerCaseAlterationName;
 import static org.mskcc.cbio.oncokb.util.MainUtils.manuallyAssignedTruncatingMutation;
 
 /**
@@ -944,7 +941,7 @@ public class SummaryUtils {
             if (NamingUtils.hasAbbreviation(queryAlteration)) {
                 sb.append(queryHugoSymbol).append(" ").append(NamingUtils.getFullName(queryAlteration)).append(" (").append(queryAlteration).append(")");
             } else {
-                String mappedAltName = altNameShouldConvertToLowerCase(alteration) ? toLowerCaseExceptAllCaps(alteration.getName()) : alteration.getName();
+                String mappedAltName = altNameShouldConvertToLowerCase(alteration) ? lowerCaseAlterationName(alteration.getName()) : alteration.getName();
                 sb.append(queryHugoSymbol).append(" ").append(mappedAltName);
                 String lman = ((mappedAltName.endsWith("s") && mappedAltName.length() > 2) ? mappedAltName.substring(0, mappedAltName.length() - 1) : mappedAltName).toLowerCase();
                 List<String> matchedSpecialAlterations = specialAlterations.stream().filter(lman::contains).collect(Collectors.toList());
@@ -956,7 +953,7 @@ public class SummaryUtils {
             if (NamingUtils.hasAbbreviation(queryAlteration)) {
                 sb.append(queryHugoSymbol).append(" ").append(NamingUtils.getFullName(queryAlteration)).append(" (").append(queryAlteration).append(")");
             } else {
-                String mappedAltName = altNameShouldConvertToLowerCase(alteration) ? toLowerCaseExceptAllCaps(alteration.getName()) : alteration.getName();
+                String mappedAltName = altNameShouldConvertToLowerCase(alteration) ? lowerCaseAlterationName(alteration.getName()) : alteration.getName();
                 if ((gene != null && mappedAltName.contains(gene.getHugoSymbol())) || mappedAltName.contains(queryHugoSymbol)) {
                     sb.append(mappedAltName);
                 } else {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/MainUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/MainUtilsTest.java
@@ -61,22 +61,26 @@ public class MainUtilsTest extends TestCase {
     }
 
     public void testToLowerCaseExceptAllCaps() {
-        assertEquals("test", toLowerCaseExceptAllCaps("test"));
-        assertEquals("test", toLowerCaseExceptAllCaps("Test"));
-        assertEquals("test", toLowerCaseExceptAllCaps("TesT"));
-        assertEquals("TEST", toLowerCaseExceptAllCaps("TEST"));
-        assertEquals("TEST-A", toLowerCaseExceptAllCaps("TEST-A"));
-        assertEquals("test-A", toLowerCaseExceptAllCaps("Test-A"));
-        assertEquals("test_a", toLowerCaseExceptAllCaps("Test_A"));
-        assertEquals("test A", toLowerCaseExceptAllCaps("TesT A"));
-        assertEquals("TEST A", toLowerCaseExceptAllCaps("TEST A"));
-        assertEquals("", toLowerCaseExceptAllCaps(""));
-        assertEquals("_", toLowerCaseExceptAllCaps("_"));
-        assertEquals("1", toLowerCaseExceptAllCaps("1"));
-        assertEquals("-", toLowerCaseExceptAllCaps("-"));
-        assertEquals("t", toLowerCaseExceptAllCaps("t"));
-        assertEquals("T", toLowerCaseExceptAllCaps("T"));
-        assertEquals("?", toLowerCaseExceptAllCaps("?"));
+        assertEquals("test", lowerCaseAlterationName("test"));
+        assertEquals("test", lowerCaseAlterationName("Test"));
+        assertEquals("test", lowerCaseAlterationName("TesT"));
+        assertEquals("TEST", lowerCaseAlterationName("TEST"));
+        assertEquals("TEST-A", lowerCaseAlterationName("TEST-A"));
+        assertEquals("test-A", lowerCaseAlterationName("Test-A"));
+        assertEquals("test_a", lowerCaseAlterationName("Test_A"));
+        assertEquals("test A", lowerCaseAlterationName("TesT A"));
+        assertEquals("TEST A", lowerCaseAlterationName("TEST A"));
+        assertEquals("TEst", lowerCaseAlterationName("TEst"));
+        assertEquals("TEst-test", lowerCaseAlterationName("TEst-tEst"));
+        assertEquals("teST", lowerCaseAlterationName("teST"));
+        assertEquals("test", lowerCaseAlterationName("tesT"));
+        assertEquals("", lowerCaseAlterationName(""));
+        assertEquals("_", lowerCaseAlterationName("_"));
+        assertEquals("1", lowerCaseAlterationName("1"));
+        assertEquals("-", lowerCaseAlterationName("-"));
+        assertEquals("t", lowerCaseAlterationName("t"));
+        assertEquals("T", lowerCaseAlterationName("T"));
+        assertEquals("?", lowerCaseAlterationName("?"));
     }
 
     public void testCompareAnnotationSearchQueryType() {


### PR DESCRIPTION
- Do not convert any two consecutive uppercases to lowercase for mutation name
- Do not convert word if it's all upper cases

This fixes https://github.com/oncokb/oncokb-pipeline/issues/522