### PR TITLE
Allow Genome Nexus and OncoKB Transcript API timeouts to be configurable

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/OncokbTranscriptService.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/OncokbTranscriptService.java
@@ -33,7 +33,7 @@ public class OncokbTranscriptService {
 
     public OncokbTranscriptService() {
         this.client = Configuration.getDefaultApiClient();
-        String timeoutProperty = PropertiesUtils.getProperties("genome_nexus.api_timeout");
+        String timeoutProperty = PropertiesUtils.getProperties("oncokb_transcript.api_timeout");
         Integer timeout = StringUtils.isNumeric(timeoutProperty) ? Integer.parseInt(timeoutProperty) : DEFAULT_TIMEOUT;
         this.client.setConnectTimeout(timeout);
         this.client.setReadTimeout(timeout);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/OncokbTranscriptService.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/OncokbTranscriptService.java
@@ -24,7 +24,7 @@ public class OncokbTranscriptService {
     private static final String ONCOKB_TRANSCRIPT_URL = "https://transcript.oncokb.org";
 
     private ApiClient client;
-    private final int TIMEOUT = 30000;
+    private final int DEFAULT_TIMEOUT = 30000;
     private final String SEQUENCE_TYPE = "PROTEIN";
     private Boolean enabled = false;
 
@@ -33,8 +33,10 @@ public class OncokbTranscriptService {
 
     public OncokbTranscriptService() {
         this.client = Configuration.getDefaultApiClient();
-        this.client.setConnectTimeout(TIMEOUT);
-        this.client.setReadTimeout(TIMEOUT);
+        String timeoutProperty = PropertiesUtils.getProperties("genome_nexus.api_timeout");
+        Integer timeout = StringUtils.isNumeric(timeoutProperty) ? Integer.parseInt(timeoutProperty) : DEFAULT_TIMEOUT;
+        this.client.setConnectTimeout(timeout);
+        this.client.setReadTimeout(timeout);
         this.client.setBasePath(getOncokbTranscriptUrl());
 
         String oncokbTranscriptToken = PropertiesUtils.getProperties("oncokb_transcript.token");

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/GenomeNexusUtils.java
@@ -39,7 +39,7 @@ public class GenomeNexusUtils {
 
     private static final String GN_37_URL = "https://www.genomenexus.org";
     private static final String GN_38_URL = "https://grch38.genomenexus.org";
-    private static final int GN_READ_TIMEOUT_OVERRIDE = 30000;
+    private static final int DEFAULT_TIMEOUT = 30000;
 
     public static String getEnsemblSequencePOSTUrl(ReferenceGenome referenceGenome) {
         return getEnsemblAPIUrl(referenceGenome) + "/sequence/id";
@@ -78,7 +78,9 @@ public class GenomeNexusUtils {
 
     private static ApiClient getGNApiClient(String url) {
         ApiClient client = new ApiClient();
-        client.setReadTimeout(GN_READ_TIMEOUT_OVERRIDE);
+        String timeoutProperty = PropertiesUtils.getProperties("genome_nexus.api_timeout");
+        Integer timeout = StringUtils.isNumeric(timeoutProperty) ? Integer.parseInt(timeoutProperty) : DEFAULT_TIMEOUT;
+        client.setReadTimeout(timeout);
         client.setBasePath(url);
         return client;
     }

--- a/core/src/main/resources/properties-EXAMPLE/config.properties
+++ b/core/src/main/resources/properties-EXAMPLE/config.properties
@@ -29,6 +29,10 @@ genome_nexus.grch38.url=https://grch38.genomenexus.org
 
 # Optional properties
 
+# External API timeouts in milliseconds
+genome_nexus.api_timeout=30000
+oncokb_transcript.api_timeout=30000
+
 #Name of application
 app.name=
 


### PR DESCRIPTION
Resolves https://github.com/oncokb/oncokb/issues/3875

### Changes
Add two additional spring properties that configures the api client timeouts for GN and Transcript services.
A timeout of `0` indicated no timeout