### PR TITLE
Allow mvn tests to be ran in docker containers to avoid MySQL database changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ core/src/main/resources/log4j.properties
 web/src/main/resources/certificate
 web/src/main/resources/sentry.properties
 api_test/golang/output
+unit_test/mysql_dumps
 
 # These files are coming from VS CODE while setting up
 .project

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ For this option, you need to download the VEP cache, which is used in the `gn-ve
 
 ### Additional Information
 
+#### Running unit tests
+1. Continue to use `mvn test` command that connects to a local MySQL server defined in database.properties file. Note that some test cases will insert dummy data, so make sure the database is not used for any downstream workflows.
+2. Run tests using docker-compose by running `sh unit_test/scripts/run_docker_test.sh`. Make sure to add a mysql data dump file under `unit_test/mysql_dumps`
+
 #### Generating oncokb-transcript token
 
 The docker compose file has a pre-generated oncokb-transcript [JWT](https://jwt.io/introduction) token, which is required to make API requests to the oncokb-transcript service. To generate the JWT token, go to the https://jwt.io/ website and follow these instructions:

--- a/core/src/main/resources/spring/beans/DataSource.xml
+++ b/core/src/main/resources/spring/beans/DataSource.xml
@@ -5,6 +5,7 @@ http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="ignoreResourceNotFound" value="true"/>
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE"/>
 		<property name="location">
 			<value>properties/database.properties</value>
 		</property>

--- a/unit_test/scripts/docker-compose.yml
+++ b/unit_test/scripts/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  mysql:
+    image: mysql:8.0.36
+    environment:
+      MYSQL_DATABASE: "oncokb_core_test"
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DEFAULT_AUTHENTICATION_PLUGIN: mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - type: bind
+        source: ../mysql_dumps
+        target: /docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+    networks:
+      - testnet
+  maven:
+    image: maven:3.8.6-openjdk-8
+    container_name: maven-test-runner
+    depends_on:
+      mysql:
+        condition: service_healthy
+        restart: true
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    volumes:
+      - ${PWD}:/usr/src/app
+    working_dir: /usr/src/app
+    entrypoint: ["sh", "-c", "./unit_test/scripts/run_test.sh"]
+    networks:
+      - testnet
+
+networks:
+  testnet:

--- a/unit_test/scripts/docker-compose.yml
+++ b/unit_test/scripts/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       MYSQL_DATABASE: "oncokb_core_test"
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DEFAULT_AUTHENTICATION_PLUGIN: mysql_native_password
+    # Workaround to resolve error (https://stackoverflow.com/questions/50424900/error-client-does-not-support-authentication-protocol-requested-by-server-cons)
+    # TLDR; we need to upgrade our MySQL connect from v5 to v8, so that everything works properly with mysql v8+
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - type: bind

--- a/unit_test/scripts/run_docker_test.sh
+++ b/unit_test/scripts/run_docker_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export MYSQL_ROOT_PASSWORD=rootroot
+
+mvn -ntp package -P enterprise -DskipTests=true
+docker-compose -f unit_test/scripts/docker-compose.yml up --build --exit-code-from maven 

--- a/unit_test/scripts/run_test.sh
+++ b/unit_test/scripts/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Due to DataSource.xml having <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE"/>
+# The system properties passed in here will override database.properties values
+
+mvn -ntp test \
+  -Djdbc.driverClassName=com.mysql.jdbc.Driver \
+  -Djdbc.url="jdbc:mysql://mysql:3306/oncokb_core_test?useUnicode=yes&characterEncoding=UTF-8" \
+  -Djdbc.username=root \
+  -Djdbc.password=${MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/841

### Issue:
When running data release, we often run `mvn test` which insert some dummy data (does not cleanup), and that ends up in production.

### Fix
Add option to run mvn test in a docker container with MySQL initialized from a mysql database dump file. Dummy data is not persisted onto actual database that may be used for downstream workflow, like data release.
  - Easier to get mvn test running in a pipeline because you don't need to setup MySQL, docker-compose will spin neccessary services.
  
I was not able to implement rollbacks on database using Transactions and Rollback annotations due to our old spring version. Open to hearing if anyone has ideas on how to cleanup test data cleanly, if we feel strongly about running `mvn test` locally rather than in docker container.