### PR TITLE
Improve performance of genomicLocationShouldAnnotate

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -122,11 +122,7 @@ public class CacheFetcher {
                     continue;
                 }
                 String chromosome = ensemblGene.getChromosome();
-
-                if (!chromosomeEnsemblGenesMap.containsKey(chromosome)) {
-                    chromosomeEnsemblGenesMap.put(chromosome, new HashSet<>());
-                }
-
+                chromosomeEnsemblGenesMap.putIfAbsent(chromosome, new HashSet<>());
                 chromosomeEnsemblGenesMap.get(chromosome).add(ensemblGene);
             }
         }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -338,7 +338,7 @@ public class CacheFetcher {
                 return false;
             }
         }
-        Map<String, Set<EnsemblGene>> chromosomeCanonicalEnsemblGeneMap = canonicalEnsemblGenesByChromosomeByReferenceGenome.get(referenceGenome);
+        Map<String, Set<EnsemblGene>> chromosomeCanonicalEnsemblGeneMap = getCanonicalEnsemblGenesByChromosome(referenceGenome);
         // when the transcript info is not available, we should always annotate the genomic location
         if (chromosomeCanonicalEnsemblGeneMap == null || chromosomeCanonicalEnsemblGeneMap.isEmpty()) {
             return true;
@@ -349,6 +349,9 @@ public class CacheFetcher {
                 gl = notationConverter.parseGenomicLocation(query);
             } else if (gnVariantAnnotationType.equals(GNVariantAnnotationType.HGVS_G)) {
                 query = notationConverter.hgvsNormalizer(query);
+                // We are only doing a partial HGVSg -> Genomic Location conversion.
+                // The withinBuffer method only requires the chromosome and range, so we do
+                // not need to parse the ref/var residues. This is slightly more performanant than using regex.
                 gl = MainUtils.parseChromosomeAndRangeFromHGVSg(query);
             }
             if (gl == null) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -237,10 +237,10 @@ public class CacheFetcher {
         return this.oncokbTranscriptService.findGeneBySymbol(symbol);
     }
 
-    // @Cacheable(
-    //     cacheResolver = "generalCacheResolver",
-    //     keyGenerator = "concatKeyGenerator"
-    // )
+    @Cacheable(
+        cacheResolver = "generalCacheResolver",
+        keyGenerator = "concatKeyGenerator"
+    )
     public IndicatorQueryResp processQuery(ReferenceGenome referenceGenome,
                                            Integer entrezGeneId,
                                            String hugoSymbol,
@@ -266,8 +266,8 @@ public class CacheFetcher {
         );
     }
 
-    // @Cacheable(cacheResolver = "generalCacheResolver",
-    //     keyGenerator = "concatKeyGenerator")
+    @Cacheable(cacheResolver = "generalCacheResolver",
+        keyGenerator = "concatKeyGenerator")
     public Alteration getAlterationFromGenomeNexus(GNVariantAnnotationType gnVariantAnnotationType, ReferenceGenome referenceGenome, String genomicLocation) throws org.genome_nexus.ApiException {
         return AlterationUtils.getAlterationFromGenomeNexus(gnVariantAnnotationType, referenceGenome, genomicLocation);
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
@@ -4,7 +4,6 @@ import com.mysql.jdbc.StringUtils;
 import org.apache.commons.collections.map.HashedMap;
 import org.mskcc.cbio.oncokb.apiModels.download.DownloadAvailability;
 import org.mskcc.cbio.oncokb.model.*;
-import org.mskcc.cbio.oncokb.model.TumorType;
 
 import java.io.IOException;
 import java.util.*;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -1,5 +1,6 @@
 package org.mskcc.cbio.oncokb.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.mskcc.cbio.oncokb.apiModels.*;
 import org.mskcc.cbio.oncokb.model.*;
@@ -863,13 +864,22 @@ public class MainUtils {
     }
 
     public static int findDigitEndIndex(String str, int startIndex) {
+        if (startIndex < 0) {
+            return -1;
+        }
         int i = startIndex;
         while (i < str.length() && Character.isDigit(str.charAt(i))) {
             i++;
         }
-        return i;
+        return i == startIndex ? -1 : i;
     }
 
+    /**
+     * We don't intend to check if the HGVSg is valid. If you need a method that validates and parses,
+     * then use the NotationConverter.parseHGVSg() method.
+     * @param hgvsg 
+     * @return null if cannot parse, otherwise the GenomicLocation
+     */
     public static GenomicLocation parseChromosomeAndRangeFromHGVSg(String hgvsg) {
         if (hgvsg == null) {
             return null;
@@ -879,26 +889,34 @@ public class MainUtils {
 
         // Step 1: Split by ":g."
         String[] parts = hgvsg.split(":g\\.");
+        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            return null;
+        }
         location.setChromosome(parts[0]);  // Chromosome is the part before ":g."
         String coordinates = parts[1];  // This is the part after "g."
 
         // Step 2: Handle the coordinates part
         int underscoreIndex = coordinates.indexOf('_');
-
-        if (underscoreIndex != -1) {
-            // If there is an underscore, we have both start and end values
-            start = Integer.parseInt(coordinates.substring(0, underscoreIndex));
-            // Find where the digits after the underscore end (before any letters)
-            int endIndex = findDigitEndIndex(coordinates, underscoreIndex + 1);
-            end = Integer.parseInt(coordinates.substring(underscoreIndex + 1, endIndex));
-        } else {
-            // No underscore means start = end
-            int endIndex = findDigitEndIndex(coordinates, 0);
-            start = Integer.parseInt(coordinates.substring(0, endIndex));
-            end = start;
+        try {
+            if (underscoreIndex != -1) {
+                // If there is an underscore, we have both start and end values
+                start = Integer.parseInt(coordinates.substring(0, underscoreIndex));
+                // Find where the digits after the underscore end (before any letters)
+                int endIndex = findDigitEndIndex(coordinates, underscoreIndex + 1);
+                end = Integer.parseInt(coordinates.substring(underscoreIndex + 1, endIndex));
+            } else {
+                // No underscore means start = end
+                int endIndex = findDigitEndIndex(coordinates, 0);
+                start = Integer.parseInt(coordinates.substring(0, endIndex));
+                end = start;
+            }
+            location.setStart(start);
+            location.setEnd(end);
+        } catch (NumberFormatException exception) {
+            return null;
+        } catch (IndexOutOfBoundsException exception) {
+            return null;
         }
-        location.setStart(start);
-        location.setEnd(end);
         return location;
     }
 }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -1,5 +1,6 @@
 package org.mskcc.cbio.oncokb.util;
 
+import org.cbioportal.genome_nexus.model.GenomicLocation;
 import org.mskcc.cbio.oncokb.apiModels.*;
 import org.mskcc.cbio.oncokb.model.*;
 import org.w3c.dom.Document;
@@ -859,5 +860,45 @@ public class MainUtils {
         if (q2 == null)
             return asc ? -1 : 1;
         return (PRIORITIZED_QUERY_TYPES.indexOf(q1) - PRIORITIZED_QUERY_TYPES.indexOf(q2)) * (asc ? 1 : -1);
+    }
+
+    public static int findDigitEndIndex(String str, int startIndex) {
+        int i = startIndex;
+        while (i < str.length() && Character.isDigit(str.charAt(i))) {
+            i++;
+        }
+        return i;
+    }
+
+    public static GenomicLocation parseChromosomeAndRangeFromHGVSg(String hgvsg) {
+        if (hgvsg == null) {
+            return null;
+        }
+        GenomicLocation location = new GenomicLocation();
+        int start, end;
+
+        // Step 1: Split by ":g."
+        String[] parts = hgvsg.split(":g\\.");
+        location.setChromosome(parts[0]);  // Chromosome is the part before ":g."
+        String coordinates = parts[1];  // This is the part after "g."
+
+        // Step 2: Handle the coordinates part
+        int underscoreIndex = coordinates.indexOf('_');
+
+        if (underscoreIndex != -1) {
+            // If there is an underscore, we have both start and end values
+            start = Integer.parseInt(coordinates.substring(0, underscoreIndex));
+            // Find where the digits after the underscore end (before any letters)
+            int endIndex = findDigitEndIndex(coordinates, underscoreIndex + 1);
+            end = Integer.parseInt(coordinates.substring(underscoreIndex + 1, endIndex));
+        } else {
+            // No underscore means start = end
+            int endIndex = findDigitEndIndex(coordinates, 0);
+            start = Integer.parseInt(coordinates.substring(0, endIndex));
+            end = start;
+        }
+        location.setStart(start);
+        location.setEnd(end);
+        return location;
     }
 }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/MainUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/MainUtilsTest.java
@@ -2,6 +2,9 @@ package org.mskcc.cbio.oncokb.util;
 
 import static org.mskcc.cbio.oncokb.util.MainUtils.*;
 
+import org.cbioportal.genome_nexus.model.GenomicLocation;
+import org.junit.Test;
+
 import junit.framework.TestCase;
 import org.mskcc.cbio.oncokb.model.AnnotationSearchQueryType;
 import org.mskcc.cbio.oncokb.model.MutationEffect;
@@ -94,5 +97,37 @@ public class MainUtilsTest extends TestCase {
         assertTrue(compareAnnotationSearchQueryType(null, null, true) == 0);
         assertTrue(compareAnnotationSearchQueryType(AnnotationSearchQueryType.VARIANT, AnnotationSearchQueryType.GENE, true) > 0);
         assertTrue(compareAnnotationSearchQueryType(AnnotationSearchQueryType.VARIANT, AnnotationSearchQueryType.GENE, false) < 0);
+    }
+
+    public void testParseChromosomeAndRangeFromHGVSg() {
+        GenomicLocation parsedGl = parseChromosomeAndRangeFromHGVSg("7:g.100A>T");
+        assertEquals("7", parsedGl.getChromosome());
+        assertEquals(new Integer(100), parsedGl.getStart());
+        assertEquals(new Integer(100), parsedGl.getEnd());
+        
+
+        parsedGl = parseChromosomeAndRangeFromHGVSg("X:g.100_105del");
+        assertEquals("X", parsedGl.getChromosome());
+        assertEquals(new Integer(100), parsedGl.getStart());
+        assertEquals(new Integer(105), parsedGl.getEnd());
+
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg(""));
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg(":g.100A>T"));
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg("7:g."));
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg("7:g.A"));
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg("7:g.A_B"));
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg("7:g.100_A"));
+        assertEquals(null, parseChromosomeAndRangeFromHGVSg("7:g.A_100"));
+    }
+
+    public void testFindDigitEndIndex() {
+        assertEquals(-1, findDigitEndIndex("100T", -1));
+        assertEquals(-1, findDigitEndIndex("100-", 3));
+        assertEquals(-1, findDigitEndIndex("abc123def", 0));
+
+        assertEquals(3, findDigitEndIndex("100T", 0));
+        assertEquals(3, findDigitEndIndex("100-", 0));
+        assertEquals(6, findDigitEndIndex("abc123def", 3));
+        assertEquals(6, findDigitEndIndex("abc123def", 5));
     }
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
@@ -155,8 +155,7 @@ public class AnnotationsApiController {
             matchedRG,
             genomicLocation,
             tumorType,
-            new HashSet<>(MainUtils.stringToEvidenceTypes(evidenceTypes, ",")),
-            this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(matchedRG)
+            new HashSet<>(MainUtils.stringToEvidenceTypes(evidenceTypes, ","))
         );
         return new ResponseEntity<>(indicatorQueryResp, HttpStatus.OK);
     }
