### PR TITLE
Fix gene-specific alteration matching for HGVS annotation queries.

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/bo/impl/AlterationBoImpl.java
@@ -38,7 +38,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
     @Override
     public Alteration findAlteration(Gene gene, AlterationType alterationType, ReferenceGenome referenceGenome, String alteration, Boolean isGermline) {
-        return AlterationUtils.findAlteration(referenceGenome, alteration, CacheUtils.getAlterations(gene.getEntrezGeneId(), referenceGenome), isGermline);
+        return AlterationUtils.findAlterationWithGeneticType(referenceGenome, gene, alteration, CacheUtils.getAlterations(gene.getEntrezGeneId(), referenceGenome), isGermline);
     }
 
     @Override
@@ -216,14 +216,14 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
 
 
         if (addEGFRCTD(alteration)) {
-            Alteration alt = AlterationUtils.findAlteration(referenceGenome, "CTD", fullAlterations, alteration.getForGermline());
+            Alteration alt = AlterationUtils.findAlterationWithGeneticType(referenceGenome, alteration.getGene(), "CTD", fullAlterations, alteration.getForGermline());
             if (alt != null) {
                 alterations.add(alt);
             }
         }
 
         if (alteration.getGene().getHugoSymbol().equals("EGFR") && alteration.getAlteration().equals("CTD")) {
-            Alteration alt = AlterationUtils.findAlteration(referenceGenome, "CTD", fullAlterations, alteration.getForGermline());
+            Alteration alt = AlterationUtils.findAlterationWithGeneticType(referenceGenome, alteration.getGene(), "CTD", fullAlterations, alteration.getForGermline());
             if (alt != null && !alterations.contains(alt)) {
                 alterations.add(alt);
             }
@@ -319,7 +319,7 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         if (addDeletion) {
-            Alteration deletion = AlterationUtils.findAlteration(referenceGenome, "Deletion", fullAlterations, alteration.getForGermline());
+            Alteration deletion = AlterationUtils.findAlterationWithGeneticType(referenceGenome, alteration.getGene(), "Deletion", fullAlterations, alteration.getForGermline());
             if (deletion != null) {
                 alterations.add(deletion);
 
@@ -369,14 +369,14 @@ public class AlterationBoImpl extends GenericBoImpl<Alteration, AlterationDao> i
         }
 
         for (String effect : effects) {
-            Alteration alt = AlterationUtils.findAlteration(referenceGenome, effect + " mutations", fullAlterations, alteration.getForGermline());
+            Alteration alt = AlterationUtils.findAlterationWithGeneticType(referenceGenome, alteration.getGene(), effect + " mutations", fullAlterations, alteration.getForGermline());
             if (alt != null) {
                 alterations.add(alt);
             }
         }
 
         if (!addOncogenicMutations(alteration, alternativeAlleles, new ArrayList<>(alterations)) && addVUSMutation(alteration, matchedAlt != null)) {
-            Alteration VUSMutation = AlterationUtils.findAlteration(referenceGenome, InferredMutation.VUS.getVariant(), fullAlterations, alteration.getForGermline());
+            Alteration VUSMutation = AlterationUtils.findAlterationWithGeneticType(referenceGenome, alteration.getGene(), InferredMutation.VUS.getVariant(), fullAlterations, alteration.getForGermline());
             if (VUSMutation != null) {
                 alterations.add(VUSMutation);
             }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -38,6 +38,7 @@ import org.mskcc.cbio.oncokb.apiModels.annotation.AnnotateMutationByHGVSgQuery;
 import org.mskcc.cbio.oncokb.bo.AlterationBo;
 import org.mskcc.cbio.oncokb.bo.EvidenceBo;
 import org.mskcc.cbio.oncokb.genomenexus.GNVariantAnnotationType;
+import org.mskcc.cbio.oncokb.importer.VariantConsequenceImporter;
 import org.mskcc.cbio.oncokb.model.Alteration;
 import org.mskcc.cbio.oncokb.model.AlterationPositionBoundary;
 import org.mskcc.cbio.oncokb.model.AlterationType;
@@ -57,11 +58,14 @@ import org.mskcc.cbio.oncokb.model.VariantConsequence;
 import org.mskcc.cbio.oncokb.model.genomeNexus.TranscriptSummaryAlterationResult;
 import org.mskcc.cbio.oncokb.util.parser.ParseAlterationResult;
 import org.mskcc.cbio.oncokb.util.parser.ProteinChangeParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author jgao, Hongxin Zhang
  */
 public final class AlterationUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlterationUtils.class);
     private static List<String> oncogenicList = Arrays.asList(new String[]{
         "", Oncogenicity.INCONCLUSIVE.getOncogenic(), Oncogenicity.LIKELY_NEUTRAL.getOncogenic(),
         Oncogenicity.LIKELY.getOncogenic(), Oncogenicity.YES.getOncogenic()});
@@ -1399,7 +1403,8 @@ public final class AlterationUtils {
 
     private static boolean matchesGene(Alteration alt, Gene gene) {
         if (gene == null) {
-            return true;
+            LOGGER.error("Invalid gene provided");
+            return false;
         }
         return gene.equals(alt.getGene());
     }

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/AlterationUtils.java
@@ -1277,7 +1277,7 @@ public final class AlterationUtils {
     }
 
     public static Alteration findExactlyMatchedAlteration(ReferenceGenome referenceGenome, Alteration alteration, List<Alteration> fullAlterations) {
-        Alteration matchedByAlteration = findAlteration(referenceGenome, alteration.getAlteration(), fullAlterations, alteration.getForGermline());
+        Alteration matchedByAlteration = findAlterationWithGeneticType(referenceGenome, alteration.getGene(), alteration.getAlteration(), fullAlterations, alteration.getForGermline());
         if (matchedByAlteration != null) {
             if (matchedByAlteration.getConsequence() == null
                 || alteration.getConsequence() == null
@@ -1364,22 +1364,15 @@ public final class AlterationUtils {
 
         return new ArrayList<>(result);
     }
-    public static Alteration findAlteration(ReferenceGenome referenceGenome, String alteration, List<Alteration> fullAlterations) {
-        return findAlteration(referenceGenome, alteration, fullAlterations, null);
-    }
 
-    public static Alteration findAlteration(ReferenceGenome referenceGenome, String alteration, List<Alteration> fullAlterations, Boolean isGermline) {
-        return findAlterationWithGeneticType(referenceGenome, alteration, fullAlterations, isGermline);
-    }
-
-    public static Alteration findAlterationWithGeneticType(ReferenceGenome referenceGenome, String alteration, List<Alteration> fullAlterations, Boolean isGermline) {
+    public static Alteration findAlterationWithGeneticType(ReferenceGenome referenceGenome, Gene gene, String alteration, List<Alteration> fullAlterations, Boolean isGermline) {
         if (alteration == null) {
             return null;
         }
         // Implement the data access logic
         for (int i = 0; i < fullAlterations.size(); i++) {
             Alteration alt = fullAlterations.get(i);
-            if (alt.getAlteration() != null && alt.getAlteration().equalsIgnoreCase(alteration) && (isGermline == null ||  alt.getForGermline() == isGermline)) {
+            if (alt.getAlteration() != null && alt.getAlteration().equalsIgnoreCase(alteration) && (isGermline == null ||  alt.getForGermline() == isGermline) && matchesGene(alt, gene)) {
                 if (referenceGenome == null) {
                     return alt;
                 } else if (alt.getReferenceGenomes().contains(referenceGenome)) {
@@ -1389,7 +1382,7 @@ public final class AlterationUtils {
         }
         for (int i = 0; i < fullAlterations.size(); i++) {
             Alteration alt = fullAlterations.get(i);
-            if (alt.getAlteration() != null && alt.getName().equalsIgnoreCase(alteration) && (isGermline == null ||  alt.getForGermline() == isGermline)) {
+            if (alt.getAlteration() != null && alt.getName().equalsIgnoreCase(alteration) && (isGermline == null ||  alt.getForGermline() == isGermline) && matchesGene(alt, gene)) {
                 if (referenceGenome == null) {
                     return alt;
                 } else if (alt.getReferenceGenomes().contains(referenceGenome)) {
@@ -1399,9 +1392,16 @@ public final class AlterationUtils {
         }
 
         if (NamingUtils.hasAbbreviation(alteration)) {
-            return findAlterationWithGeneticType(referenceGenome, NamingUtils.getFullName(alteration), fullAlterations, isGermline);
+            return findAlterationWithGeneticType(referenceGenome, gene, NamingUtils.getFullName(alteration), fullAlterations, isGermline);
         }
         return null;
+    }
+
+    private static boolean matchesGene(Alteration alt, Gene gene) {
+        if (gene == null) {
+            return true;
+        }
+        return gene.equals(alt.getGene());
     }
 
     public static Alteration findAlteration(ReferenceGenome referenceGenome, String alteration, String name, List<Alteration> fullAlterations) {

--- a/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/util/IndicatorUtils.java
@@ -564,7 +564,7 @@ public class IndicatorUtils {
             List<TumorType> relevantUpwardTumorTypes = new ArrayList<>();
 
             // For germline, we should find the exact alteration (there are no rules yet)
-            Alteration matchedAlt = AlterationUtils.findAlteration(query.getReferenceGenome(), alteration.getAlteration(), AlterationUtils.getAllAlterations(query.getReferenceGenome(), gene), query.isGermline());
+            Alteration matchedAlt = AlterationUtils.findAlterationWithGeneticType(query.getReferenceGenome(), gene, alteration.getAlteration(), AlterationUtils.getAllAlterations(query.getReferenceGenome(), gene), query.isGermline());
             Boolean variantExists = matchedAlt != null;
             indicatorQuery.setVariantExist(variantExists);
             if (!variantExists) {

--- a/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
+++ b/core/src/test/java/org/mskcc/cbio/oncokb/util/IndicatorUtilsTest.java
@@ -1235,8 +1235,9 @@ public class IndicatorUtilsTest {
             relevantAlterations.stream().anyMatch(alt -> alt.getAlteration() != null
                 && alt.getAlteration().startsWith(InferredMutation.PATHOGENIC_VARIANTS.getVariant())));
 
-        Alteration pathogenicVariantsAlt = AlterationUtils.findAlteration(
+        Alteration pathogenicVariantsAlt = AlterationUtils.findAlterationWithGeneticType(
             DEFAULT_REFERENCE_GENOME,
+            gene,
             InferredMutation.PATHOGENIC_VARIANTS.getVariant(),
             AlterationUtils.getAllAlterations(DEFAULT_REFERENCE_GENOME, gene),
             true

--- a/release-notes/pr-4107-fix-find-alteration-with-gene.md
+++ b/release-notes/pr-4107-fix-find-alteration-with-gene.md
@@ -1,0 +1,30 @@
+# Title
+
+Fix gene-specific alteration matching for HGVS annotation queries.
+
+## What's New
+
+Updated somatic and germline annotation lookup to attach the resolved gene when matching curated alterations from HGVSg and HGVSc inputs.
+This fixes cases where annotation queries could miss the intended curated alteration or match an alteration from the wrong gene when the alteration string was not unique by itself.
+
+## Impact
+
+API clients and users of the annotation endpoints may see corrected germline annotation results for affected HGVS-based queries.
+
+## API Changes
+
+None.
+
+| Parameter/Field Path | Change (Added/Edit/Removed) | Endpoints |
+| --- | --- | --- |
+| None | None | None |
+
+## Migration / Action Required
+
+None.
+
+## Related Links
+
+- PR: #4107
+- Issue:
+- Docs:

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/AnnotationsApiController.java
@@ -980,6 +980,7 @@ public class AnnotationsApiController {
     ) throws org.genome_nexus.ApiException {
         Alteration alteration = AlterationUtils.findAlterationWithGeneticType(
             referenceGenome,
+            selectedAnnotatedAlteration.getAlteration().getGene(),
             hgvsg,
             allAlterations,
             germline
@@ -1018,6 +1019,7 @@ public class AnnotationsApiController {
                 hgvsc = hgvscParts[1];
                 alteration = AlterationUtils.findAlterationWithGeneticType(
                     referenceGenome,
+                    selectedAnnotatedAlteration.getAlteration().getGene(),
                     hgvsc,
                     allAlterations,
                     germline
@@ -1098,6 +1100,7 @@ public class AnnotationsApiController {
             if (this.cacheFetcher.hgvscShouldBeAnnotated(hgvsc)) {
                 Alteration alteration = AlterationUtils.findAlterationWithGeneticType(
                     referenceGenome,
+                    GeneUtils.getGeneByHugoSymbol(query.getGene()),
                     query.getAlteration(),
                     allAlterations,
                     query.isGermline()

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/GermlineAnnotationsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/GermlineAnnotationsApiController.java
@@ -484,10 +484,9 @@ public class GermlineAnnotationsApiController {
             String[] hgvscParts = hgvsc.split(":");
             if (hgvscParts.length == 2) {
                 hgvsc = hgvscParts[1];
-                Gene gene = GeneUtils.getGene(selectedAnnotatedAlteration.getTranscriptConsequenceSummary().getHugoGeneSymbol());
                 alteration = AlterationUtils.findAlterationWithGeneticType(
                     referenceGenome,
-                    gene,
+                    selectedAnnotatedAlteration.getAlteration().getGene(),
                     hgvsc,
                     allAlterations,
                     germline

--- a/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/GermlineAnnotationsApiController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/api/pub/v1/GermlineAnnotationsApiController.java
@@ -428,6 +428,7 @@ public class GermlineAnnotationsApiController {
     ) throws org.genome_nexus.ApiException {
         Alteration alteration = AlterationUtils.findAlterationWithGeneticType(
             referenceGenome,
+            selectedAnnotatedAlteration.getAlteration().getGene(),
             hgvsg,
             allAlterations,
             germline
@@ -483,8 +484,10 @@ public class GermlineAnnotationsApiController {
             String[] hgvscParts = hgvsc.split(":");
             if (hgvscParts.length == 2) {
                 hgvsc = hgvscParts[1];
+                Gene gene = GeneUtils.getGene(selectedAnnotatedAlteration.getTranscriptConsequenceSummary().getHugoGeneSymbol());
                 alteration = AlterationUtils.findAlterationWithGeneticType(
                     referenceGenome,
+                    gene,
                     hgvsc,
                     allAlterations,
                     germline
@@ -586,6 +589,7 @@ public class GermlineAnnotationsApiController {
             if (this.cacheFetcher.hgvscShouldBeAnnotated(hgvsc)) {
                 Alteration alteration = AlterationUtils.findAlterationWithGeneticType(
                     referenceGenome,
+                    GeneUtils.getGeneByHugoSymbol(query.getGene()),
                     query.getAlteration(),
                     allAlterations,
                     query.isGermline()


### PR DESCRIPTION
Updated somatic and germline annotation lookup to attach the resolved gene when matching curated alterations from HGVSg and HGVSc inputs.
This fixes cases where annotation queries could miss the intended curated alteration or match an alteration from the wrong gene when the alteration string was not unique by itself.