### PR TITLE
Fix/germline mutation description

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceTypeUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/EvidenceTypeUtils.java
@@ -41,6 +41,7 @@ public class EvidenceTypeUtils {
     public static Set<EvidenceType> getGermlineVariantEvidenceTypes() {
         Set<EvidenceType> evidenceTypes = new HashSet<>();
         evidenceTypes.add(EvidenceType.PATHOGENIC);
+        evidenceTypes.add(EvidenceType.MUTATION_EFFECT);
         evidenceTypes.add(EvidenceType.GENOMIC_INDICATOR);
         evidenceTypes.add(EvidenceType.GENE_PENETRANCE);
         evidenceTypes.add(EvidenceType.GENE_CANCER_RISK);


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/876

### Issue
1. `variant_summary` is mostly a programmatically generated field and we don't have the logic to do that currently for germline variants.
    - Fix is to add a condition to not set this when germline variant
2. mutation effect description is not returned for germline variant

<img width="1677" height="990" alt="image" src="https://github.com/user-attachments/assets/48bd06c9-81a6-465c-9f5c-07301a37b2bc" />
