### PR TITLE
Add germline support to data download util endpoints

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/ActionableGene.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/ActionableGene.java
@@ -13,6 +13,7 @@ public class ActionableGene {
     Integer entrezGeneId;
     String gene;
     String referenceGenome;
+    String setting;
     String variant;
     String proteinChange;
     String cancerType;
@@ -78,6 +79,14 @@ public class ActionableGene {
 
     public void setReferenceGenome(String referenceGenome) {
         this.referenceGenome = referenceGenome;
+    }
+
+    public String getSetting() {
+        return setting;
+    }
+
+    public void setSetting(String setting) {
+        this.setting = setting;
     }
 
     public String getVariant() {
@@ -160,7 +169,7 @@ public class ActionableGene {
         this.description = description;
     }
 
-    public ActionableGene(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String gene, String referenceGenome, String variant, String proteinChange, String cancerType, String level, String solidPropagationLevel, String liquidPropagationLevel, String drugs, String pmids, String abstracts, String description) {
+    public ActionableGene(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String gene, String referenceGenome, String setting, String variant, String proteinChange, String cancerType, String level, String solidPropagationLevel, String liquidPropagationLevel, String drugs, String pmids, String abstracts, String description) {
         this.grch37Isoform = grch37Isoform;
         this.grch37RefSeq = grch37RefSeq;
         this.grch38Isoform = grch38Isoform;
@@ -168,6 +177,7 @@ public class ActionableGene {
         this.entrezGeneId = entrezGeneId;
         this.gene = gene;
         this.referenceGenome = referenceGenome;
+        this.setting = setting;
         this.variant = variant;
         this.proteinChange = proteinChange;
         this.cancerType = cancerType;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/AnnotatedVariant.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/AnnotatedVariant.java
@@ -17,7 +17,6 @@ public class AnnotatedVariant {
     String variant;
     String proteinChange;
     String oncogenicity;
-    String pathogenicity;
     String mutationEffect;
     String mutationEffectPmids;
     String mutationEffectAbstracts;
@@ -111,14 +110,6 @@ public class AnnotatedVariant {
         this.oncogenicity = oncogenicity;
     }
 
-    public String getPathogenicity() {
-        return pathogenicity;
-    }
-
-    public void setPathogenicity(String pathogenicity) {
-        this.pathogenicity = pathogenicity;
-    }
-
     public String getMutationEffect() {
         return mutationEffect;
     }
@@ -151,7 +142,7 @@ public class AnnotatedVariant {
         this.mutationEffectAbstracts = mutationEffectAbstracts;
     }
 
-    public AnnotatedVariant(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String gene, String referenceGenome, String setting, String variant, String proteinChange, String oncogenicity, String pathogenicity, String mutationEffect, String mutationEffectPmids, String mutationEffectAbstracts, String description) {
+    public AnnotatedVariant(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String gene, String referenceGenome, String setting, String variant, String proteinChange, String oncogenicity, String mutationEffect, String mutationEffectPmids, String mutationEffectAbstracts, String description) {
         this.grch37Isoform = grch37Isoform;
         this.grch37RefSeq = grch37RefSeq;
         this.grch38Isoform = grch38Isoform;
@@ -163,7 +154,6 @@ public class AnnotatedVariant {
         this.variant = variant;
         this.proteinChange = proteinChange;
         this.oncogenicity = oncogenicity;
-        this.pathogenicity = pathogenicity;
         this.mutationEffect = mutationEffect;
         this.mutationEffectPmids = mutationEffectPmids;
         this.mutationEffectAbstracts = mutationEffectAbstracts;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/AnnotatedVariant.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/AnnotatedVariant.java
@@ -13,9 +13,11 @@ public class AnnotatedVariant {
     Integer entrezGeneId;
     String gene;
     String referenceGenome;
+    String setting;
     String variant;
     String proteinChange;
     String oncogenicity;
+    String pathogenicity;
     String mutationEffect;
     String mutationEffectPmids;
     String mutationEffectAbstracts;
@@ -77,6 +79,14 @@ public class AnnotatedVariant {
         this.referenceGenome = referenceGenome;
     }
 
+    public String getSetting() {
+        return setting;
+    }
+
+    public void setSetting(String setting) {
+        this.setting = setting;
+    }
+
     public String getVariant() {
         return variant;
     }
@@ -99,6 +109,14 @@ public class AnnotatedVariant {
 
     public void setOncogenicity(String oncogenicity) {
         this.oncogenicity = oncogenicity;
+    }
+
+    public String getPathogenicity() {
+        return pathogenicity;
+    }
+
+    public void setPathogenicity(String pathogenicity) {
+        this.pathogenicity = pathogenicity;
     }
 
     public String getMutationEffect() {
@@ -133,7 +151,7 @@ public class AnnotatedVariant {
         this.mutationEffectAbstracts = mutationEffectAbstracts;
     }
 
-    public AnnotatedVariant(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String gene, String referenceGenome, String variant, String proteinChange, String oncogenicity, String mutationEffect, String mutationEffectPmids, String mutationEffectAbstracts, String description) {
+    public AnnotatedVariant(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String gene, String referenceGenome, String setting, String variant, String proteinChange, String oncogenicity, String pathogenicity, String mutationEffect, String mutationEffectPmids, String mutationEffectAbstracts, String description) {
         this.grch37Isoform = grch37Isoform;
         this.grch37RefSeq = grch37RefSeq;
         this.grch38Isoform = grch38Isoform;
@@ -141,9 +159,11 @@ public class AnnotatedVariant {
         this.entrezGeneId = entrezGeneId;
         this.gene = gene;
         this.referenceGenome = referenceGenome;
+        this.setting = setting;
         this.variant = variant;
         this.proteinChange = proteinChange;
         this.oncogenicity = oncogenicity;
+        this.pathogenicity = pathogenicity;
         this.mutationEffect = mutationEffect;
         this.mutationEffectPmids = mutationEffectPmids;
         this.mutationEffectAbstracts = mutationEffectAbstracts;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/CuratedGene.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/CuratedGene.java
@@ -15,6 +15,7 @@ public class CuratedGene implements Serializable {
     Integer entrezGeneId;
     String hugoSymbol;
     GeneType geneType;
+    String setting;
     String highestSensitiveLevel;
     String highestResistanceLevel;
     String summary;
@@ -84,6 +85,14 @@ public class CuratedGene implements Serializable {
         this.geneType = geneType;
     }
 
+    public String getSetting() {
+        return setting;
+    }
+
+    public void setSetting(String setting) {
+        this.setting = setting;
+    }
+
     public String getHighestSensitiveLevel() {
         return highestSensitiveLevel;
     }
@@ -116,7 +125,7 @@ public class CuratedGene implements Serializable {
         this.background = background;
     }
 
-    public CuratedGene(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String hugoSymbol, GeneType geneType, String highestSensitiveLevel, String highestResistanceLevel, String summary, String background) {
+    public CuratedGene(String grch37Isoform, String grch37RefSeq, String grch38Isoform, String grch38RefSeq, Integer entrezGeneId, String hugoSymbol, GeneType geneType, String setting, String highestSensitiveLevel, String highestResistanceLevel, String summary, String background) {
         this.grch37Isoform = grch37Isoform;
         this.grch37RefSeq = grch37RefSeq;
         this.grch38Isoform = grch38Isoform;
@@ -124,6 +133,7 @@ public class CuratedGene implements Serializable {
         this.entrezGeneId = entrezGeneId;
         this.hugoSymbol = hugoSymbol;
         this.geneType = geneType;
+        this.setting = setting;
         this.highestSensitiveLevel = highestSensitiveLevel;
         this.highestResistanceLevel = highestResistanceLevel;
         this.summary = summary;

--- a/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/download/FileName.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/apiModels/download/FileName.java
@@ -7,6 +7,7 @@ public enum FileName {
     ALL_ANNOTATED_VARIANTS("allAnnotatedVariants"),
     ALL_ACTIONABLE_VARIANTS("allActionableVariants"),
     ALL_CURATED_GENES("allCuratedGenes"),
+    ALL_CURATED_GENES_GERMLINE("allCuratedGenesGermline"),
     CANCER_GENE_LIST("cancerGeneList"),
     README("README");
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -66,8 +66,7 @@ public class CacheFetcher {
         header.add("GRCh38 RefSeq");
         header.add("Gene Type");
         header.add("# of occurrence within resources (Column K-P)");
-        header.add("OncoKB Annotated in Somatic");
-        header.add("OncoKB Annotated in Germline");
+        header.add("OncoKB Annotated");
         header.add("MSK-IMPACT");
         header.add("MSK-HEME");
         header.add("FOUNDATION ONE");
@@ -93,7 +92,6 @@ public class CacheFetcher {
             }
             row.add(String.valueOf(cancerGene.getOccurrenceCount()));
             row.add(getStringByBoolean(cancerGene.getOncokbAnnotated()));
-            row.add(getStringByBoolean(cancerGene.getOncokbAnnotatedInGermline()));
             row.add(getStringByBoolean(cancerGene.getmSKImpact()));
             row.add(getStringByBoolean(cancerGene.getmSKHeme()));
             row.add(getStringByBoolean(cancerGene.getFoundation()));

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -190,6 +190,7 @@ public class CacheFetcher {
                     gene.getGrch38Isoform(), gene.getGrch38RefSeq(),
                     gene.getEntrezGeneId(), gene.getHugoSymbol(),
                     gene.getGeneType() != null ? gene.getGeneType() : GeneType.INSUFFICIENT_EVIDENCE,
+                    germline ? "Germline" : "Somatic",
                     highestSensitiveLevel, highestResistanceLevel,
                     includeEvidence ? SummaryUtils.getGeneSummaryByGeneticType(gene, gene.getHugoSymbol(), germline) : "",
                     includeEvidence ? SummaryUtils.getGeneBackgroundByGeneticType(gene, gene.getHugoSymbol(), germline) : ""
@@ -198,6 +199,21 @@ public class CacheFetcher {
         }
         MainUtils.sortCuratedGenes(genes);
         return genes;
+    }
+
+    @Cacheable(cacheResolver = "generalCacheResolver")
+    public List<CuratedGene> getCuratedGenesAll(boolean includeEvidence) {
+        List<CuratedGene> result = new ArrayList<>();
+        List<CuratedGene> somaticGenes = this.getCuratedGenes(includeEvidence, false);
+        Map<String, CuratedGene> germlineBySymbol = this.getCuratedGenes(includeEvidence, true).stream()
+            .collect(Collectors.toMap(CuratedGene::getHugoSymbol, g -> g));
+        for (CuratedGene gene : somaticGenes) {
+            result.add(gene);
+            if (germlineBySymbol.containsKey(gene.getHugoSymbol())) {
+                result.add(germlineBySymbol.get(gene.getHugoSymbol()));
+            }
+        }
+        return result;
     }
 
     @Cacheable(cacheResolver = "generalCacheResolver")
@@ -213,6 +229,7 @@ public class CacheFetcher {
         header.add("Entrez Gene ID");
         header.add("Hugo Symbol");
         header.add("Gene Type");
+        header.add("Setting");
         header.add("Highest Level of Evidence(sensitivity)");
         header.add("Highest Level of Evidence(resistance)");
         if (includeEvidence == Boolean.TRUE) {
@@ -222,76 +239,38 @@ public class CacheFetcher {
         sb.append(MainUtils.listToString(header, separator));
         sb.append(newLine);
 
-        List<CuratedGene> genes = this.getCuratedGenes(includeEvidence == Boolean.TRUE, false);
-        for (CuratedGene gene : genes) {
-            List<String> row = new ArrayList<>();
-            row.add(gene.getGrch37Isoform());
-            row.add(gene.getGrch37RefSeq());
-            row.add(gene.getGrch38Isoform());
-            row.add(gene.getGrch38RefSeq());
-            row.add(String.valueOf(gene.getEntrezGeneId()));
-            row.add(gene.getHugoSymbol());
-            if (gene.getGeneType() != null) {
-                row.add(gene.getGeneType().toString());
-            } else {
-                row.add("");
+        List<CuratedGene> somaticGenes = this.getCuratedGenes(includeEvidence == Boolean.TRUE, false);
+        List<CuratedGene> germlineGenes = this.getCuratedGenes(includeEvidence == Boolean.TRUE, true);
+        Map<String, CuratedGene> germlineBySymbol = germlineGenes.stream()
+            .collect(Collectors.toMap(CuratedGene::getHugoSymbol, g -> g));
+
+        for (CuratedGene gene : somaticGenes) {
+            appendCuratedGeneRow(sb, gene, includeEvidence, separator, newLine);
+            if (germlineBySymbol.containsKey(gene.getHugoSymbol())) {
+                appendCuratedGeneRow(sb, germlineBySymbol.get(gene.getHugoSymbol()), includeEvidence, separator, newLine);
             }
-            row.add(gene.getHighestSensitiveLevel());
-            row.add(gene.getHighestResistancLevel());
-            if (includeEvidence == Boolean.TRUE) {
-                row.add(gene.getSummary());
-                row.add(gene.getBackground());
-            }
-            sb.append(MainUtils.listToString(row, separator));
-            sb.append(newLine);
         }
         return sb.toString();
     }
 
-    @Cacheable(cacheResolver = "generalCacheResolver")
-    public String getCuratedGenesGermlineTxt(boolean includeEvidence) {
-        String separator = "\t";
-        String newLine = "\n";
-        StringBuilder sb = new StringBuilder();
-        List<String> header = new ArrayList<>();
-        header.add("GRCh37 Isoform");
-        header.add("GRCh37 RefSeq");
-        header.add("GRCh38 Isoform");
-        header.add("GRCh38 RefSeq");
-        header.add("Entrez Gene ID");
-        header.add("Hugo Symbol");
-        header.add("Gene Type");
-        header.add("Highest Level of Evidence(sensitivity)");
+    private void appendCuratedGeneRow(StringBuilder sb, CuratedGene gene, boolean includeEvidence, String separator, String newLine) {
+        List<String> row = new ArrayList<>();
+        row.add(gene.getGrch37Isoform());
+        row.add(gene.getGrch37RefSeq());
+        row.add(gene.getGrch38Isoform());
+        row.add(gene.getGrch38RefSeq());
+        row.add(String.valueOf(gene.getEntrezGeneId()));
+        row.add(gene.getHugoSymbol());
+        row.add(gene.getGeneType() != null ? gene.getGeneType().toString() : "");
+        row.add(gene.getSetting());
+        row.add(gene.getHighestSensitiveLevel());
+        row.add(gene.getHighestResistancLevel());
         if (includeEvidence == Boolean.TRUE) {
-            header.add("Summary");
-            header.add("Background");
+            row.add(gene.getSummary());
+            row.add(gene.getBackground());
         }
-        sb.append(MainUtils.listToString(header, separator));
+        sb.append(MainUtils.listToString(row, separator));
         sb.append(newLine);
-
-        List<CuratedGene> genes = this.getCuratedGenes(includeEvidence == Boolean.TRUE, true);
-        for (CuratedGene gene : genes) {
-            List<String> row = new ArrayList<>();
-            row.add(gene.getGrch37Isoform());
-            row.add(gene.getGrch37RefSeq());
-            row.add(gene.getGrch38Isoform());
-            row.add(gene.getGrch38RefSeq());
-            row.add(String.valueOf(gene.getEntrezGeneId()));
-            row.add(gene.getHugoSymbol());
-            if (gene.getGeneType() != null) {
-                row.add(gene.getGeneType().toString());
-            } else {
-                row.add("");
-            }
-            row.add(gene.getHighestSensitiveLevel());
-            if (includeEvidence == Boolean.TRUE) {
-                row.add(gene.getSummary());
-                row.add(gene.getBackground());
-            }
-            sb.append(MainUtils.listToString(row, separator));
-            sb.append(newLine);
-        }
-        return sb.toString();
     }
 
     private String getStringByBoolean(Boolean val) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/cache/CacheFetcher.java
@@ -65,8 +65,9 @@ public class CacheFetcher {
         header.add("GRCh38 Isoform");
         header.add("GRCh38 RefSeq");
         header.add("Gene Type");
-        header.add("# of occurrence within resources (Column J-P)");
-        header.add("OncoKB Annotated");
+        header.add("# of occurrence within resources (Column K-P)");
+        header.add("OncoKB Annotated in Somatic");
+        header.add("OncoKB Annotated in Germline");
         header.add("MSK-IMPACT");
         header.add("MSK-HEME");
         header.add("FOUNDATION ONE");
@@ -92,6 +93,7 @@ public class CacheFetcher {
             }
             row.add(String.valueOf(cancerGene.getOccurrenceCount()));
             row.add(getStringByBoolean(cancerGene.getOncokbAnnotated()));
+            row.add(getStringByBoolean(cancerGene.getOncokbAnnotatedInGermline()));
             row.add(getStringByBoolean(cancerGene.getmSKImpact()));
             row.add(getStringByBoolean(cancerGene.getmSKHeme()));
             row.add(getStringByBoolean(cancerGene.getFoundation()));
@@ -154,7 +156,7 @@ public class CacheFetcher {
     }
 
     @Cacheable(cacheResolver = "generalCacheResolver")
-    public List<CuratedGene> getCuratedGenes(boolean includeEvidence) {
+    public List<CuratedGene> getCuratedGenes(boolean includeEvidence, boolean germline) {
         List<CuratedGene> genes = new ArrayList<>();
         for (Gene gene : CacheUtils.getAllGenes()) {
             // Skip all genes without entrez gene id
@@ -162,9 +164,17 @@ public class CacheFetcher {
                 continue;
             }
 
+            // Skip genes that have no germline evidence when building the germline list
+            if (germline && CacheUtils.getEvidences(gene).stream().noneMatch(e -> Boolean.TRUE.equals(e.getForGermline()))) {
+                continue;
+            }
+
             String highestSensitiveLevel = "";
             String highestResistanceLevel = "";
-            Set<Evidence> therapeuticEvidences = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, EvidenceTypeUtils.getTreatmentEvidenceTypes());
+            Set<Evidence> therapeuticEvidences = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, EvidenceTypeUtils.getTreatmentEvidenceTypes())
+                .stream()
+                .filter(evidence -> Boolean.TRUE.equals(evidence.getForGermline()) == germline)
+                .collect(Collectors.toSet());
             Set<Evidence> highestSensitiveLevelEvidences = EvidenceUtils.getOnlyHighestLevelEvidences(EvidenceUtils.getSensitiveEvidences(therapeuticEvidences), null, null);
             Set<Evidence> highestResistanceLevelEvidences = EvidenceUtils.getOnlyHighestLevelEvidences(EvidenceUtils.getResistanceEvidences(therapeuticEvidences), null, null);
             if (!highestSensitiveLevelEvidences.isEmpty()) {
@@ -181,8 +191,8 @@ public class CacheFetcher {
                     gene.getEntrezGeneId(), gene.getHugoSymbol(),
                     gene.getGeneType() != null ? gene.getGeneType() : GeneType.INSUFFICIENT_EVIDENCE,
                     highestSensitiveLevel, highestResistanceLevel,
-                    includeEvidence ? SummaryUtils.geneSummary(gene, gene.getHugoSymbol(), false) : "",
-                    includeEvidence ? SummaryUtils.geneBackground(gene, gene.getHugoSymbol()) : ""
+                    includeEvidence ? SummaryUtils.getGeneSummaryByGeneticType(gene, gene.getHugoSymbol(), germline) : "",
+                    includeEvidence ? SummaryUtils.getGeneBackgroundByGeneticType(gene, gene.getHugoSymbol(), germline) : ""
                 )
             );
         }
@@ -212,7 +222,7 @@ public class CacheFetcher {
         sb.append(MainUtils.listToString(header, separator));
         sb.append(newLine);
 
-        List<CuratedGene> genes = this.getCuratedGenes(includeEvidence == Boolean.TRUE);
+        List<CuratedGene> genes = this.getCuratedGenes(includeEvidence == Boolean.TRUE, false);
         for (CuratedGene gene : genes) {
             List<String> row = new ArrayList<>();
             row.add(gene.getGrch37Isoform());
@@ -228,6 +238,52 @@ public class CacheFetcher {
             }
             row.add(gene.getHighestSensitiveLevel());
             row.add(gene.getHighestResistancLevel());
+            if (includeEvidence == Boolean.TRUE) {
+                row.add(gene.getSummary());
+                row.add(gene.getBackground());
+            }
+            sb.append(MainUtils.listToString(row, separator));
+            sb.append(newLine);
+        }
+        return sb.toString();
+    }
+
+    @Cacheable(cacheResolver = "generalCacheResolver")
+    public String getCuratedGenesGermlineTxt(boolean includeEvidence) {
+        String separator = "\t";
+        String newLine = "\n";
+        StringBuilder sb = new StringBuilder();
+        List<String> header = new ArrayList<>();
+        header.add("GRCh37 Isoform");
+        header.add("GRCh37 RefSeq");
+        header.add("GRCh38 Isoform");
+        header.add("GRCh38 RefSeq");
+        header.add("Entrez Gene ID");
+        header.add("Hugo Symbol");
+        header.add("Gene Type");
+        header.add("Highest Level of Evidence(sensitivity)");
+        if (includeEvidence == Boolean.TRUE) {
+            header.add("Summary");
+            header.add("Background");
+        }
+        sb.append(MainUtils.listToString(header, separator));
+        sb.append(newLine);
+
+        List<CuratedGene> genes = this.getCuratedGenes(includeEvidence == Boolean.TRUE, true);
+        for (CuratedGene gene : genes) {
+            List<String> row = new ArrayList<>();
+            row.add(gene.getGrch37Isoform());
+            row.add(gene.getGrch37RefSeq());
+            row.add(gene.getGrch38Isoform());
+            row.add(gene.getGrch38RefSeq());
+            row.add(String.valueOf(gene.getEntrezGeneId()));
+            row.add(gene.getHugoSymbol());
+            if (gene.getGeneType() != null) {
+                row.add(gene.getGeneType().toString());
+            } else {
+                row.add("");
+            }
+            row.add(gene.getHighestSensitiveLevel());
             if (includeEvidence == Boolean.TRUE) {
                 row.add(gene.getSummary());
                 row.add(gene.getBackground());

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/CancerGene.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/CancerGene.java
@@ -14,6 +14,7 @@ public class CancerGene implements Serializable {
     private String grch38Isoform = "";
     private String grch38RefSeq = "";
     private Boolean oncokbAnnotated = false;
+    private Boolean oncokbAnnotatedInGermline = false;
     private Integer occurrenceCount = 0;
     private Boolean mSKImpact = false;
     private Boolean mSKHeme = false;
@@ -78,6 +79,14 @@ public class CancerGene implements Serializable {
 
     public void setOncokbAnnotated(Boolean oncokbAnnotated) {
         this.oncokbAnnotated = oncokbAnnotated;
+    }
+
+    public Boolean getOncokbAnnotatedInGermline() {
+        return oncokbAnnotatedInGermline;
+    }
+
+    public void setOncokbAnnotatedInGermline(Boolean oncokbAnnotatedInGermline) {
+        this.oncokbAnnotatedInGermline = oncokbAnnotatedInGermline;
     }
 
     public Integer getOccurrenceCount() {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/CancerGene.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/CancerGene.java
@@ -14,7 +14,6 @@ public class CancerGene implements Serializable {
     private String grch38Isoform = "";
     private String grch38RefSeq = "";
     private Boolean oncokbAnnotated = false;
-    private Boolean oncokbAnnotatedInGermline = false;
     private Integer occurrenceCount = 0;
     private Boolean mSKImpact = false;
     private Boolean mSKHeme = false;
@@ -79,14 +78,6 @@ public class CancerGene implements Serializable {
 
     public void setOncokbAnnotated(Boolean oncokbAnnotated) {
         this.oncokbAnnotated = oncokbAnnotated;
-    }
-
-    public Boolean getOncokbAnnotatedInGermline() {
-        return oncokbAnnotatedInGermline;
-    }
-
-    public void setOncokbAnnotatedInGermline(Boolean oncokbAnnotatedInGermline) {
-        this.oncokbAnnotatedInGermline = oncokbAnnotatedInGermline;
     }
 
     public Integer getOccurrenceCount() {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -1550,6 +1550,14 @@ public final class AlterationUtils {
 
     public static List<ActionableGene> getAllActionableVariants(Boolean isTextFile, boolean germline) {
         List<ActionableGene> actionableGeneList = new ArrayList<>();
+        actionableGeneList.addAll(getActionableVariantsForSetting(isTextFile, false));
+        actionableGeneList.addAll(getActionableVariantsForSetting(isTextFile, true));
+        MainUtils.sortActionableVariants(actionableGeneList);
+        return actionableGeneList;
+    }
+
+    private static Set<ActionableGene> getActionableVariantsForSetting(Boolean isTextFile, boolean germline) {
+        String setting = germline ? "Germline" : "Somatic";
         Set<Gene> genes = CacheUtils.getAllGenes();
         Map<Gene, Set<ClinicalVariant>> map = new HashMap<>();
 
@@ -1566,6 +1574,7 @@ public final class AlterationUtils {
                 for (ArticleAbstract articleAbstract : articleAbstracts) {
                     abstracts.add(articleAbstract.getAbstractContent() + " " + articleAbstract.getLink());
                 }
+                String proteinChange = germline ? clinicalVariant.getVariant().getProteinChange() : clinicalVariant.getVariant().getAlteration();
 
                 if (clinicalVariant.getExcludedCancerTypes().size() > 0) {
                     String cancerTypeName = TumorTypeUtils.getTumorTypesNameWithExclusion(clinicalVariant.getCancerTypes(), clinicalVariant.getExcludedCancerTypes());
@@ -1576,8 +1585,9 @@ public final class AlterationUtils {
                         gene.getEntrezGeneId(),
                         gene.getHugoSymbol(),
                         clinicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
+                        setting,
                         clinicalVariant.getVariant().getName(),
-                        clinicalVariant.getVariant().getAlteration(),
+                        proteinChange,
                         cancerTypeName,
                         clinicalVariant.getLevel(),
                         clinicalVariant.getSolidPropagationLevel(),
@@ -1604,8 +1614,9 @@ public final class AlterationUtils {
                             gene.getEntrezGeneId(),
                             gene.getHugoSymbol(),
                             clinicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
+                            setting,
                             clinicalVariant.getVariant().getName(),
-                            clinicalVariant.getVariant().getAlteration(),
+                            proteinChange,
                             TumorTypeUtils.getTumorTypeName(tumorType),
                             clinicalVariant.getLevel(),
                             clinicalVariant.getSolidPropagationLevel(),
@@ -1628,10 +1639,7 @@ public final class AlterationUtils {
                 }
             }
         }
-
-        actionableGeneList.addAll(actionableGenes);
-        MainUtils.sortActionableVariants(actionableGeneList);
-        return actionableGeneList;
+        return actionableGenes;
     }
 
     public static String resolveProteinAlterationShort(String alteration) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/CancerGeneUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/CancerGeneUtils.java
@@ -58,8 +58,7 @@ public class CancerGeneUtils {
                         }
                         if (hasSomaticEvidence && hasGermlineEvidence) break;
                     }
-                    cancerGene.setOncokbAnnotated(hasSomaticEvidence);
-                    cancerGene.setOncokbAnnotatedInGermline(hasGermlineEvidence);
+                    cancerGene.setOncokbAnnotated(hasSomaticEvidence || hasGermlineEvidence);
                     cancerGene.setOccurrenceCount(1);
                     cancerGene.setGeneType(gene.getGeneType());
                     cancerGene.setGeneAliases(gene.getGeneAliases());

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/CancerGeneUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/CancerGeneUtils.java
@@ -10,14 +10,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.mskcc.cbio.oncokb.model.CancerGene;
+import org.mskcc.cbio.oncokb.model.Evidence;
 import org.mskcc.cbio.oncokb.model.Gene;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Created by jiaojiao on 6/9/17.
@@ -51,7 +48,18 @@ public class CancerGeneUtils {
                     cancerGene.setGrch37RefSeq(gene.getGrch37RefSeq());
                     cancerGene.setGrch38Isoform(gene.getGrch38Isoform());
                     cancerGene.setGrch38RefSeq(gene.getGrch38RefSeq());
-                    cancerGene.setOncokbAnnotated(true);
+                    boolean hasSomaticEvidence = false;
+                    boolean hasGermlineEvidence = false;
+                    for (Evidence evidence : CacheUtils.getEvidences(gene)) {
+                        if (Boolean.TRUE.equals(evidence.getForGermline())) {
+                            hasGermlineEvidence = true;
+                        } else {
+                            hasSomaticEvidence = true;
+                        }
+                        if (hasSomaticEvidence && hasGermlineEvidence) break;
+                    }
+                    cancerGene.setOncokbAnnotated(hasSomaticEvidence);
+                    cancerGene.setOncokbAnnotatedInGermline(hasGermlineEvidence);
                     cancerGene.setOccurrenceCount(1);
                     cancerGene.setGeneType(gene.getGeneType());
                     cancerGene.setGeneAliases(gene.getGeneAliases());

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -188,7 +188,7 @@ public class IndicatorUtils {
 
             // Gene summary
             if (evidenceTypes.contains(EvidenceType.GENE_SUMMARY)) {
-                indicatorQuery.setGeneSummary(SummaryUtils.geneSummary(gene, query.getHugoSymbol(), query.isGermline()));
+                indicatorQuery.setGeneSummary(SummaryUtils.getGeneSummaryByGeneticType(gene, query.getHugoSymbol(), query.isGermline()));
                 latestEvidenceDate = updateLatestEvidenceDate(latestEvidenceDate,
                     EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENE_SUMMARY)));
             }
@@ -546,7 +546,7 @@ public class IndicatorUtils {
 
             // Gene summary
             if (evidenceTypes.contains(EvidenceType.GENE_SUMMARY)) {
-                indicatorQuery.setGeneSummary(SummaryUtils.geneSummary(gene, query.getHugoSymbol(), query.isGermline()));
+                indicatorQuery.setGeneSummary(SummaryUtils.getGeneSummaryByGeneticType(gene, query.getHugoSymbol(), query.isGermline()));
                 latestEvidenceDate = updateLatestEvidenceDate(latestEvidenceDate,
                     EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENE_SUMMARY)));
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/MainUtils.java
@@ -61,6 +61,23 @@ public class MainUtils {
         )
     );
 
+    public static int compareDataVersions(String left, String right) {
+        if (left == null && right == null) return 0;
+        if (left == null) return -1;
+        if (right == null) return 1;
+        String[] leftParts = left.trim().split("\\.");
+        String[] rightParts = right.trim().split("\\.");
+        int len = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < len; i++) {
+            int leftPart = i < leftParts.length ? Integer.parseInt(leftParts[i]) : 0;
+            int rightPart = i < rightParts.length ? Integer.parseInt(rightParts[i]) : 0;
+            if (leftPart != rightPart) {
+                return Integer.compare(leftPart, rightPart);
+            }
+        }
+        return 0;
+    }
+
     public static Oncogenicity getCuratedAlterationOncogenicity(Alteration alteration) {
         List<Evidence> selfAltOncogenicEvis = EvidenceUtils.getEvidence(Collections.singletonList(alteration),
             Collections.singleton(EvidenceType.ONCOGENIC), null);

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/SummaryUtils.java
@@ -590,43 +590,32 @@ public class SummaryUtils {
         return sb.toString();
     }
 
-    public static String geneSummary(Gene gene, String queryHugoSymbol, boolean isGermline) {
+    public static String getGeneSummaryByGeneticType(Gene gene, String queryHugoSymbol, boolean isGermline) {
         if (gene != null && gene.getHugoSymbol().equals(SpecialStrings.OTHERBIOMARKERS)) {
             return "";
         }
-        return enrichGeneEvidenceDescription(EvidenceType.GENE_SUMMARY, gene, StringUtils.isEmpty(queryHugoSymbol) ? gene.getHugoSymbol() : queryHugoSymbol, isGermline);
+        return enrichGeneSummaryDescription(gene, StringUtils.isEmpty(queryHugoSymbol) ? gene.getHugoSymbol() : queryHugoSymbol, isGermline);
     }
 
-    public static String geneBackground(Gene gene, String queryHugoSymbol) {
-        if (gene != null && gene.getHugoSymbol().equals(SpecialStrings.OTHERBIOMARKERS)) {
-            return "";
-        }
-        return enrichGeneEvidenceDescription(EvidenceType.GENE_BACKGROUND, gene, StringUtils.isEmpty(queryHugoSymbol) ? gene.getHugoSymbol() : queryHugoSymbol, false);
-    }
-
-    private static String enrichGeneEvidenceDescription(EvidenceType evidenceType, Gene gene, String hugoSymbol, boolean isGermline) {
-        Set<Evidence> geneBackgroundEvs = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(evidenceType));
+    private static String enrichGeneSummaryDescription(Gene gene, String hugoSymbol, boolean isGermline) {
+        Set<Evidence> evidences = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENE_SUMMARY));
         String summary = "";
 
-        if (evidenceType.equals(EvidenceType.GENE_SUMMARY) && geneBackgroundEvs.size() == 2) {
+        if (evidences.size() == 2) {
+            // For germline gene summary, we need to combine somatic and germline summary together.
             String somaticSummary = null;
             String germlineSummary = null;
-            for (Evidence ev : geneBackgroundEvs) {
+            for (Evidence ev : evidences) {
                 if (ev.getForGermline()) {
                     germlineSummary = ev.getDescription();
                 } else {
                     somaticSummary = ev.getDescription();
                 }
             }
-
-            if (isGermline) {
-                summary = joinStringsWithSpace(somaticSummary, germlineSummary);
-            } else {
-                summary = somaticSummary;
-            }
-        } else if (!geneBackgroundEvs.isEmpty()) {
-            Evidence ev = geneBackgroundEvs.iterator().next();
-            if (ev != null) {
+            summary = isGermline ? joinStringsWithSpace(somaticSummary, germlineSummary) : somaticSummary;
+        } else if (!evidences.isEmpty()) {
+            Evidence ev = evidences.iterator().next();
+            if (ev != null && Boolean.TRUE.equals(ev.getForGermline()) == isGermline) {
                 summary = ev.getDescription();
             }
         }
@@ -635,9 +624,38 @@ public class SummaryUtils {
             summary = "";
         }
         summary = summary.trim();
-        summary = summary.endsWith(".") ? summary : summary + ".";
-        summary = CplUtils.annotateGene(summary, hugoSymbol);
-        return summary;
+        if (!summary.isEmpty()) {
+            summary = summary.endsWith(".") ? summary : summary + ".";
+        }
+        return CplUtils.annotateGene(summary, hugoSymbol);
+    }
+
+    public static String getGeneBackgroundByGeneticType(Gene gene, String queryHugoSymbol, Boolean isGermline) {
+        if (gene != null && gene.getHugoSymbol().equals(SpecialStrings.OTHERBIOMARKERS)) {
+            return "";
+        }
+        return enrichGeneBackgroundDescription(gene, StringUtils.isEmpty(queryHugoSymbol) ? gene.getHugoSymbol() : queryHugoSymbol, isGermline);
+    }
+
+    private static String enrichGeneBackgroundDescription(Gene gene, String hugoSymbol, Boolean isGermline) {
+        Set<Evidence> evidences = EvidenceUtils.getEvidenceByGeneAndEvidenceTypes(gene, Collections.singleton(EvidenceType.GENE_BACKGROUND));
+        String summary = "";
+
+        for (Evidence ev : evidences) {
+            if (Boolean.TRUE.equals(ev.getForGermline()) == (Boolean.TRUE.equals(isGermline))) {
+                summary = ev.getDescription();
+                break;
+            }
+        }
+
+        if (summary == null) {
+            summary = "";
+        }
+        summary = summary.trim();
+        if (!summary.isEmpty()) {
+            summary = summary.endsWith(".") ? summary : summary + ".";
+        }
+        return CplUtils.annotateGene(summary, hugoSymbol);
     }
 
     public static String variantSummaryForTruncatingMutation(String altQuery, Alteration alteration, Oncogenicity oncogenicity) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/Constants.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/Constants.java
@@ -5,5 +5,6 @@ package org.mskcc.cbio.oncokb.api.pub.v1;
  */
 public class Constants {
     public static final String VERSION = "The data version";
+    public static final String GERMLINE_VERSION = "The data version. Must be 7.1 or higher.";
     public static final String INCLUDE_EVIDENCE = "Include gene summary and background";
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.io.IOException;
 import java.util.List;
 
-import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.GERMLINE_VERSION;
 import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.INCLUDE_EVIDENCE;
 import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.VERSION;
 
@@ -164,35 +163,5 @@ public interface UtilsApi {
         , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
     );
 
-    @PublicApi
-    @PremiumPublicApi
-    @ApiOperation(value = "", notes = "Get list of genes OncoKB curated for germline.", tags = {"Cancer Genes"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 503, message = "Service Unavailable")
-    })
-    @RequestMapping(value = "/utils/germline/allCuratedGenes",
-        produces = {"application/json"},
-        method = RequestMethod.GET)
-    ResponseEntity<List<CuratedGene>> utilsAllCuratedGenesGermlineGet(
-        @ApiParam(value = GERMLINE_VERSION) @RequestParam(value = "version", required = false) String version
-        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
-    );
 
-    @PublicApi
-    @PremiumPublicApi
-    @ApiOperation(value = "", notes = "Get list of genes OncoKB curated for germline in text file.", tags = {"Cancer Genes"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "OK"),
-        @ApiResponse(code = 404, message = "Not Found"),
-        @ApiResponse(code = 503, message = "Service Unavailable")
-    })
-    @RequestMapping(value = "/utils/allCuratedGermlineGenes.txt",
-        produces = "text/plain; charset=UTF-8",
-        method = RequestMethod.GET)
-    ResponseEntity<String> utilsAllCuratedGenesGermlineTxtGet(
-        @ApiParam(value = GERMLINE_VERSION) @RequestParam(value = "version", required = false) String version
-        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
-    );
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApi.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.io.IOException;
 import java.util.List;
 
+import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.GERMLINE_VERSION;
 import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.INCLUDE_EVIDENCE;
 import static org.mskcc.cbio.oncokb.api.pub.v1.Constants.VERSION;
 
@@ -160,6 +161,38 @@ public interface UtilsApi {
         method = RequestMethod.GET)
     ResponseEntity<String> utilsAllCuratedGenesTxtGet(
         @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
+        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
+    );
+
+    @PublicApi
+    @PremiumPublicApi
+    @ApiOperation(value = "", notes = "Get list of genes OncoKB curated for germline.", tags = {"Cancer Genes"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 503, message = "Service Unavailable")
+    })
+    @RequestMapping(value = "/utils/germline/allCuratedGenes",
+        produces = {"application/json"},
+        method = RequestMethod.GET)
+    ResponseEntity<List<CuratedGene>> utilsAllCuratedGenesGermlineGet(
+        @ApiParam(value = GERMLINE_VERSION) @RequestParam(value = "version", required = false) String version
+        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
+    );
+
+    @PublicApi
+    @PremiumPublicApi
+    @ApiOperation(value = "", notes = "Get list of genes OncoKB curated for germline in text file.", tags = {"Cancer Genes"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "OK"),
+        @ApiResponse(code = 404, message = "Not Found"),
+        @ApiResponse(code = 503, message = "Service Unavailable")
+    })
+    @RequestMapping(value = "/utils/allCuratedGermlineGenes.txt",
+        produces = "text/plain; charset=UTF-8",
+        method = RequestMethod.GET)
+    ResponseEntity<String> utilsAllCuratedGenesGermlineTxtGet(
+        @ApiParam(value = GERMLINE_VERSION) @RequestParam(value = "version", required = false) String version
         , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
     );
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -314,7 +314,7 @@ public class UtilsApiController implements UtilsApi {
         if (version != null) {
             return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES, FileExtension.JSON);
         }
-        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenes(includeEvidence, false), HttpStatus.OK);
+        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenesAll(includeEvidence), HttpStatus.OK);
     }
 
     @Override
@@ -326,28 +326,6 @@ public class UtilsApiController implements UtilsApi {
             return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES, FileExtension.TEXT);
         }
         return new ResponseEntity<>(this.cacheFetcher.getCuratedGenesTxt(includeEvidence), HttpStatus.OK);
-    }
-
-    @Override
-    public ResponseEntity<List<CuratedGene>> utilsAllCuratedGenesGermlineGet(
-        @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
-        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
-    ) {
-        if (version != null) {
-            return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES_GERMLINE, FileExtension.JSON);
-        }
-        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenes(includeEvidence, true), HttpStatus.OK);
-    }
-
-    @Override
-    public ResponseEntity<String> utilsAllCuratedGenesGermlineTxtGet(
-        @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
-        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
-    ) {
-        if (version != null) {
-            return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES_GERMLINE, FileExtension.TEXT);
-        }
-        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenesGermlineTxt(includeEvidence), HttpStatus.OK);
     }
 
 }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -70,7 +70,6 @@ public class UtilsApiController implements UtilsApi {
         header.add("Alteration");
         header.add("Protein Change");
         header.add("Oncogenicity");
-        header.add("Pathogenicity");
         header.add("Mutation Effect");
         header.add("PMIDs");
         header.add("Abstracts");
@@ -91,7 +90,6 @@ public class UtilsApiController implements UtilsApi {
             row.add(nullToEmpty(annotatedVariant.getVariant()));
             row.add(nullToEmpty(annotatedVariant.getProteinChange()));
             row.add(nullToEmpty(annotatedVariant.getOncogenicity()));
-            row.add(nullToEmpty(annotatedVariant.getPathogenicity()));
             row.add(nullToEmpty(annotatedVariant.getMutationEffect()));
             row.add(nullToEmpty(annotatedVariant.getMutationEffectPmids()));
             row.add(nullToEmpty(annotatedVariant.getMutationEffectAbstracts()));
@@ -157,6 +155,7 @@ public class UtilsApiController implements UtilsApi {
                 for (ArticleAbstract articleAbstract : articleAbstracts) {
                     abstracts.add(articleAbstract.getAbstractContent() + " " + articleAbstract.getLink());
                 }
+                String oncogenicity = resolveDownloadOncogenicity(biologicalVariant);
                 annotatedVariants.add(new AnnotatedVariant(
                     gene.getGrch37Isoform(),
                     gene.getGrch37RefSeq(),
@@ -168,8 +167,7 @@ public class UtilsApiController implements UtilsApi {
                     setting,
                     biologicalVariant.getVariant().getName(),
                     germline ? biologicalVariant.getVariant().getProteinChange() : biologicalVariant.getVariant().getAlteration(),
-                    biologicalVariant.getOncogenic(),
-                    biologicalVariant.getPathogenic(),
+                    oncogenicity,
                     biologicalVariant.getMutationEffect(),
                     MainUtils.listToString(new ArrayList<>(biologicalVariant.getMutationEffectPmids()), ", ", true),
                     MainUtils.listToString(abstracts, "; ", true),
@@ -187,6 +185,13 @@ public class UtilsApiController implements UtilsApi {
             }
         }
         return annotatedVariants;
+    }
+
+    private static String resolveDownloadOncogenicity(BiologicalVariant biologicalVariant) {
+        if (biologicalVariant.getPathogenic() != null && !biologicalVariant.getPathogenic().isEmpty()) {
+            return biologicalVariant.getPathogenic();
+        }
+        return biologicalVariant.getOncogenic();
     }
 
     private static String nullToEmpty(String s) {

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/UtilsApiController.java
@@ -2,6 +2,7 @@ package org.mskcc.cbio.oncokb.api.pub.v1;
 
 import io.swagger.annotations.ApiParam;
 import org.mskcc.cbio.oncokb.apiModels.ActionableGene;
+import org.mskcc.cbio.oncokb.serializer.EntrezGeneIdConverter;
 import org.mskcc.cbio.oncokb.apiModels.AnnotatedVariant;
 import org.mskcc.cbio.oncokb.apiModels.CuratedGene;
 import org.mskcc.cbio.oncokb.apiModels.VariantOfUnknownSignificance;
@@ -31,6 +32,8 @@ import static org.mskcc.cbio.oncokb.util.HttpUtils.getDataDownloadResponseEntity
  */
 @Controller
 public class UtilsApiController implements UtilsApi {
+    private static final EntrezGeneIdConverter ENTREZ_ID_CONVERTER = new EntrezGeneIdConverter();
+    
     @Autowired
     CacheFetcher cacheFetcher;
 
@@ -41,7 +44,7 @@ public class UtilsApiController implements UtilsApi {
         if (version != null) {
             return getDataDownloadResponseEntity(version, FileName.ALL_ANNOTATED_VARIANTS, FileExtension.JSON);
         }
-        return new ResponseEntity<>(getAllAnnotatedVariants(false, false), HttpStatus.OK);
+        return new ResponseEntity<>(getAllAnnotatedVariants(false), HttpStatus.OK);
     }
 
     @Override
@@ -63,9 +66,11 @@ public class UtilsApiController implements UtilsApi {
         header.add("Entrez Gene ID");
         header.add("Hugo Symbol");
         header.add("Reference Genome");
+        header.add("Setting");
         header.add("Alteration");
         header.add("Protein Change");
         header.add("Oncogenicity");
+        header.add("Pathogenicity");
         header.add("Mutation Effect");
         header.add("PMIDs");
         header.add("Abstracts");
@@ -73,22 +78,24 @@ public class UtilsApiController implements UtilsApi {
         sb.append(MainUtils.listToString(header, separator));
         sb.append(newLine);
 
-        for (AnnotatedVariant annotatedVariant : getAllAnnotatedVariants(true, false)) {
+        for (AnnotatedVariant annotatedVariant : getAllAnnotatedVariants(true)) {
             List<String> row = new ArrayList<>();
-            row.add(annotatedVariant.getGrch37Isoform());
-            row.add(annotatedVariant.getGrch37RefSeq());
-            row.add(annotatedVariant.getGrch38Isoform());
-            row.add(annotatedVariant.getGrch38RefSeq());
-            row.add(String.valueOf(annotatedVariant.getEntrezGeneId()));
-            row.add(annotatedVariant.getGene());
-            row.add(annotatedVariant.getReferenceGenome());
-            row.add(annotatedVariant.getVariant());
-            row.add(annotatedVariant.getProteinChange());
-            row.add(annotatedVariant.getOncogenicity());
-            row.add(annotatedVariant.getMutationEffect());
-            row.add(annotatedVariant.getMutationEffectPmids());
-            row.add(annotatedVariant.getMutationEffectAbstracts());
-            row.add(annotatedVariant.getDescription());
+            row.add(nullToEmpty(annotatedVariant.getGrch37Isoform()));
+            row.add(nullToEmpty(annotatedVariant.getGrch37RefSeq()));
+            row.add(nullToEmpty(annotatedVariant.getGrch38Isoform()));
+            row.add(nullToEmpty(annotatedVariant.getGrch38RefSeq()));
+            row.add(annotatedVariant.getEntrezGeneId() == null ? "" : String.valueOf(annotatedVariant.getEntrezGeneId()));
+            row.add(nullToEmpty(annotatedVariant.getGene()));
+            row.add(nullToEmpty(annotatedVariant.getReferenceGenome()));
+            row.add(nullToEmpty(annotatedVariant.getSetting()));
+            row.add(nullToEmpty(annotatedVariant.getVariant()));
+            row.add(nullToEmpty(annotatedVariant.getProteinChange()));
+            row.add(nullToEmpty(annotatedVariant.getOncogenicity()));
+            row.add(nullToEmpty(annotatedVariant.getPathogenicity()));
+            row.add(nullToEmpty(annotatedVariant.getMutationEffect()));
+            row.add(nullToEmpty(annotatedVariant.getMutationEffectPmids()));
+            row.add(nullToEmpty(annotatedVariant.getMutationEffectAbstracts()));
+            row.add(nullToEmpty(annotatedVariant.getDescription()));
             sb.append(MainUtils.listToString(row, separator));
             sb.append(newLine);
         }
@@ -124,8 +131,16 @@ public class UtilsApiController implements UtilsApi {
         return new ResponseEntity<>(sb.toString(), HttpStatus.OK);
     }
 
-    private List<AnnotatedVariant> getAllAnnotatedVariants(Boolean isTextFile, boolean germline) {
+    private List<AnnotatedVariant> getAllAnnotatedVariants(Boolean isTextFile) {
         List<AnnotatedVariant> annotatedVariantList = new ArrayList<>();
+        annotatedVariantList.addAll(getAnnotatedVariantsForSetting(isTextFile, false));
+        annotatedVariantList.addAll(getAnnotatedVariantsForSetting(isTextFile, true));
+        MainUtils.sortAnnotatedVariants(annotatedVariantList);
+        return annotatedVariantList;
+    }
+
+    private Set<AnnotatedVariant> getAnnotatedVariantsForSetting(Boolean isTextFile, boolean germline) {
+        String setting = germline ? "Germline" : "Somatic";
         Set<Gene> genes = CacheUtils.getAllGenes();
         Map<Gene, Set<BiologicalVariant>> map = new HashMap<>();
 
@@ -147,12 +162,14 @@ public class UtilsApiController implements UtilsApi {
                     gene.getGrch37RefSeq(),
                     gene.getGrch38Isoform(),
                     gene.getGrch38RefSeq(),
-                    gene.getEntrezGeneId(),
+                    ENTREZ_ID_CONVERTER.convert(gene.getEntrezGeneId()),
                     gene.getHugoSymbol(),
                     biologicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
+                    setting,
                     biologicalVariant.getVariant().getName(),
-                    biologicalVariant.getVariant().getAlteration(),
+                    germline ? biologicalVariant.getVariant().getProteinChange() : biologicalVariant.getVariant().getAlteration(),
                     biologicalVariant.getOncogenic(),
+                    biologicalVariant.getPathogenic(),
                     biologicalVariant.getMutationEffect(),
                     MainUtils.listToString(new ArrayList<>(biologicalVariant.getMutationEffectPmids()), ", ", true),
                     MainUtils.listToString(abstracts, "; ", true),
@@ -169,10 +186,11 @@ public class UtilsApiController implements UtilsApi {
                 ));
             }
         }
+        return annotatedVariants;
+    }
 
-        annotatedVariantList.addAll(annotatedVariants);
-        MainUtils.sortAnnotatedVariants(annotatedVariantList);
-        return annotatedVariantList;
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
     }
 
     private List<VariantOfUnknownSignificance> getAllVus() {
@@ -226,6 +244,7 @@ public class UtilsApiController implements UtilsApi {
         header.add("Entrez Gene ID");
         header.add("Hugo Symbol");
         header.add("Reference Genome");
+        header.add("Setting");
         header.add("Alteration");
         header.add("Protein Change");
         header.add("Cancer Type");
@@ -241,113 +260,28 @@ public class UtilsApiController implements UtilsApi {
 
         for (ActionableGene actionableGene : AlterationUtils.getAllActionableVariants(true, false)) {
             List<String> row = new ArrayList<>();
-            row.add(actionableGene.getGrch37Isoform());
-            row.add(actionableGene.getGrch37RefSeq());
-            row.add(actionableGene.getGrch38Isoform());
-            row.add(actionableGene.getGrch38RefSeq());
-            row.add(String.valueOf(actionableGene.getEntrezGeneId()));
-            row.add(actionableGene.getGene());
-            row.add(actionableGene.getReferenceGenome());
-            row.add(actionableGene.getVariant());
-            row.add(actionableGene.getProteinChange());
-            row.add(actionableGene.getCancerType());
-            row.add(actionableGene.getLevel());
-            row.add(actionableGene.getSolidPropagationLevel());
-            row.add(actionableGene.getLiquidPropagationLevel());
-            row.add(actionableGene.getDrugs());
-            row.add(actionableGene.getPmids());
-            row.add(actionableGene.getAbstracts());
-            row.add(actionableGene.getDescription());
+            row.add(nullToEmpty(actionableGene.getGrch37Isoform()));
+            row.add(nullToEmpty(actionableGene.getGrch37RefSeq()));
+            row.add(nullToEmpty(actionableGene.getGrch38Isoform()));
+            row.add(nullToEmpty(actionableGene.getGrch38RefSeq()));
+            row.add(actionableGene.getEntrezGeneId() == null ? "" : String.valueOf(actionableGene.getEntrezGeneId()));
+            row.add(nullToEmpty(actionableGene.getGene()));
+            row.add(nullToEmpty(actionableGene.getReferenceGenome()));
+            row.add(nullToEmpty(actionableGene.getSetting()));
+            row.add(nullToEmpty(actionableGene.getVariant()));
+            row.add(nullToEmpty(actionableGene.getProteinChange()));
+            row.add(nullToEmpty(actionableGene.getCancerType()));
+            row.add(nullToEmpty(actionableGene.getLevel()));
+            row.add(nullToEmpty(actionableGene.getSolidPropagationLevel()));
+            row.add(nullToEmpty(actionableGene.getLiquidPropagationLevel()));
+            row.add(nullToEmpty(actionableGene.getDrugs()));
+            row.add(nullToEmpty(actionableGene.getPmids()));
+            row.add(nullToEmpty(actionableGene.getAbstracts()));
+            row.add(nullToEmpty(actionableGene.getDescription()));
             sb.append(MainUtils.listToString(row, separator));
             sb.append(newLine);
         }
         return new ResponseEntity<>(sb.toString(), HttpStatus.OK);
-    }
-
-    private List<ActionableGene> getAllActionableVariants(Boolean isTextFile) {
-        List<ActionableGene> actionableGeneList = new ArrayList<>();
-        Set<Gene> genes = CacheUtils.getAllGenes();
-        Map<Gene, Set<ClinicalVariant>> map = new HashMap<>();
-
-        for (Gene gene : genes) {
-            map.put(gene, MainUtils.getClinicalVariants(gene, false));
-        }
-
-        Set<ActionableGene> actionableGenes = new HashSet<>();
-        for (Map.Entry<Gene, Set<ClinicalVariant>> entry : map.entrySet()) {
-            Gene gene = entry.getKey();
-            for (ClinicalVariant clinicalVariant : entry.getValue()) {
-                Set<ArticleAbstract> articleAbstracts = clinicalVariant.getDrugAbstracts();
-                List<String> abstracts = new ArrayList<>();
-                for (ArticleAbstract articleAbstract : articleAbstracts) {
-                    abstracts.add(articleAbstract.getAbstractContent() + " " + articleAbstract.getLink());
-                }
-
-                if (clinicalVariant.getExcludedCancerTypes().size() > 0) {
-                    String cancerTypeName = TumorTypeUtils.getTumorTypesNameWithExclusion(clinicalVariant.getCancerTypes(), clinicalVariant.getExcludedCancerTypes());
-                    // for any clinical variant that has cancer type excluded, we no longer list the cancer types separately
-                    actionableGenes.add(new ActionableGene(
-                        gene.getGrch37Isoform(), gene.getGrch37RefSeq(),
-                        gene.getGrch38Isoform(), gene.getGrch38RefSeq(),
-                        gene.getEntrezGeneId(),
-                        gene.getHugoSymbol(),
-                        clinicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
-                        clinicalVariant.getVariant().getName(),
-                        clinicalVariant.getVariant().getAlteration(),
-                        cancerTypeName,
-                        clinicalVariant.getLevel(),
-                        clinicalVariant.getSolidPropagationLevel(),
-                        clinicalVariant.getLiquidPropagationLevel(),
-                        MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrug()), ", ", true),
-                        MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrugPmids()), ", ", true),
-                        MainUtils.listToString(abstracts, "; ", true),
-                        CplUtils.annotate(
-                            clinicalVariant.getDrugDescription(),
-                            gene.getHugoSymbol(),
-                            clinicalVariant.getVariant().getName(),
-                            cancerTypeName,
-                            null,
-                            gene,
-                            null,
-                            isTextFile
-                        )
-                    ));
-                } else {
-                    for (TumorType tumorType : clinicalVariant.getCancerTypes()) {
-                        actionableGenes.add(new ActionableGene(
-                            gene.getGrch37Isoform(), gene.getGrch37RefSeq(),
-                            gene.getGrch38Isoform(), gene.getGrch38RefSeq(),
-                            gene.getEntrezGeneId(),
-                            gene.getHugoSymbol(),
-                            clinicalVariant.getVariant().getReferenceGenomes().stream().map(referenceGenome -> referenceGenome.name()).collect(Collectors.joining(", ")),
-                            clinicalVariant.getVariant().getName(),
-                            clinicalVariant.getVariant().getAlteration(),
-                            TumorTypeUtils.getTumorTypeName(tumorType),
-                            clinicalVariant.getLevel(),
-                            clinicalVariant.getSolidPropagationLevel(),
-                            clinicalVariant.getLiquidPropagationLevel(),
-                            MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrug()), ", ", true),
-                            MainUtils.listToString(new ArrayList<>(clinicalVariant.getDrugPmids()), ", ", true),
-                            MainUtils.listToString(abstracts, "; ", true),
-                            CplUtils.annotate(
-                                clinicalVariant.getDrugDescription(),
-                                gene.getHugoSymbol(),
-                                clinicalVariant.getVariant().getName(),
-                                TumorTypeUtils.getTumorTypeName(tumorType),
-                                null,
-                                gene,
-                                tumorType,
-                                isTextFile
-                            )
-                        ));
-                    }
-                }
-            }
-        }
-
-        actionableGeneList.addAll(actionableGenes);
-        MainUtils.sortActionableVariants(actionableGeneList);
-        return actionableGeneList;
     }
 
     @Override
@@ -380,7 +314,7 @@ public class UtilsApiController implements UtilsApi {
         if (version != null) {
             return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES, FileExtension.JSON);
         }
-        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenes(includeEvidence), HttpStatus.OK);
+        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenes(includeEvidence, false), HttpStatus.OK);
     }
 
     @Override
@@ -392,6 +326,28 @@ public class UtilsApiController implements UtilsApi {
             return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES, FileExtension.TEXT);
         }
         return new ResponseEntity<>(this.cacheFetcher.getCuratedGenesTxt(includeEvidence), HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<List<CuratedGene>> utilsAllCuratedGenesGermlineGet(
+        @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
+        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
+    ) {
+        if (version != null) {
+            return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES_GERMLINE, FileExtension.JSON);
+        }
+        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenes(includeEvidence, true), HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<String> utilsAllCuratedGenesGermlineTxtGet(
+        @ApiParam(value = VERSION) @RequestParam(value = "version", required = false) String version
+        , @ApiParam(value = INCLUDE_EVIDENCE, defaultValue = "TRUE") @RequestParam(value = "includeEvidence", required = false, defaultValue = "TRUE") Boolean includeEvidence
+    ) {
+        if (version != null) {
+            return getDataDownloadResponseEntity(version, FileName.ALL_CURATED_GENES_GERMLINE, FileExtension.TEXT);
+        }
+        return new ResponseEntity<>(this.cacheFetcher.getCuratedGenesGermlineTxt(includeEvidence), HttpStatus.OK);
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/1188

- Curated Genes: Added germline
- Annotated variants: The annotated variants endpoint now includes both somatic and germline variants in a single response, with a new Setting column (Somatic/Germline).
- Actionable variants: Similarly updated to include a Setting column. The text output generation was also consolidated and cleaned up.