### PR TITLE
Update unit-test yaml

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,8 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ master, refactor , next-minor-release ]
+    branches: [master, refactor, next-minor-release]
+  pull_request:
 
 jobs:
   main:
@@ -16,11 +17,12 @@ jobs:
         run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary, please not remove it
 
       - name: Set up MySQL
-        uses: mirromutth/mysql-action@v1.1
+        uses: shogo82148/actions-setup-mysql@v1
         with:
-          mysql version: '8.0'
-          mysql database: 'test'
-          mysql root password: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          mysql-version: "8.0"
+          root-password: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          my-cnf: |
+            default-authentication-plugin=mysql_native_password
 
       - name: Wait for MySQL
         env:
@@ -53,9 +55,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
         run: |
-          mvn -ntp test \
-          -Djdbc.driverClassName=com.mysql.jdbc.Driver \
-          -Djdbc.url=jdbc:mysql://127.0.0.1:3306/test \
+          mvn -ntp test -Djdbc.driverClassName=com.mysql.jdbc.Driver \
+          -Djdbc.url='jdbc:mysql://127.0.0.1:3306/test?useUnicode=yes&characterEncoding=UTF-8' \
           -Djdbc.username=root \
           -Djdbc.password=${MYSQL_ROOT_PASSWORD}
-

--- a/unit_test/scripts/run_docker_test.sh
+++ b/unit_test/scripts/run_docker_test.sh
@@ -3,4 +3,4 @@
 export MYSQL_ROOT_PASSWORD=rootroot
 
 mvn -ntp package -P enterprise -DskipTests=true
-docker-compose -f unit_test/scripts/docker-compose.yml up --build --exit-code-from maven 
+docker compose -f unit_test/scripts/docker-compose.yml up --build --exit-code-from maven 


### PR DESCRIPTION
### Changes
- Use `shogo82148/actions-setup-mysql@v1` because it allows us to have greater control over MySQL server configuration
- Use `default-authentication-plugin=mysql_native_password` since MySQL connector is still on v5
- Run unit tests on PRs

Ideally we should update the MySQL connector to v8
