### PR TITLE
Prioritize somatic over germline gene in search bar

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AnnotationSearchUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AnnotationSearchUtils.java
@@ -847,7 +847,11 @@ class GeneComp implements Comparator<TypeaheadSearchResp> {
         if (e2 == null || e2.getGene() == null) {
             return -1;
         }
-        return GeneUtils.compareGenesByKeyword(e1.getGene(), e2.getGene(), this.keyword);
+        int geneCompare = GeneUtils.compareGenesByKeyword(e1.getGene(), e2.getGene(), this.keyword);
+        if (e1.getGene().equals(e2.getGene())) {
+            return e1.getGeneticType().compareTo(e2.getGeneticType());
+        }
+        return geneCompare;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/974

Response now:
```
[
  {
    "gene": {
      "entrezGeneId": 324,
      "hugoSymbol": "APC",
      "geneType": "TSG",
      "grch37Isoform": "ENST00000257430",
      "grch37RefSeq": "NM_000038.5",
      "grch38Isoform": "ENST00000257430",
      "grch38RefSeq": "NM_000038.5",
      "geneAliases": [
        "PPP1R46",
        "DP2.5"
      ],
      "genesets": []
    },
    "variants": null,
    "tumorTypes": null,
    "drug": null,
    "oncogenicity": null,
    "highestSensitiveLevel": "",
    "highestResistanceLevel": "",
    "variantExist": false,
    "annotation": null,
    "queryType": "GENE",
    "link": "/gene/APC/somatic",
    "annotationByLevel": null,
    "geneticType": "SOMATIC",
    "vus": null
  },
  {
    "gene": {
      "entrezGeneId": 324,
      "hugoSymbol": "APC",
      "geneType": "TSG",
      "grch37Isoform": "ENST00000257430",
      "grch37RefSeq": "NM_000038.5",
      "grch38Isoform": "ENST00000257430",
      "grch38RefSeq": "NM_000038.5",
      "geneAliases": [
        "PPP1R46",
        "DP2.5"
      ],
      "genesets": []
    },
    "variants": null,
    "tumorTypes": null,
    "drug": null,
    "oncogenicity": null,
    "highestSensitiveLevel": "",
    "highestResistanceLevel": "",
    "variantExist": false,
    "annotation": null,
    "queryType": "GENE",
    "link": "/gene/APC/germline",
    "annotationByLevel": null,
    "geneticType": "GERMLINE",
    "vus": null
  }
]
```