### PR TITLE
Update startup logs and add health endpoint

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/health/InMemoryCacheSizes.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/health/InMemoryCacheSizes.java
@@ -1,0 +1,103 @@
+package org.mskcc.cbio.oncokb.model.health;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class InMemoryCacheSizes {
+    private Integer genesCacheSize;
+    private Integer alterationsCacheSize;
+    private Integer drugsCacheSize;
+    private Integer cancerTypesCacheSize;
+    private Integer geneEvidencesCacheSize;
+
+
+    public InMemoryCacheSizes(Integer genesCacheSize, Integer alterationsCacheSize, Integer drugsCacheSize, Integer cancerTypesCacheSize, Integer geneEvidencesCacheSize) {
+        this.genesCacheSize = genesCacheSize;
+        this.alterationsCacheSize = alterationsCacheSize;
+        this.drugsCacheSize = drugsCacheSize;
+        this.cancerTypesCacheSize = cancerTypesCacheSize;
+        this.geneEvidencesCacheSize = geneEvidencesCacheSize;
+    }
+
+
+    public Integer getGenesCacheSize() {
+        return this.genesCacheSize;
+    }
+
+    public void setGenesCacheSize(Integer genesCacheSize) {
+        this.genesCacheSize = genesCacheSize;
+    }
+
+    public Integer getAlterationsCacheSize() {
+        return this.alterationsCacheSize;
+    }
+
+    public void setAlterationsCacheSize(Integer alterationsCacheSize) {
+        this.alterationsCacheSize = alterationsCacheSize;
+    }
+
+    public Integer getDrugsCacheSize() {
+        return this.drugsCacheSize;
+    }
+
+    public void setDrugsCacheSize(Integer drugsCacheSize) {
+        this.drugsCacheSize = drugsCacheSize;
+    }
+
+    public Integer getCancerTypesCacheSize() {
+        return this.cancerTypesCacheSize;
+    }
+
+    public void setCancerTypesCacheSize(Integer cancerTypesCacheSize) {
+        this.cancerTypesCacheSize = cancerTypesCacheSize;
+    }
+
+    public Integer getGeneEvidencesCacheSize() {
+        return this.geneEvidencesCacheSize;
+    }
+
+    public void setGeneEvidencesCacheSize(Integer geneEvidencesCacheSize) {
+        this.geneEvidencesCacheSize = geneEvidencesCacheSize;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        InMemoryCacheSizes that = (InMemoryCacheSizes) obj;
+        return Objects.equals(genesCacheSize, that.genesCacheSize) &&
+            Objects.equals(alterationsCacheSize, that.alterationsCacheSize) &&
+            Objects.equals(drugsCacheSize, that.drugsCacheSize) &&
+            Objects.equals(cancerTypesCacheSize, that.cancerTypesCacheSize) &&
+            Objects.equals(geneEvidencesCacheSize, that.geneEvidencesCacheSize);
+    }
+
+    public List<String> getDifferentCacheSizes(InMemoryCacheSizes other) {
+        List<String> differences = new ArrayList<>();
+        
+        if (other == null) {
+            differences.add("Other cache object is null");
+            return differences;
+        }
+    
+        if (!Objects.equals(this.genesCacheSize, other.genesCacheSize)) {
+            differences.add("Genes cache: Expected " + this.genesCacheSize + ", but is " + other.genesCacheSize);
+        }
+        if (!Objects.equals(this.alterationsCacheSize, other.alterationsCacheSize)) {
+            differences.add("Alterations cache: Expected " + this.alterationsCacheSize + ", but is " + other.alterationsCacheSize);
+        }
+        if (!Objects.equals(this.drugsCacheSize, other.drugsCacheSize)) {
+            differences.add("Drugs cache: Expected " + this.drugsCacheSize + ", but is " + other.drugsCacheSize);
+        }
+        if (!Objects.equals(this.cancerTypesCacheSize, other.cancerTypesCacheSize)) {
+            differences.add("Cancer Types cache: Expected " + this.cancerTypesCacheSize + ", but is " + other.cancerTypesCacheSize);
+        }
+        if (!Objects.equals(this.geneEvidencesCacheSize, other.geneEvidencesCacheSize)) {
+            differences.add("Gene-based Evidences cache: Expected " + this.geneEvidencesCacheSize + ", but is " + other.geneEvidencesCacheSize);
+        }
+    
+        return differences;
+    }
+
+}

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/CacheUtils.java
@@ -35,6 +35,7 @@ public class CacheUtils {
 
     private static List<DownloadAvailability> downloadAvailabilities = new ArrayList<>();
 
+    private static Integer allEvidencesSize;
 
     // Cache data from database
     private static Set<Gene> genes = new HashSet<>();
@@ -138,7 +139,7 @@ public class CacheUtils {
             alterations.values().stream().mapToInt(List::size).sum(),
             drugs.size(),
             cancerTypes.size(),
-            evidences.size()
+            allEvidencesSize
         );
     }
 
