### PR TITLE
Get all genomic indicators by gene AND alteration name starting with Pathogenic variants

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -1334,7 +1334,7 @@ public final class AlterationUtils {
         return findAlterationsByStartWith(StructuralAlteration.FUSIONS.getVariant(), fullAlterations);
     }
 
-    private static boolean startsWithIgnoreCase(String url, String param) {
+    public static boolean startsWithIgnoreCase(String url, String param) {
         return url.regionMatches(true, 0, param, 0, param.length());
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -326,8 +326,14 @@ public class EvidenceUtils {
         return genomicIndicatorEvis;
     }
 
-    public static List<Evidence> getGenomicIndicatorAssociatedWithPathogenicVariants(Gene gene, String alleleState) {
-        List<Evidence> genomicIndicatorEvis = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENOMIC_INDICATOR)).stream().collect(Collectors.toList());
+    public static List<Evidence> getGenomicIndicatorAssociatedWithPathogenicVariants(Gene gene, ReferenceGenome referenceGenome, String alleleState) {
+        List<Alteration> pathogenicAlterations = AlterationUtils
+            .getAllAlterations(referenceGenome, gene)
+            .stream().filter(alt -> {
+                return alt.getAlteration() != null && AlterationUtils.startsWithIgnoreCase(alt.getAlteration(), InferredMutation.PATHOGENIC_VARIANTS.getVariant());
+            })
+            .collect(Collectors.toList());
+        List<Evidence> genomicIndicatorEvis = evidenceBo.findEvidencesByAlteration(pathogenicAlterations, Collections.singleton(EvidenceType.GENOMIC_INDICATOR));
         if (StringUtils.isNotEmpty(alleleState)) {
             genomicIndicatorEvis = genomicIndicatorEvis.stream().filter(evidence -> StringUtils.isEmpty(evidence.getKnownEffect()) || evidence.getKnownEffect().toLowerCase().contains(alleleState)).collect(Collectors.toList());
         }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -328,7 +328,7 @@ public class IndicatorUtils {
             if (query.isGermline() && !indicatorQuery.getVariantExist() && query.getPathogenicity() != null) {
                 if (query.getPathogenicity().equals(Pathogenicity.YES) || query.getPathogenicity().equals(Pathogenicity.LIKELY)) {
                     GermlineVariant germlineVariant = new GermlineVariant();
-                    List<Evidence> genomicIndicatorEvis = EvidenceUtils.getGenomicIndicatorAssociatedWithPathogenicVariants(gene, query.getAlleleState());
+                    List<Evidence> genomicIndicatorEvis = EvidenceUtils.getGenomicIndicatorAssociatedWithPathogenicVariants(gene, query.getReferenceGenome(), query.getAlleleState());
                     germlineVariant.setGenomicIndicators(genomicIndicatorEvis.stream().map(Evidence::getName).collect(Collectors.toList()));
                     indicatorQuery.setGermline(germlineVariant);
                 }


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/683

If a variant does not exist, but the user indicates through request param that it is P/LP, then we should return all the genomic indicators that starts with "Pathogenic Variants". 