### PR TITLE
Add GitHub Action to move unfinished tickets to next sprint

### DIFF
--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -3,7 +3,7 @@
 name: "Sprint Issues Rollover"
 
 on:
-  workflow_dispatch:
+  pull_request:
   # schedule:
   #     # Runs every Wednesday at 6pm EST
   #     - cron: '0 22 * * 3'

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -3,21 +3,22 @@
 name: "Sprint Issues Rollover"
 
 on:
-    schedule:
-        # Runs every Wednesday at 6pm EST
-        - cron: '0 22 * * 3'
+  workflow_dispatch:
+  # schedule:
+  #     # Runs every Wednesday at 6pm EST
+  #     - cron: '0 22 * * 3'
 
 jobs:
-    main:
-        name: Move to next week
-        runs-on: ubuntu-latest
-        steps:
-            - uses: blombard/move-to-next-iteration@master
-              with:
-                  owner: oncokb
-                  number: 3 # The project number as you see it in the URL
-                  token: ${{ secrets.PROJECT_PAT }} # Needs 'project' write perms
-                  iteration-field: Week
-                  iteration: current
-                  new-iteration: next
-                  excluded-statuses: ✅ Done
+  main:
+    name: Move to next week
+    runs-on: ubuntu-latest
+    steps:
+      - uses: blombard/move-to-next-iteration@master
+        with:
+          owner: oncokb
+          number: 3 # The project number as you see it in the URL
+          token: ${{ secrets.PROJECT_PAT }} # Needs 'project' write perms
+          iteration-field: Week
+          iteration: last
+          new-iteration: current
+          excluded-statuses: ✅ Done

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           owner: oncokb
           number: 3 # The project number as you see it in the URL
-          token: ${{ secrets.GITHUB_TOKEN }} # Needs 'project' write perms
+          token: ${{ secrets.PROJECT_PAT }} # Needs 'project' write perms
           iteration-field: Week
           iteration: last
           new-iteration: current

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -1,0 +1,23 @@
+# This workflow will move all unfinish tickets to the next sprint
+
+name: "Sprint Issues Rollover"
+
+on:
+    schedule:
+        # Runs every Wednesday at 6pm EST
+        - cron: '0 22 * * 3'
+
+jobs:
+    main:
+        name: Move to next week
+        runs-on: ubuntu-latest
+        steps:
+            - uses: blombard/move-to-next-iteration@master
+              with:
+                  owner: oncokb
+                  number: 3 # The project number as you see it in the URL
+                  token: ${{ secrets.PROJECT_PAT }} # Needs 'project' write perms
+                  iteration-field: Week
+                  iteration: current
+                  new-iteration: next
+                  excluded-statuses: ✅ Done

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           owner: oncokb
           number: 3 # The project number as you see it in the URL
-          token: ${{ secrets.PROJECT_PAT }} # Needs 'project' write perms
+          token: ${{ secrets.GITHUB_TOKEN }} # Needs 'project' write perms
           iteration-field: Week
           iteration: last
           new-iteration: current

--- a/.github/workflows/sprint-issues-rollover.yml
+++ b/.github/workflows/sprint-issues-rollover.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           owner: oncokb
           number: 3 # The project number as you see it in the URL
-          token: ${{ secrets.PROJECT_PAT }} # Needs 'project' write perms
+          token: ${{secrets.PROJECT_PAT}} # Needs 'project' write perms
           iteration-field: Week
           iteration: last
           new-iteration: current


### PR DESCRIPTION
Issue: We have to manually move tickets to next weeks sprint

Changes:
- Run github action every Wed 6pm EST to automatically move to next sprint

### Todo
- [x] Create a token that has full permissions to Github Projects (https://github.com/settings/tokens)
![token-gif](https://github.com/user-attachments/assets/b2dabb67-3fbd-44a7-b780-b52ff686f009)
- [x] Go to oncokb/oncokb -> Settings -> Secrets & Variables -> Actions -> Add new secret called `PROJECT_PAT`
![image](https://github.com/user-attachments/assets/580f3fb3-f566-45e2-84aa-5134bf512c23)