@@ -190,14 +189,8 @@ public class AnnotationsApiController {
         if (body == null) {
             throw new ApiHttpErrorException("The request body is missing.", HttpStatus.BAD_REQUEST);
         } else {
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch37 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh37);
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch38 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh38);
             for (AnnotateMutationByGenomicChangeQuery query : body) {
-                Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch37;
-                if (ReferenceGenome.GRCh38.equals(query.getReferenceGenome())) {
-                    selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch38;
-                }
-                IndicatorQueryResp resp = this.getIndicatorQueryFromGenomicLocation(query.getReferenceGenome(), query.getGenomicLocation(), query.getTumorType(), query.getEvidenceTypes(), selectedEnsemblGenesMap);
+                IndicatorQueryResp resp = this.getIndicatorQueryFromGenomicLocation(query.getReferenceGenome(), query.getGenomicLocation(), query.getTumorType(), query.getEvidenceTypes());
                 resp.getQuery().setId(query.getId());
                 result.add(resp);
             }
@@ -236,8 +229,7 @@ public class AnnotationsApiController {
                 matchedRG,
                 hgvsg,
                 tumorType,
-                new HashSet<>(MainUtils.stringToEvidenceTypes(evidenceTypes, ",")),
-                this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(matchedRG)
+                new HashSet<>(MainUtils.stringToEvidenceTypes(evidenceTypes, ","))
             );
         }
         return new ResponseEntity<>(indicatorQueryResp, HttpStatus.OK);
