### PR TITLE
Enable request ID and user-agent logging in the no-frontend image

### DIFF
--- a/release-notes/pr-4142-fix-no-frontend-image-request-logging.md
+++ b/release-notes/pr-4142-fix-no-frontend-image-request-logging.md
@@ -1,0 +1,25 @@
+# Title
+
+Enable request ID and user-agent logging in the no-frontend image.
+
+## What's New
+
+Registered `RequestResponseLoggingFilter` in the public API web profile so the no-frontend image now populates MDC `requestId` and `userAgent` values in application logs.
+
+## Impact
+
+Operators using the no-frontend image get improved request traceability and client attribution in logs. No functional API behavior changes.
+
+## API Changes
+
+None.
+
+## Migration / Action Required
+
+None.
+
+## Related Links
+
+- PR: #4142
+- Issue:
+- Docs:

--- a/web/src/main/webapp/WEB-INF/web-public-api.xml
+++ b/web/src/main/webapp/WEB-INF/web-public-api.xml
@@ -50,4 +50,12 @@
         <filter-name>CorsFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+    <filter>
+        <filter-name>RequestResponseLoggingFilter</filter-name>
+        <filter-class>org.mskcc.cbio.oncokb.logging.RequestResponseLoggingFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>RequestResponseLoggingFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 </web-app>


### PR DESCRIPTION
`RequestResponseLoggingFilter` wasn't being using used in `no-frontend`