### PR TITLE
fixed alteration annotation for 3 letter aminoacids and log4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ The WAR file is under `/web/target/`
 4. Either download Tomcat 8 on local machine or let CSC download for you.
 5. Right click Tomcat server and choose `Add Deployment`. This is the WAR file generated in the previous step.
 6. Edit the Tomcat server and add `"vm.install.path": "/path/to/java8"`.
-7. Start Tomcat server. Make sure to `Publish Server (Full)` to keep server synchronized with WAR file (if changes were made).
-8. Test the endpoint by making a request to `http://localhost:8080/app/api/v1/info`
+7. Additionally, append `-Dlog4j.configuration=\"file:/path/to/log4j.properties\"` to `"args.vm.override.string"` to ensure Tomcat loads the correct Log4j configuration.
+8. Start Tomcat server. Make sure to `Publish Server (Full)` to keep server synchronized with WAR file (if changes were made).
+9. Test the endpoint by making a request to `http://localhost:8080/app/api/v1/info`
 
 ## Run with Docker containers
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ The WAR file is under `/web/target/`
 4. Either download Tomcat 8 on local machine or let CSC download for you.
 5. Right click Tomcat server and choose `Add Deployment`. This is the WAR file generated in the previous step.
 6. Edit the Tomcat server and add `"vm.install.path": "/path/to/java8"`.
-7. Additionally, append `-Dlog4j.configuration=\"file:/path/to/log4j.properties\"` to `"args.vm.override.string"` to ensure Tomcat loads the correct Log4j configuration.
+7. Set `"args.override.boolean": "true"` to ensure VM override arguments are applied.
+7. Append `-Dlog4j.configuration=\"file:/path/to/log4j.properties\"` to `"args.vm.override.string"` so Tomcat loads the correct Log4j configuration.
 8. Start Tomcat server. Make sure to `Publish Server (Full)` to keep server synchronized with WAR file (if changes were made).
 9. Test the endpoint by making a request to `http://localhost:8080/app/api/v1/info`
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Query.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 import org.apache.commons.lang3.StringUtils;
 import org.mskcc.cbio.oncokb.apiModels.annotation.*;
+import org.mskcc.cbio.oncokb.util.AlterationUtils;
 import org.mskcc.cbio.oncokb.util.AminoAcidConverterUtils;
 import org.mskcc.cbio.oncokb.util.GeneUtils;
 import org.mskcc.cbio.oncokb.util.QueryUtils;
@@ -185,10 +186,7 @@ public class Query implements java.io.Serializable {
     }
 
     public void setAlteration(String alteration) {
-        if (alteration != null) {
-            alteration = alteration.replace("p.", "");
-        }
-        this.alteration = AminoAcidConverterUtils.resolveHgvspShortFromHgvsp(alteration);;
+        this.alteration =  AlterationUtils.resolveProteinAlterationShort(alteration);
     }
 
     public String getAlterationType() {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -1808,4 +1808,11 @@ public final class AlterationUtils {
         MainUtils.sortActionableVariants(actionableGeneList);
         return actionableGeneList;
     }
+
+    public static String resolveProteinAlterationShort(String alteration) {
+        if (alteration != null) {
+            alteration = alteration.replace("p.", "");
+        }
+        return AminoAcidConverterUtils.resolveHgvspShortFromHgvsp(alteration);
+    }
 }

--- a/core/src/main/resources/properties-EXAMPLE/log4j.properties
+++ b/core/src/main/resources/properties-EXAMPLE/log4j.properties
@@ -3,21 +3,13 @@
 # -Dlog4j.configuration=file:core/src/main/resources/properties/log4j.properties
 # to setup the file logger.
 
-# Change INFO to DEBUG, if you want to see debugging info on underlying libraries we use.
-log4j.rootLogger=INFO, a
+log4j.rootLogger=INFO, stdout
 
-# Change INFO to DEBUG, if you want see debugging info on our packages only.
-log4j.category.org.mskcc=INFO
+# Logger for our application
+log4j.logger.org.mskcc=INFO
+log4j.logger.org.springframework.security=INFO
 
-
-## IMPORTANT - THRESHOLD SHOULD NOT BE DEBUG FOR PRODUCTION, CREDENTIALS CAN BE DISPLAYED!
-
-log4j.appender.a = org.apache.log4j.rolling.RollingFileAppender
-log4j.appender.a.rollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
-log4j.appender.a.rollingPolicy.FileNamePattern = oncokb.log.%d.gz
-log4j.appender.a.File = oncokb.log
-log4j.appender.a.layout = org.apache.log4j.PatternLayout
-log4j.appender.a.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} [%t] %-5p [%X{requestId}] %c - %m%n
-log4j.appender.a.append = true
-
-log4j.logger.org.springframework.security=DEBUG
+# Console appender
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%X{requestId}]  %C:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pvt/PrivateUtilsApiController.java
@@ -399,6 +399,7 @@ public class PrivateUtilsApiController implements PrivateUtilsApi {
             gene = GeneUtils.getGene(entrezGeneId, hugoSymbol);
             Alteration alterationModel = AlterationUtils.findAlteration(gene, matchedRG, alteration);
             if (alterationModel == null) {
+                alteration = AlterationUtils.resolveProteinAlterationShort(alteration);
                 if (gene == null) {
                     alterationModel = new Alteration();
                     gene = new Gene();


### PR DESCRIPTION
https://github.com/oncokb/oncokb/issues/3951
- Added a static helper function to convert 3-letter amino acid codes to 1-letter codes before alteration annotation.
Integrated this function in both `Query().setAlteration()` and during `AlterationModel` assignment to ensure consistent handling.
- Updated log4j.properties with Calvin’s suggested changes to improve logging visibility.