@@ -217,7 +218,7 @@ public class CacheUtils {
 
             current = MainUtils.getCurrentTimestamp();
             synEvidences();
-            System.out.println("Cached all evidences " + CacheUtils.getCacheCompletionMessage(current));
+            System.out.println("Cached " + allEvidencesSize + " evidences " + CacheUtils.getCacheCompletionMessage(current));
             current = MainUtils.getCurrentTimestamp();
 
             for (Map.Entry<Integer, List<Evidence>> entry : evidences.entrySet()) {
@@ -644,10 +645,10 @@ public class CacheUtils {
 
     private static void cacheAllEvidencesByGenes() {
         Long current = MainUtils.getCurrentTimestamp();
+        List<Evidence> allEvidences = ApplicationContextSingleton.getEvidenceBo().findAll();
+        allEvidencesSize = allEvidences.size();
 
-        Map<Gene, List<Evidence>> mappedEvidence =
-            EvidenceUtils.separateEvidencesByGene(genes, new HashSet<>(
-                ApplicationContextSingleton.getEvidenceBo().findAll()));
+        Map<Gene, List<Evidence>> mappedEvidence = EvidenceUtils.separateEvidencesByGene(genes, new HashSet<>(allEvidences));
         Iterator it = mappedEvidence.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<Gene, List<Evidence>> pair = (Map.Entry) it.next();

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -263,7 +263,7 @@ public class UtilsApiController implements UtilsApi {
         return new ResponseEntity<>(sb.toString(), HttpStatus.OK);
     }
 
-    private List<ActionableGene> getAllActionableVariants(Boolean isTextFile) {
+    public List<ActionableGene> getAllActionableVariants(Boolean isTextFile) {
         List<ActionableGene> actionableGeneList = new ArrayList<>();
         Set<Gene> genes = CacheUtils.getAllGenes();
         Map<Gene, Set<ClinicalVariant>> map = new HashMap<>();

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -204,7 +204,7 @@ public class UtilsApiController implements UtilsApi {
         if (version != null) {
             return getDataDownloadResponseEntity(version, FileName.ALL_ACTIONABLE_VARIANTS, FileExtension.JSON);
         }
-        return new ResponseEntity<>(getAllActionableVariants(false), HttpStatus.OK);
+        return new ResponseEntity<>(AlterationUtils.getAllActionableVariants(false), HttpStatus.OK);
     }
 
     @Override
@@ -238,7 +238,7 @@ public class UtilsApiController implements UtilsApi {
         sb.append(MainUtils.listToString(header, separator));
         sb.append(newLine);
 
-        for (ActionableGene actionableGene : getAllActionableVariants(true)) {
+        for (ActionableGene actionableGene : AlterationUtils.getAllActionableVariants(true)) {
             List<String> row = new ArrayList<>();
             row.add(actionableGene.getGrch37Isoform());
             row.add(actionableGene.getGrch37RefSeq());
@@ -263,91 +263,6 @@ public class UtilsApiController implements UtilsApi {
         return new ResponseEntity<>(sb.toString(), HttpStatus.OK);
     }
 
-    public List<ActionableGene> getAllActionableVariants(Boolean isTextFile) {
-        List<ActionableGene> actionableGeneList = new ArrayList<>();
-        Set<Gene> genes = CacheUtils.getAllGenes();
-        Map<Gene, Set<ClinicalVariant>> map = new HashMap<>();
-
-        for (Gene gene : genes) {
-            map.put(gene, MainUtils.getClinicalVariants(gene));
-        }
-
-        Set<ActionableGene> actionableGenes = new HashSet<>();
-        for (Map.Entry<Gene, Set<ClinicalVariant>> entry : map.entrySet()) {
-            Gene gene = entry.getKey();
-            for (ClinicalVariant clinicalVariant : entry.getValue()) {
-                Set<ArticleAbstract> articleAbstracts = clinicalVariant.getDrugAbstracts();
-                List<String> abstracts = new ArrayList<>();
-                for (ArticleAbstract articleAbstract : articleAbstracts) {
-                    abstracts.add(articleAbstract.getAbstractContent() + " " + articleAbstract.getLink());
-                }
-
-                if (clinicalVariant.getExcludedCancerTypes().size() > 0) {
-                    String cancerTypeName = TumorTypeUtils.getTumorTypesNameWithExclusion(clinicalVariant.getCancerTypes(), clinicalVariant.getExcludedCancerTypes());
-                    // for any clinical variant that has cancer type excluded, we no longer list the cancer types separately
-                    actionableGenes.add(new ActionableGene(
-                        gene.getGrch37Isoform(), gene.getGrch37RefSeq(),
-                        gene.getGrch38Isoform(), gene.getGrch38RefSeq(),
-                        gene.getEntrezGeneId(),
-                        gene.getHugoSymbol(),
-                        clinicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
-                        clinicalVariant.getVariant().getName(),
-                        clinicalVariant.getVariant().getAlteration(),
-                        cancerTypeName,
-                        clinicalVariant.getLevel(),
-                        clinicalVariant.getSolidPropagationLevel(),
-                        clinicalVariant.getLiquidPropagationLevel(),
-                        MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrug()), ", ", true),
-                        MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrugPmids()), ", ", true),
-                        MainUtils.listToString(abstracts, "; ", true),
-                        CplUtils.annotate(
-                            clinicalVariant.getDrugDescription(),
-                            gene.getHugoSymbol(),
-                            clinicalVariant.getVariant().getName(),
-                            cancerTypeName,
-                            null,
-                            gene,
-                            null,
-                            isTextFile
-                        )
-                    ));
-                } else {
-                    for (TumorType tumorType : clinicalVariant.getCancerTypes()) {
-                        actionableGenes.add(new ActionableGene(
-                            gene.getGrch37Isoform(), gene.getGrch37RefSeq(),
-                            gene.getGrch38Isoform(), gene.getGrch38RefSeq(),
-                            gene.getEntrezGeneId(),
-                            gene.getHugoSymbol(),
-                            clinicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
-                            clinicalVariant.getVariant().getName(),
-                            clinicalVariant.getVariant().getAlteration(),
-                            TumorTypeUtils.getTumorTypeName(tumorType),
-                            clinicalVariant.getLevel(),
-                            clinicalVariant.getSolidPropagationLevel(),
-                            clinicalVariant.getLiquidPropagationLevel(),
-                            MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrug()), ", ", true),
-                            MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrugPmids()), ", ", true),
-                            MainUtils.listToString(abstracts, "; ", true),
-                            CplUtils.annotate(
-                                clinicalVariant.getDrugDescription(),
-                                gene.getHugoSymbol(),
-                                clinicalVariant.getVariant().getName(),
-                                TumorTypeUtils.getTumorTypeName(tumorType),
-                                null,
-                                gene,
-                                tumorType,
-                                isTextFile
-                            )
-                        ));
-                    }
-                }
-            }
-        }
-
-        actionableGeneList.addAll(actionableGenes);
-        MainUtils.sortActionableVariants(actionableGeneList);
-        return actionableGeneList;
-    }
 
     @Override
     public ResponseEntity<List<CancerGene>> utilsCancerGeneListGet(

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/HealthController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/HealthController.java
@@ -1,8 +1,8 @@
 package org.mskcc.cbio.oncokb.controller;
 
-import org.mskcc.cbio.oncokb.api.pub.v1.UtilsApiController;
 import org.mskcc.cbio.oncokb.apiModels.ActionableGene;
 import org.mskcc.cbio.oncokb.model.health.InMemoryCacheSizes;
+import org.mskcc.cbio.oncokb.util.AlterationUtils;
 import org.mskcc.cbio.oncokb.util.ApplicationContextSingleton;
 import org.mskcc.cbio.oncokb.util.CacheUtils;
 import org.slf4j.Logger;
@@ -55,8 +55,7 @@ public class HealthController {
     }
 
     private Boolean checkActionableGenesResponse() {
-        UtilsApiController utilsApiController = new UtilsApiController();
-        List<ActionableGene> actionableVariants = utilsApiController.getAllActionableVariants(false);
+        List<ActionableGene> actionableVariants = AlterationUtils.getAllActionableVariants(false);
         Boolean result = !actionableVariants.isEmpty();
         if (result == false) {
             LOGGER.debug("Failed get actionable genes check");

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/HealthController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/HealthController.java
@@ -1,0 +1,53 @@
+package org.mskcc.cbio.oncokb.controller;
+
+
+import org.mskcc.cbio.oncokb.model.Evidence;
+import org.mskcc.cbio.oncokb.model.Gene;
+import org.mskcc.cbio.oncokb.model.health.InMemoryCacheSizes;
+import org.mskcc.cbio.oncokb.util.ApplicationContextSingleton;
+import org.mskcc.cbio.oncokb.util.CacheUtils;
+import org.mskcc.cbio.oncokb.util.EvidenceUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Controller
+@RequestMapping("/health")
+public class HealthController {
+
+    /**
+     * Checks if the in-memory caches initilized during application startup is consistent.
+     * @return true if the cache size is consistent, otherwise false
+     */
+    @GetMapping("/cache-size")
+    public ResponseEntity<Void> checkInMemoryCacheSizes() {
+        // Re-fetch MySQL data
+        Set<Gene> reloadedGenes = new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll());
+        Integer reloadedGeneCacheSize = (new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll())).size();
+        Integer reloadedAlterationCacheSize = ApplicationContextSingleton.getAlterationBo().findAll().size();
+        Integer reloadedDrugCacheSize = new HashSet<>(ApplicationContextSingleton.getDrugBo().findAll()).size();
+        Integer reloadedCancerTypeCacheSize = ApplicationContextSingleton.getTumorTypeBo().findAll().size();
+
+        Map<Gene, List<Evidence>> mappedEvidence = EvidenceUtils.separateEvidencesByGene(reloadedGenes, new HashSet<>(ApplicationContextSingleton.getEvidenceBo().findAll()));
+        Integer reloadedGeneEvidenceCacheSize = mappedEvidence.size();
+
+        InMemoryCacheSizes reloadedCacheSize = new InMemoryCacheSizes(reloadedGeneCacheSize, reloadedAlterationCacheSize, reloadedDrugCacheSize, reloadedCancerTypeCacheSize, reloadedGeneEvidenceCacheSize);
+
+        // Compare with sizes of current in-memory caches in CacheUtils.java
+        InMemoryCacheSizes currentCacheSizes = CacheUtils.getCurrentCacheSizes();
+
+        List<String> invalidCacheNames = reloadedCacheSize.getDifferentCacheSizes(currentCacheSizes);
+        if (!invalidCacheNames.isEmpty()) {
+            System.out.println(String.join("\n", invalidCacheNames));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/HealthController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/HealthController.java
@@ -1,26 +1,23 @@
 package org.mskcc.cbio.oncokb.controller;
 
-
-import org.mskcc.cbio.oncokb.model.Evidence;
-import org.mskcc.cbio.oncokb.model.Gene;
 import org.mskcc.cbio.oncokb.model.health.InMemoryCacheSizes;
 import org.mskcc.cbio.oncokb.util.ApplicationContextSingleton;
 import org.mskcc.cbio.oncokb.util.CacheUtils;
-import org.mskcc.cbio.oncokb.util.EvidenceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @Controller
-@RequestMapping("/health")
+@RequestMapping("/v1/health")
 public class HealthController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthController.class);
 
     /**
      * Checks if the in-memory caches initilized during application startup is consistent.
@@ -29,23 +26,20 @@ public class HealthController {
     @GetMapping("/cache-size")
     public ResponseEntity<Void> checkInMemoryCacheSizes() {
         // Re-fetch MySQL data
-        Set<Gene> reloadedGenes = new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll());
-        Integer reloadedGeneCacheSize = (new HashSet<>(ApplicationContextSingleton.getGeneBo().findAll())).size();
-        Integer reloadedAlterationCacheSize = ApplicationContextSingleton.getAlterationBo().findAll().size();
-        Integer reloadedDrugCacheSize = new HashSet<>(ApplicationContextSingleton.getDrugBo().findAll()).size();
-        Integer reloadedCancerTypeCacheSize = ApplicationContextSingleton.getTumorTypeBo().findAll().size();
+        Integer reloadedGeneCacheSize = ApplicationContextSingleton.getGeneBo().countAll();
+        Integer reloadedAlterationCacheSize = ApplicationContextSingleton.getAlterationBo().countAll();
+        Integer reloadedDrugCacheSize = ApplicationContextSingleton.getDrugBo().countAll();
+        Integer reloadedCancerTypeCacheSize = ApplicationContextSingleton.getTumorTypeBo().countAll();
+        Integer reloadedEvidenceCacheSize = ApplicationContextSingleton.getEvidenceBo().countAll();
 
-        Map<Gene, List<Evidence>> mappedEvidence = EvidenceUtils.separateEvidencesByGene(reloadedGenes, new HashSet<>(ApplicationContextSingleton.getEvidenceBo().findAll()));
-        Integer reloadedGeneEvidenceCacheSize = mappedEvidence.size();
-
-        InMemoryCacheSizes reloadedCacheSize = new InMemoryCacheSizes(reloadedGeneCacheSize, reloadedAlterationCacheSize, reloadedDrugCacheSize, reloadedCancerTypeCacheSize, reloadedGeneEvidenceCacheSize);
+        InMemoryCacheSizes reloadedCacheSize = new InMemoryCacheSizes(reloadedGeneCacheSize, reloadedAlterationCacheSize, reloadedDrugCacheSize, reloadedCancerTypeCacheSize, reloadedEvidenceCacheSize);
 
         // Compare with sizes of current in-memory caches in CacheUtils.java
         InMemoryCacheSizes currentCacheSizes = CacheUtils.getCurrentCacheSizes();
 
         List<String> invalidCacheNames = reloadedCacheSize.getDifferentCacheSizes(currentCacheSizes);
         if (!invalidCacheNames.isEmpty()) {
-            System.out.println(String.join("\n", invalidCacheNames));
+            LOGGER.debug(String.join("\n", invalidCacheNames));
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
         return ResponseEntity.ok().build();

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -40,7 +40,7 @@
         <url-pattern>/api/v1/*</url-pattern>
         <url-pattern>/api/private/*</url-pattern>
         <url-pattern>/legacy-api</url-pattern>
-        <url-pattern>/health</url-pattern>
+        <url-pattern>/v1/health</url-pattern>
 	</servlet-mapping>
     <servlet>
         <servlet-name>PublicSinglePage</servlet-name>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -40,6 +40,7 @@
         <url-pattern>/api/v1/*</url-pattern>
         <url-pattern>/api/private/*</url-pattern>
         <url-pattern>/legacy-api</url-pattern>
+        <url-pattern>/health</url-pattern>
 	</servlet-mapping>
     <servlet>
         <servlet-name>PublicSinglePage</servlet-name>


### PR DESCRIPTION
Resolves https://github.com/oncokb/oncokb/issues/3869

### Changes
Add a health endpoint that fetches the data from MySQL again and compares it with the in-memory caches populated during app startup.


```
## Output from logs when health endpoint fails

Genes cache: Expected 906, but is 914
Alterations cache: Expected 19260, but is 19277
Drugs cache: Expected 148, but is 149
Gene-based Evidences cache: Expected 906, but is 914
```