### PR TITLE
pick fusion mutation where variant exists over a matched rule

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -204,11 +204,7 @@ public class IndicatorUtils {
                     query.getProteinEnd(), query.getHgvs(), query.isGermline(), query.getInheritanceMechanism(), query.getPathogenicity());
                 result.add(IndicatorUtils.processQuery(tmpQuery, levels, highestLevelOnly, evidenceTypes, geneQueryOnly));
             }
-            return result
-                .stream()
-                .sorted((a, b) -> b.getVariantExist().compareTo(a.getVariantExist()))
-                .findFirst()
-                .get();
+            return result.iterator().next();
         }
 
         if (gene != null) {
@@ -1210,6 +1206,12 @@ class IndicatorQueryRespComp implements Comparator<IndicatorQueryResp> {
         if (e2.getGeneExist() == null || !e2.getGeneExist()) {
             return -1;
         }
+
+        result = e2.getVariantExist().compareTo(e1.getVariantExist());
+        if (result != 0) {
+            return result;
+        }
+
         return -1;
     }
 }


### PR DESCRIPTION
resolves https://github.com/oncokb/oncokb-pipeline/issues/1079

Context:
When PAX3 is used as hugo symbol 1, `PAX3-FOXO1 Fusion` is matched: http://localhost:9095/gene/PAX3/somatic/PAX3-FOXO1%20Fusion/RMS

When FOXO1 is used as hugo symbol 1, `Truncating Mutations` is matched: 
https://www.oncokb.org/gene/FOXO1/somatic/Truncating%20Mutations/RMS

This change prioritizes an existing variant instead of picking the first.