### PR TITLE
Fix association variants save

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
@@ -9,7 +9,6 @@ import org.json.JSONObject;
 import org.mskcc.cbio.oncokb.bo.*;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.util.*;
-import org.mskcc.cbio.oncokb.bo.OncokbTranscriptService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -455,6 +454,8 @@ public class DriveAnnotationParser {
         String DESC_KEY = "description";
         String ALLELE_STATES_KEY = "allele_state";
 
+        EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
+
         for (int i = 0; i < genomicIndicators.length(); i++) {
             JSONObject genomicIndicator = genomicIndicators.getJSONObject(i);
 
@@ -475,7 +476,7 @@ public class DriveAnnotationParser {
                 JSONObject alleleStatesObject = genomicIndicator.getJSONObject(ALLELE_STATES_KEY);
                 evidence.setKnownEffect(Arrays.stream(ALLELE_STATE_CHECKS).filter(alleleState -> alleleStatesObject.has(alleleState) && StringUtils.isNotEmpty(alleleStatesObject.getString(alleleState))).collect(Collectors.joining(",")));
             }
-            ApplicationContextSingleton.getEvidenceBo().save(evidence);
+            evidenceBo.save(evidence);
         }
     }
 
@@ -486,15 +487,22 @@ public class DriveAnnotationParser {
             JSONObject associatedVariant = associatedVariants.getJSONObject(i);
             String name = associatedVariant.getString("name");
             String uuid = associatedVariant.getString("uuid");
-            Optional<Alteration> matchedOptional = alterations.stream().filter(alteration -> {
-                if (StringUtils.isNotEmpty(uuid)) {
-                    if (uuid.equals(alteration.getUuid())) return true;
+            List<Alteration> parsedAssociatedVariantList = AlterationUtils.parseMutationString(name, ",");
+            if (!parsedAssociatedVariantList.isEmpty()) {
+                // At this point, associated variant is a single variant, so we will get the first element from the mutation string parsing method.
+                name = parsedAssociatedVariantList.get(0).getName();
+            }
+            Optional<Alteration> matchedOptional = Optional.empty();
+            for (Alteration alteration : alterations) {
+                if (StringUtils.isNotEmpty(uuid) && uuid.equals(alteration.getUuid())) {
+                    matchedOptional = Optional.of(alteration);
+                    break;
                 }
-                if (StringUtils.isNotEmpty(name)) {
-                    if (name.toLowerCase().equals(alteration.getAlteration().toLowerCase())) return true;
+                if (StringUtils.isNotEmpty(name) && name.equalsIgnoreCase(alteration.getAlteration())) {
+                    matchedOptional = Optional.of(alteration);
+                    break;
                 }
-                return false;
-            }).findFirst();
+            }
             if (matchedOptional.isPresent()) {
                 mappedAlterations.add(matchedOptional.get());
             } else {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/DriveAnnotationParser.java
@@ -487,11 +487,7 @@ public class DriveAnnotationParser {
             JSONObject associatedVariant = associatedVariants.getJSONObject(i);
             String name = associatedVariant.getString("name");
             String uuid = associatedVariant.getString("uuid");
-            List<Alteration> parsedAssociatedVariantList = AlterationUtils.parseMutationString(name, ",");
-            if (!parsedAssociatedVariantList.isEmpty()) {
-                // At this point, associated variant is a single variant, so we will get the first element from the mutation string parsing method.
-                name = parsedAssociatedVariantList.get(0).getName();
-            }
+            name = AlterationUtils.trimComment(name);
             Optional<Alteration> matchedOptional = Optional.empty();
             for (Alteration alteration : alterations) {
                 if (StringUtils.isNotEmpty(uuid) && uuid.equals(alteration.getUuid())) {


### PR DESCRIPTION
Resolves https://github.com/oncokb/oncokb-pipeline/issues/653

The issue is that some germline variants are written as `c.123C>T (p.V12)`, where we have the protein change in the variant name. We need to parse out the protein change from the name, otherwise the genomic indicator is not able to be properly mapped to the alteration.