### PR TITLE
Update API version

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/Constants.java
@@ -1,14 +1,11 @@
 package org.mskcc.cbio.oncokb;
 
-import com.vdurmont.semver4j.Semver;
 import org.mskcc.cbio.oncokb.model.ReferenceGenome;
 import org.mskcc.cbio.oncokb.model.VariantConsequence;
 import org.mskcc.cbio.oncokb.util.VariantConsequenceUtils;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -24,8 +21,8 @@ public final class Constants {
     public static final String UPSTREAM_GENE = "upstream_gene_variant";
     public static final String PROTEIN_ALTERING_VARIANT = "protein_altering_variant";
 
-    public static final String PUBLIC_API_VERSION = "v1.4.1";
-    public static final String PRIVATE_API_VERSION = "v1.4.1";
+    public static final String PUBLIC_API_VERSION = "v1.5.0";
+    public static final String PRIVATE_API_VERSION = "v1.5.0";
 
     // Defaults
     public static final String SWAGGER_DEFAULT_DESCRIPTION="OncoKB, a comprehensive and curated precision oncology knowledge base, offers oncologists detailed, evidence-based information about individual somatic mutations and structural alterations present in patient tumors with the goal of supporting optimal treatment decisions.";


### PR DESCRIPTION
### Reasons for updating from v1.4.1 --> v1.5.0
1. Backfilled DEPRECATED API fields
2. Added new API fields (query.hgvsInfo, query.canonicalTranscript)
3. Added solid/liquidPropagationLevels to allActionableVariants file 