### PR TITLE
Fixed exception on big number

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/parser/ProteinChangeParser.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/parser/ProteinChangeParser.java
@@ -57,16 +57,16 @@ public class ProteinChangeParser {
 
         result = parseSplice(proteinChange);
         if (result.isParsed) return result;
-        
+
         result = parseRange(proteinChange);
         if (result.isParsed) return result;
-        
+
         result = parseFrameshift(proteinChange);
         if (result.isParsed) return result;
 
         result = parsePoint(proteinChange);
         if (result.isParsed)  return result;
-        
+
         result = parseExtension(proteinChange);
         if (result.isParsed) return result;
 
@@ -114,7 +114,7 @@ public class ProteinChangeParser {
 
                 if (groupSixWithoutDigits.contains("*")) {
                     result.consequence = "stop_gained";
-                } 
+                }
                 else if (groupSixWithoutDigits.length() != groupSix.length() && groupSixWithoutDigits.length() > 0) {
                     if (groupSixWithoutDigits.length() > deletion) {
                         result.consequence = IN_FRAME_INSERTION;
@@ -145,7 +145,7 @@ public class ProteinChangeParser {
         ParseAlterationResult result = new ParseAlterationResult();
         Matcher m = SPLICE_PATTERN.matcher(proteinChange);
         if (m.matches()) {
-            
+
             result.isParsed = true;
             String[] parts = m.group(0).toLowerCase().split("splice", 2);
             result.normalizedProteinChange = parts[0].toUpperCase() + "splice";
@@ -276,7 +276,7 @@ public class ProteinChangeParser {
             result.normalizedProteinChange = (m.group(1) == null ? "" : "M")
                 + "1ext"
                 + (m.group(2) == null ? "" : m.group(2));
-            
+
             result.start = 1;
             result.end = result.start;
             result.consequence = IN_FRAME_INSERTION;
@@ -299,7 +299,7 @@ public class ProteinChangeParser {
                 result.end = result.start;
                 result.consequence = "stop_lost";
             }
-        } 
+        }
         return result;
     }
 
@@ -332,7 +332,12 @@ public class ProteinChangeParser {
             result.normalizedProteinChange = proteinChange.toUpperCase();
 
             ref = m.group(1) == null ? "" : m.group(1).toUpperCase();
-            start = Integer.valueOf(m.group(2));
+            try {
+                start = Integer.valueOf(m.group(2));
+            } catch (NumberFormatException e) {
+                result.setIsParsed(false);
+                return result;
+            }
             end = start;
             var = m.group(3).toUpperCase();
 
@@ -372,7 +377,7 @@ public class ProteinChangeParser {
         result.var = var;
         result.start = start;
         result.end = end;
-        return result;                       
+        return result;
     }
 
 }

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/parser/ProteinChangeParserTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/parser/ProteinChangeParserTest.java
@@ -1,0 +1,32 @@
+package org.mskcc.cbio.oncokb.util.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import org.junit.Test;
+
+public class ProteinChangeParserTest {
+
+    @Test
+    public void testParseGeneralWithValidInput() {
+        ParseAlterationResult result = ProteinChangeParser.parseGeneral("V600E");
+        assertTrue(result.isParsed);
+        assertEquals("V", result.ref);
+        assertEquals(600, result.start.intValue());
+        assertEquals("E", result.var);
+        assertEquals("missense_variant", result.consequence);
+    }
+
+    @Test
+    public void testParseGeneralWithLargeNumber() {
+        ParseAlterationResult result = ProteinChangeParser.parseGeneral("V2147483647E");
+        assertTrue(result.isParsed);
+        assertEquals(2147483647, result.start.intValue());
+    }
+
+    @Test
+    public void testParseGeneralWithTooBigNumber() {
+        ParseAlterationResult result = ProteinChangeParser.parseGeneral("V600000000000000000000E");
+        assertFalse(result.isParsed);
+    }
+}


### PR DESCRIPTION
closes https://github.com/oncokb/oncokb-pipeline/issues/1196

We are getting datadog alerts because someone is querying with a large mutation number. I added a try/catch to deal with.