### PR TITLE
Fix unit test

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           MYSQL_FILE_NAME=mysql.sql.gz
           if [ -z "${ONCOKB_OAUTH_TOKEN}" ]; then
-            echo "ONCOKB_OAUTH_TOKEN is not set; cannot download test data." >&2
+            echo "ONCOKB_OAUTH_TOKEN is not set. If this is a forked PR, GitHub does not pass base repo secrets to pull_request workflows." >&2
             exit 1
           fi
           curl -fsSL \


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/1039

Secrets are not exposed to workflows triggered by forked pull_request events. GitHub strips secrets for security (the workflow code comes from the fork), so the `ONCOKB_OAUTH_TOKEN` will be empty.

Fix:
Instead of failing at the unit test step, which gives errors that are not immediately obvious why the test failed, we fail at the import data step.


Workarounds:
 - Check unit_test run on forked repo (requires fork owner to setup their own secrets)
 - Don't push to forked repo; use upstream 
 - Requires more work, using Git hub environments (https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#required-reviewers)

