### PR TITLE
Fix validation check inserting duplicate entries into MySQL

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceUtils.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.mskcc.cbio.oncokb.bo.AlterationBo;
 import org.mskcc.cbio.oncokb.bo.ArticleBo;
 import org.mskcc.cbio.oncokb.bo.EvidenceBo;
@@ -516,6 +518,18 @@ public class EvidenceUtils {
         return result;
     }
 
+    public static Set<String> getPmids(JSONObject evidence) {
+        Set<String> result = new HashSet<>();
+        JSONArray articles = evidence.getJSONArray("articles");
+        for (int i =0; i<articles.length(); i++) {
+            JSONObject article = articles.getJSONObject(i);
+            if (article.optString("pmid", null) != null) {
+                result.add(article.getString("pmid"));
+            }
+        }
+        return result;
+    }
+
     public static Set<ArticleAbstract> getAbstracts(Set<Evidence> evidences) {
         Set<ArticleAbstract> result = new HashSet<>();
 
@@ -527,6 +541,21 @@ public class EvidenceUtils {
                     articleAbstract.setLink(article.getLink());
                     result.add(articleAbstract);
                 }
+            }
+        }
+        return result;
+    }
+
+    public static Set<ArticleAbstract> getAbstracts(JSONObject evidence) {
+        Set<ArticleAbstract> result = new HashSet<>();
+        JSONArray articles = evidence.getJSONArray("articles");
+        for (int i =0; i<articles.length(); i++) {
+            JSONObject article = articles.getJSONObject(i);
+            if (!StringUtils.isEmpty(article.optString("abstract", null))) {
+                ArticleAbstract articleAbstract = new ArticleAbstract();
+                articleAbstract.setAbstractContent(article.getString("abstract"));
+                articleAbstract.setLink(article.optString("link", null));
+                result.add(articleAbstract);
             }
         }
         return result;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/TreatmentUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/TreatmentUtils.java
@@ -6,7 +6,11 @@
 
 package org.mskcc.cbio.oncokb.util;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.mskcc.cbio.oncokb.model.*;
+
+import com.google.gdata.util.common.base.StringUtil;
 
 import java.util.*;
 
@@ -59,6 +63,11 @@ public final class TreatmentUtils {
         return MainUtils.listToString(treatmentNames, ", ");
     }
 
+    public static String getTreatmentName(JSONArray treatments) {
+        List<String> treatmentNames = getTreatments(treatments);
+        return MainUtils.listToString(treatmentNames, ", ");
+    }
+
     public static List<Treatment> sortTreatmentsByName(List<Treatment> treatments) {
         Collections.sort(treatments, new Comparator<Treatment>() {
             public int compare(Treatment t1, Treatment t2) {
@@ -76,7 +85,6 @@ public final class TreatmentUtils {
         List<String> treatmentNames = new ArrayList<>();
         List<Treatment> sortedTreatment = new ArrayList<>(treatments);
         sortTreatmentsByPriority(sortedTreatment);
-
         for (Treatment treatment : sortedTreatment) {
             List<String> drugNames = new ArrayList<>();
             for (Drug drug : treatment.getDrugs()) {
@@ -86,6 +94,39 @@ public final class TreatmentUtils {
             }
             treatmentNames.add(MainUtils.listToString(drugNames, "+"));
         }
+        return treatmentNames;
+    }
+
+    public static List<String> getTreatments(JSONArray treatments) {
+        List<String> treatmentNames = new ArrayList<>();
+
+        List<JSONObject> sortedTreatments = new ArrayList<>();
+        for (int i = 0; i < treatments.length(); i++) {
+            sortedTreatments.add(treatments.getJSONObject(i));
+        }
+
+        sortedTreatments.sort(Comparator.comparingInt(t -> t.optInt("priority", Integer.MAX_VALUE)));
+    
+        for (JSONObject treatment : sortedTreatments) {
+            JSONArray drugs = treatment.getJSONArray("drugs");
+    
+            List<JSONObject> sortedDrugs = new ArrayList<>();
+            for (int j = 0; j < drugs.length(); j++) {
+                sortedDrugs.add(drugs.getJSONObject(j));
+            }
+            sortedDrugs.sort(Comparator.comparingInt(drug -> drug.optInt("priority", Integer.MAX_VALUE)));
+    
+            List<String> drugNames = new ArrayList<>();
+            for (JSONObject drug : sortedDrugs) {
+                String name = drug.optString("drugName", null);
+                if (!StringUtil.isEmpty(name)) {
+                    drugNames.add(name.trim());
+                }
+            }
+    
+            treatmentNames.add(MainUtils.listToString(drugNames, "+"));
+        }
+        
         return treatmentNames;
     }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/TumorTypeUtils.java
@@ -6,6 +6,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.mskcc.cbio.oncokb.model.*;
 import org.mskcc.cbio.oncokb.model.clinicalTrialsMathcing.Tumor;
 
@@ -312,17 +314,58 @@ public class TumorTypeUtils {
         }
     }
 
+    public static String getTumorTypeName(JSONObject tumorType) {
+        if (tumorType == null) {
+            return "";
+        } else {
+
+            if (!StringUtils.isEmpty(tumorType.getString("subtype"))) {
+                return tumorType.getString("subtype");
+            } else if (!StringUtils.isEmpty(tumorType.getString("mainType"))) {
+                return tumorType.getString("mainType");
+            } else{
+                return "";
+            }
+        }
+    }
+
     public static String getTumorTypesName(Collection<TumorType> tumorTypes) {
         return tumorTypes.stream().map(tumorType -> getTumorTypeName(tumorType)).collect(Collectors.joining(", "));
+    }
+
+    public static String getTumorTypesName(JSONArray tumorTypes) {
+        List<String> tumorTypeNames = new ArrayList<>();
+        for (int i=0; i<tumorTypes.length(); i++) {
+            JSONObject tumorType = tumorTypes.getJSONObject(i);
+            tumorTypeNames.add(getTumorTypeName(tumorType));
+        }
+        return tumorTypeNames.stream().collect(Collectors.joining(", "));
     }
 
     public static String getEvidenceTumorTypesName(Evidence evidence) {
         return getTumorTypesNameWithExclusion(evidence.getCancerTypes(), evidence.getExcludedCancerTypes());
     }
 
+    public static String getEvidenceTumorTypesName(JSONObject evidence) {
+        JSONArray cancerTypes = evidence.getJSONArray("cancerTypes");
+        JSONArray excludedCancerTypes = evidence.getJSONArray("excludedCancerTypes");
+
+        return getTumorTypesNameWithExclusion(cancerTypes, excludedCancerTypes);
+    }
+
     public static String getTumorTypesNameWithExclusion(Collection<TumorType> tumorTypes, Collection<TumorType> excludedTumorTypes) {
         StringBuilder sb = new StringBuilder(getTumorTypesName(tumorTypes));
         if (excludedTumorTypes != null && excludedTumorTypes.size() > 0) {
+            sb.append(" (excluding ");
+            sb.append(getTumorTypesName(excludedTumorTypes));
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+
+    public static String getTumorTypesNameWithExclusion(JSONArray tumorTypes, JSONArray excludedTumorTypes) {
+        StringBuilder sb = new StringBuilder(getTumorTypesName(tumorTypes));
+        if (excludedTumorTypes != null && excludedTumorTypes.length() > 0) {
             sb.append(" (excluding ");
             sb.append(getTumorTypesName(excludedTumorTypes));
             sb.append(")");


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/719

TLDR; Issue is that when deserializing JSON in Evidence entity, hibernate will automatically flush the entities into the database because by default flushMode=auto. To avoid this, we are going to read directly from the JSONArray instead of deserializing into entity object.

![image](https://github.com/user-attachments/assets/e8ebf55a-97a8-4998-890f-a97c771caddc)
The test `Whether evidence description has outdate content` is now passing. Also fixed `Whether any actionable variants are not oncogenic, likely oncogenic or resistant`.
To fix this in production, we should:
1. Remove Vemurafenib, Dabrafenib, D1, and D2 drugs from the drugs table. These were added by the mvn test and were never cleaned up. You can find these by `WHERE d.ncit_code is null`
2. Refresh the staging with `full.sql`.