@@ -261,19 +253,12 @@ public class AnnotationsApiController {
         if (body == null) {
             throw new ApiHttpErrorException("The request body is missing.", HttpStatus.BAD_REQUEST);
         } else {
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch37 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh37);
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch38 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh38);
             for (AnnotateMutationByHGVSgQuery query : body) {
-                Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch37;
-                if (ReferenceGenome.GRCh38.equals(query.getReferenceGenome())) {
-                    selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch38;
-                }
                 IndicatorQueryResp resp = this.getIndicatorQueryFromHGVSg(
                     query.getReferenceGenome(),
                     query.getHgvsg(),
                     query.getTumorType(),
-                    query.getEvidenceTypes(),
-                    selectedEnsemblGenesMap
+                    query.getEvidenceTypes()
                 );
                 resp.getQuery().setId(query.getId());
                 result.add(resp);
@@ -548,11 +533,10 @@ public class AnnotationsApiController {
         ReferenceGenome referenceGenome,
         String genomicLocation,
         String tumorType,
-        Set<EvidenceType> evidenceTypes,
-        Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromsomeEnsemblGeneMap
+        Set<EvidenceType> evidenceTypes
     ) throws ApiException, org.genome_nexus.ApiException {
         Alteration alteration;
-        if (!this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, genomicLocation, referenceGenome, chromsomeEnsemblGeneMap)) {
+        if (!this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, genomicLocation, referenceGenome)) {
             alteration = new Alteration();
         } else {
             alteration = this.cacheFetcher.getAlterationFromGenomeNexus(GNVariantAnnotationType.GENOMIC_LOCATION, referenceGenome, genomicLocation);
@@ -581,11 +565,10 @@ public class AnnotationsApiController {
         ReferenceGenome referenceGenome,
         String hgvsg,
         String tumorType,
-        Set<EvidenceType> evidenceTypes,
-        Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGeneMap
+        Set<EvidenceType> evidenceTypes
     ) throws ApiException, org.genome_nexus.ApiException {
         Alteration alteration;
-        if (!this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, hgvsg, referenceGenome, chromosomeEnsemblGeneMap)) {
+        if (!this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, hgvsg, referenceGenome)) {
             alteration = new Alteration();
         } else {
             alteration = this.cacheFetcher.getAlterationFromGenomeNexus(GNVariantAnnotationType.HGVS_G, referenceGenome, hgvsg);

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
@@ -383,7 +383,7 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
             String genomicQuery = StringUtils.isNullOrEmpty(hgvsg) ? genomicChange : hgvsg;
             GNVariantAnnotationType type = StringUtils.isNullOrEmpty(hgvsg) ? GNVariantAnnotationType.GENOMIC_LOCATION : GNVariantAnnotationType.HGVS_G;
             Alteration alterationModel;
-            if (!this.cacheFetcher.genomicLocationShouldBeAnnotated(type, genomicQuery, matchedRG, this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(matchedRG))) {
+            if (!this.cacheFetcher.genomicLocationShouldBeAnnotated(type, genomicQuery, matchedRG)) {
                 alterationModel = new Alteration();
             } else {
                 alterationModel = this.cacheFetcher.getAlterationFromGenomeNexus(type, matchedRG, genomicQuery);
@@ -592,14 +592,8 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
         if (body == null) {
             throw new ApiHttpErrorException("The request body is missing.", HttpStatus.BAD_REQUEST);
         } else {
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch37 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh37);
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch38 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh38);
             for (AnnotateMutationByHGVSgQuery query : body) {
-                Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch37;
-                if (ReferenceGenome.GRCh38.equals(query.getReferenceGenome())) {
-                    selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch38;
-                }
-                boolean shouldAnnotate = this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, query.getHgvsg(), query.getReferenceGenome(),selectedEnsemblGenesMap);
+                boolean shouldAnnotate = this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.HGVS_G, query.getHgvsg(), query.getReferenceGenome());
                 result.add(new TranscriptCoverageFilterResult(query.getHgvsg(), shouldAnnotate));
             }
         }
@@ -615,14 +609,8 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
         if (body == null) {
             throw new ApiHttpErrorException("The request body is missing.", HttpStatus.BAD_REQUEST);
         } else {
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch37 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh37);
-            Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> chromosomeEnsemblGenesGrch38 = this.cacheFetcher.getCanonicalEnsemblGenesByChromosome(ReferenceGenome.GRCh38);
             for (AnnotateMutationByGenomicChangeQuery query : body) {
-                Map<String, Set<org.oncokb.oncokb_transcript.client.EnsemblGene>> selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch37;
-                if (ReferenceGenome.GRCh38.equals(query.getReferenceGenome())) {
-                    selectedEnsemblGenesMap = chromosomeEnsemblGenesGrch38;
-                }
-                boolean shouldAnnotate = this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, query.getGenomicLocation(), query.getReferenceGenome(), selectedEnsemblGenesMap);
+                boolean shouldAnnotate = this.cacheFetcher.genomicLocationShouldBeAnnotated(GNVariantAnnotationType.GENOMIC_LOCATION, query.getGenomicLocation(), query.getReferenceGenome());
                 result.add(new TranscriptCoverageFilterResult(query.getGenomicLocation(), shouldAnnotate));
             }
         }


