### PR TITLE
Use curated mutation summary instead of generated if available

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
@@ -257,7 +257,7 @@ public class SummaryUtils {
             return ONCOGENIC_MUTATIONS_DEFAULT_SUMMARY;
         }
         EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
-        // Use the curated mutation summary if exists to override the generated summary only for the excact mutation. Subject to change
+        // Use the curated mutation summary if exists to override the generated summary only for the exact mutation. Subject to change
         List<Evidence> mutationSummaryList = evidenceBo.findEvidencesByAlteration(Collections.singleton(exactMatchAlteration), Collections.singleton(EvidenceType.MUTATION_SUMMARY));
         if (mutationSummaryList.size() > 0) {
             String mutationSummary = mutationSummaryList.iterator().next().getDescription();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
@@ -257,6 +257,7 @@ public class SummaryUtils {
             return ONCOGENIC_MUTATIONS_DEFAULT_SUMMARY;
         }
         EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
+        // Use the curated mutation summary if exists to override the generated summary only for the excact mutation. Subject to change
         List<Evidence> mutationSummaryList = evidenceBo.findEvidencesByAlteration(Collections.singleton(exactMatchAlteration), Collections.singleton(EvidenceType.MUTATION_SUMMARY));
         if (mutationSummaryList.size() > 0) {
             String mutationSummary = mutationSummaryList.iterator().next().getDescription();

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
@@ -2,8 +2,8 @@ package org.mskcc.cbio.oncokb.util;
 
 import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.mskcc.cbio.oncokb.bo.EvidenceBo;
 import org.mskcc.cbio.oncokb.model.*;
-import org.mskcc.cbio.oncokb.model.TumorType;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -255,6 +255,14 @@ public class SummaryUtils {
     public static String variantSummary(Gene gene, Alteration exactMatchAlteration, List<Alteration> alterations, Query query) {
         if (!StringUtils.isEmpty(query.getAlteration()) && query.getAlteration().toLowerCase().startsWith(InferredMutation.ONCOGENIC_MUTATIONS.getVariant().toLowerCase())) {
             return ONCOGENIC_MUTATIONS_DEFAULT_SUMMARY;
+        }
+        EvidenceBo evidenceBo = ApplicationContextSingleton.getEvidenceBo();
+        List<Evidence> mutationSummaryList = evidenceBo.findEvidencesByAlteration(Collections.singleton(exactMatchAlteration), Collections.singleton(EvidenceType.MUTATION_SUMMARY));
+        if (mutationSummaryList.size() > 0) {
+            String mutationSummary = mutationSummaryList.iterator().next().getDescription();
+            if (StringUtils.isNotEmpty(mutationSummary)) {
+                return mutationSummary;
+            }
         }
         return getOncogenicSummarySubFunc(gene, exactMatchAlteration, alterations, query);
     }


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb/issues/3794

### Todo:
- [x] How should generated summary in T315G if we override the default summary for T315I?
![image](https://github.com/user-attachments/assets/46a32740-8d1c-4042-96d7-b7d289bec445)
![image](https://github.com/user-attachments/assets/a3f33851-2176-4e3e-85a7-f345f5bd5faf)
   - We decided to continue using generated summary for T315G for the time being

