### PR TITLE
Fix TumorType swagger model

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/TumorType.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/TumorType.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.Objects;
 
 
-@ApiModel(description = "OncoTree Detailed Cancer Type. See https://oncotree.mskcc.org/?version=oncotree_2019_12_01")
+@ApiModel(description = "OncoTree Detailed Cancer Type. See https://oncotree.mskcc.org/?version=oncotree_2019_12_01", value="TumorType")
 public class TumorType implements Serializable {
 
     @ApiModelProperty(value = "Database TumorType ID")

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/TumorType.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/TumorType.java
@@ -20,7 +20,7 @@ import java.util.*;
 
 @Entity
 @Table(name = "cancer_type")
-@ApiModel(description = "OncoTree Detailed Cancer Type")
+@ApiModel(description = "OncoTree Detailed Cancer Type", value="TumorTypeEntity")
 public class TumorType implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
Related to https://github.com/oncokb/oncokb-transcript/pull/523

We have `org.mskcc.cbio.oncokb.model.TumorType` and `org.mskcc.cbio.oncokb.apiModel.TumorType` annotated with `@ApiModel` for swagger docs to pick up. They have the same name, so one of them will be overriden by the other, so I added "value" property to annotation to distinguish them.