### PR DESCRIPTION
Related to https://github.com/oncokb/oncokb-pipeline/issues/553

### Before Improvements

#### Performance Benchmark
- WES - 13100 variants 31s (422 v/s); 1127 variants were within oncokb coverage (8%) 
- WGS - 1447800 variants: 1362s (1062v/s); 43993 variants were within oncokb coverage (3%) 
![image](https://github.com/user-attachments/assets/df868858-790c-49b2-828d-9a9701e829ce)

### After Improvements

#### Changes:
1. Create a `Map<String, Set<EnsemblGene>>`, where the key is the chromosome. This allows us to only search the set of EnsemblGenes for one chromosome and allows for short circuiting. There is no reason to check the range if the chromosome doesn’t match the query. 
2. For each reference genome, create two maps. This will reduce the size of Set<EnsemblGene> by ½. 
3. Eliminate the NototationConverter.hgvsgToGenomicLocation() call in oncokb core. It seems that this conversion is only used so that we can grab the chromosome and the start+end to check if there is a range intersect. This can be done without the use of regex.

#### Performance Benchmark
- WES – 13100 variants 25s (524v/s) 
- WGS – 1447800 variants: 1019s (1420v/s) 

![image](https://github.com/user-attachments/assets/dca66da4-8c83-4954-aeb1-b55931c4d3e7)

